### PR TITLE
III-3347 Make nuxt env variables public runtime config

### DIFF
--- a/api/events.js
+++ b/api/events.js
@@ -1,6 +1,4 @@
-import { fetchWithLogoutWhenFailed } from './api';
-
-export const findToModerate = (apiUrl, headers) => async (
+export const findToModerate = (apiUrl, headers, fetch) => async (
   searchQuery,
   start = 0,
   limit = 1,
@@ -16,7 +14,7 @@ export const findToModerate = (apiUrl, headers) => async (
     workflowStatus: 'READY_FOR_VALIDATION',
   }).toString();
 
-  const res = await fetchWithLogoutWhenFailed(url, {
+  const res = await fetch(url, {
     headers: headers(),
   });
   return await res.json();

--- a/api/user.js
+++ b/api/user.js
@@ -1,21 +1,19 @@
-import { fetchWithLogoutWhenFailed } from './api';
-
-export const getMe = (apiUrl, headers) => async () => {
-  const res = await fetchWithLogoutWhenFailed(`${apiUrl}/user`, {
+export const getMe = (apiUrl, headers, fetch) => async () => {
+  const res = await fetch(`${apiUrl}/user`, {
     headers: headers(),
   });
   return await res.json();
 };
 
-export const getPermissions = (apiUrl, headers) => async () => {
-  const res = await fetchWithLogoutWhenFailed(`${apiUrl}/user/permissions/`, {
+export const getPermissions = (apiUrl, headers, fetch) => async () => {
+  const res = await fetch(`${apiUrl}/user/permissions/`, {
     headers: headers(),
   });
   return await res.json();
 };
 
-export const getRoles = (apiUrl, headers) => async () => {
-  const res = await fetchWithLogoutWhenFailed(`${apiUrl}/user/roles/`, {
+export const getRoles = (apiUrl, headers, fetch) => async () => {
+  const res = await fetch(`${apiUrl}/user/roles/`, {
     headers: headers(),
   });
   return await res.json();

--- a/components/button-logout.vue
+++ b/components/button-logout.vue
@@ -11,7 +11,7 @@
   export default {
     name: 'ButtonLogout',
     methods: {
-      logout,
+      logout: () => logout(this.$config.authUrl),
     },
   };
 </script>

--- a/components/giftbox.vue
+++ b/components/giftbox.vue
@@ -114,7 +114,7 @@
     methods: {
       async fetchFeatures() {
         this.loading = true;
-        const response = await fetch(process.env.newFeaturesUrl);
+        const response = await fetch(this.$config.newFeaturesUrl);
         const { data } = await response.json();
         this.loading = false;
         return data;

--- a/components/legacy-app-page.vue
+++ b/components/legacy-app-page.vue
@@ -15,7 +15,7 @@
     },
     computed: {
       generatePath() {
-        return `${process.env.legacyAppUrl}${this.path}`;
+        return `${this.$config.legacyAppUrl}${this.path}`;
       },
     },
     mounted() {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,7 +1,7 @@
 import apiWrapper from '../api/api';
 
 export default async function (context) {
-  const jwtInURL = context?.query?.jwt ?? '';
+  const jwtInURL = (context && context.query && context.query.jwt) ? context.query.jwt : '';
 
   const cookieOptions = {
     maxAge: 60 * 60 * 24 * 7,
@@ -21,7 +21,7 @@ export default async function (context) {
     return;
   }
 
-  const api = apiWrapper(() => jwtInCookie);
+  const api = apiWrapper(context.$config.authUrl, context.$config.apiUrl, context.$config.apiKey, () => jwtInCookie);
 
   const user = await api.user.getMe();
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,5 +1,3 @@
-import apiWrapper from '../api/api';
-
 export default async function (context) {
   const jwtInURL =
     context && context.query && context.query.jwt ? context.query.jwt : '';
@@ -22,14 +20,7 @@ export default async function (context) {
     return;
   }
 
-  const api = apiWrapper(
-    context.$config.authUrl,
-    context.$config.apiUrl,
-    context.$config.apiKey,
-    () => jwtInCookie,
-  );
-
-  const user = await api.user.getMe();
+  const user = await context.$api.user.getMe();
 
   context.app.$cookies.set('user', user, cookieOptions);
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,7 +1,8 @@
 import apiWrapper from '../api/api';
 
 export default async function (context) {
-  const jwtInURL = (context && context.query && context.query.jwt) ? context.query.jwt : '';
+  const jwtInURL =
+    context && context.query && context.query.jwt ? context.query.jwt : '';
 
   const cookieOptions = {
     maxAge: 60 * 60 * 24 * 7,
@@ -21,7 +22,12 @@ export default async function (context) {
     return;
   }
 
-  const api = apiWrapper(context.$config.authUrl, context.$config.apiUrl, context.$config.apiKey, () => jwtInCookie);
+  const api = apiWrapper(
+    context.$config.authUrl,
+    context.$config.apiUrl,
+    context.$config.apiKey,
+    () => jwtInCookie,
+  );
 
   const user = await api.user.getMe();
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -96,6 +96,7 @@ export default {
       {
         default: true,
         name: 'uitdatabank',
+        url: 'https://sockets.uitdatabank.dev',
       },
     ],
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -73,13 +73,20 @@ export default {
    ** See https://nuxtjs.org/api/configuration-build/
    */
   build: {},
-  env: {
+  publicRuntimeConfig: {
     apiKey: process.env.API_KEY,
     apiUrl: process.env.API_URL,
     legacyAppUrl: process.env.LEGACY_APP_URL,
     authUrl: process.env.AUTH_URL,
-    socketUrl: process.env.SOCKET_URL,
     newFeaturesUrl: process.env.NEW_FEATURES_URL,
+    io: {
+      sockets: [
+        {
+          name: 'uitdatabank',
+          url: process.env.SOCKET_URL,
+        },
+      ],
+    }
   },
   router: {
     middleware: ['auth'],
@@ -88,7 +95,7 @@ export default {
     sockets: [
       {
         default: true,
-        url: 'https://sockets.uitdatabank.dev',
+        name: 'uitdatabank',
       },
     ],
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -82,20 +82,12 @@ export default {
     io: {
       sockets: [
         {
+          default: true,
           name: 'uitdatabank',
           url: process.env.SOCKET_URL,
         },
       ],
-    }
-  },
-  io: {
-    sockets: [
-      {
-        default: true,
-        name: 'uitdatabank',
-        url: 'https://sockets.uitdatabank.dev',
-      },
-    ],
+    },
   },
   router: {
     middleware: ['auth'],

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -88,9 +88,6 @@ export default {
       ],
     }
   },
-  router: {
-    middleware: ['auth'],
-  },
   io: {
     sockets: [
       {
@@ -99,6 +96,9 @@ export default {
         url: 'https://sockets.uitdatabank.dev',
       },
     ],
+  },
+  router: {
+    middleware: ['auth'],
   },
   styleResources: {
     scss: ['./assets/styles/_global.scss'],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "nuxt": "^2.13.0",
     "nuxt-fontawesome": "^0.4.0",
     "nuxt-i18n": "^6.13.1",
-    "nuxt-socket-io": "^1.1.4",
+    "nuxt-socket-io": "^1.1.6",
     "sass-loader": "^8.0.2"
   },
   "devDependencies": {

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -273,7 +273,7 @@
       },
     },
     methods: {
-      login,
+      login: () => login(this.$config.authUrl),
       setLanguage(language) {
         this.$i18n.locale = language;
         this.$cookies.set('udb-language', language);

--- a/plugins/api.js
+++ b/plugins/api.js
@@ -1,6 +1,6 @@
 import apiWrapper from '../api/api';
 
 export default (context, inject) => {
-  const api = apiWrapper(() => context.app.$cookies.get('token'));
+  const api = apiWrapper(context.$config.authUrl, context.$config.apiUrl, context.$config.apiKey,() => context.app.$cookies.get('token'));
   inject('api', api);
 };

--- a/plugins/api.js
+++ b/plugins/api.js
@@ -1,6 +1,11 @@
 import apiWrapper from '../api/api';
 
 export default (context, inject) => {
-  const api = apiWrapper(context.$config.authUrl, context.$config.apiUrl, context.$config.apiKey,() => context.app.$cookies.get('token'));
+  const api = apiWrapper(
+    context.$config.authUrl,
+    context.$config.apiUrl,
+    context.$config.apiKey,
+    () => context.app.$cookies.get('token'),
+  );
   inject('api', api);
 };

--- a/services/auth.js
+++ b/services/auth.js
@@ -9,23 +9,24 @@ const removeCookies = () => {
 
 const buildBaseUrl = () =>
   `${window.location.protocol}//${window.location.host}`;
+
 /**
  * Log the active user out.
  */
-export const logout = () => {
+export const logout = (authUrl) => {
   removeCookies();
 
   const queryString = new URLSearchParams({
     destination: buildBaseUrl(),
   }).toString();
 
-  window.location.href = `${process.env.authUrl}/logout?${queryString}`;
+  window.location.href = `${authUrl}/logout?${queryString}`;
 };
 
 /**
  * Login by redirecting to UiTiD
  */
-export const login = () => {
+export const login = (authUrl) => {
   removeCookies();
 
   const queryString = new URLSearchParams({
@@ -33,5 +34,5 @@ export const login = () => {
     lang: 'nl',
   }).toString();
 
-  window.location.href = `${process.env.authUrl}/connect?${queryString}`;
+  window.location.href = `${authUrl}/connect?${queryString}`;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8330,10 +8330,10 @@ nuxt-i18n@^6.13.1:
     js-cookie "^2.2.1"
     vue-i18n "^8.18.1"
 
-nuxt-socket-io@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/nuxt-socket-io/-/nuxt-socket-io-1.1.4.tgz#b660feb172996f01e646f3e89806a947714ef82d"
-  integrity sha512-ZSASMtreTgkCa+gGTZqWhAQJxPbtOWIn1MJ1vI14WDTt8D3RnMZuvKfzOOisj3PPEtxo8SLpOrOjDBX2LRfEWg==
+nuxt-socket-io@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/nuxt-socket-io/-/nuxt-socket-io-1.1.6.tgz#7ec824e89732218f64836e3aa83c4d0c60087b34"
+  integrity sha512-fYpdW/cT5Op8/3wQJqO+0yBJ219PUVM538BVCPtJMKQnVTcrS20+oBhQNk6llMM04NvXh/q0l1L0WiRcyTKfZg==
   dependencies:
     glob "^7.1.6"
     socket.io "^2.3.0"


### PR DESCRIPTION
### Removed

- Removed usages of `process.env.` outside of the `publicRuntimeConfig` in `nuxt.config.js`. Otherwise these env variables would get interpolated (i.e. hardcoded) during build, preventing us from running the same build on different environments with different `.env` files. See https://nuxtjs.org/blog/moving-from-nuxtjs-dotenv-to-runtime-config/

---
Ticket: https://jira.uitdatabank.be/browse/III-3347
