### PR TITLE
Check for 204 in case of no suggestions instead of 404

### DIFF
--- a/api/productions.js
+++ b/api/productions.js
@@ -92,7 +92,7 @@ export const getSuggestedEvents = (
     headers: headers(),
   });
 
-  if (response.status === 404) {
+  if (response.status === 204) {
     return [];
   }
 

--- a/api/productions.js
+++ b/api/productions.js
@@ -92,7 +92,7 @@ export const getSuggestedEvents = (
     headers: headers(),
   });
 
-  if (response.status === 204) {
+  if (response.status === 204 || response.status === 404) {
     return [];
   }
 


### PR DESCRIPTION
### Changed

- The suggestions endpoint was changed to return `204` (no content) in case of no suggestions, so we need to change the check in the frontend

---

Ticket: https://jira.uitdatabank.be/browse/III-3464

Related PRs:
- https://github.com/cultuurnet/udb3-silex/pull/488
- https://github.com/cultuurnet/udb3-swagger/pull/61
