### PR TITLE
Make the Vue app redirect from / to /dashboard

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,13 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {
+    mounted() {
+      this.$router.push('/dashboard');
+    },
+  };
+</script>
+
+<style></style>


### PR DESCRIPTION
### Fixed

- Fixed the AngularJS "main" screen being visible for a split second while AngularJS did the redirect from `/` to `/dashboard` inside the iframe, by making the Vue app do the redirect instead before rendering the iframe