### PR TITLE
III-3382 Push iframe location changes to the Vue router

### DIFF
--- a/components/legacy-app-page.vue
+++ b/components/legacy-app-page.vue
@@ -31,11 +31,11 @@
         }
 
         if (event.data.type === MessageTypes.URL_CHANGED) {
-          this.changeUrl(event.data.path);
+          this.changePath(event.data.path);
         }
       },
-      changeUrl(url) {
-        history.pushState(undefined, undefined, url);
+      changePath(path) {
+        this.$router.push(path);
       },
     },
   };

--- a/components/sidebar.vue
+++ b/components/sidebar.vue
@@ -4,7 +4,7 @@
       <logo class="logo" />
       <ul>
         <li>
-          <nuxt-link to="/">
+          <nuxt-link to="/dashboard">
             <fa icon="home" />
             <span>Home</span>
           </nuxt-link>


### PR DESCRIPTION
### Fixed

- Fixed an issue where clicking e.g. on the `Dashboard` link, then clicking a link inside the resulting iframe, and then clicking the `Dashboard` link again would not result in the dashboard being shown. By pushing the location change to the Vue router, Vue treats it as a navigation change so when clicking the `Dashboard` link later again this will also be treated as a navigation change. Otherwise Vue thinks the user is still on the `Dashboard` page even though another page is shown inside the iframe. This will cause a double refresh of content in the iframe though. To fix that there's an additional PR in the udb3-angular-app repository: https://github.com/cultuurnet/udb3-angular-app/pull/149

---

Ticket: https://jira.uitdatabank.be/browse/III-3382