### PR TITLE
feature/III-3491 - add locationName and locationCity information to event cards on create page

### DIFF
--- a/components/productions/create/event.vue
+++ b/components/productions/create/event.vue
@@ -5,6 +5,7 @@
         <p>{{ type }}</p>
         <h2>{{ title }}</h2>
         <p>{{ period }}</p>
+        <p>{{ `${locationName}, ${locationCity}` }}</p>
       </div>
       <img v-if="imageUrl" :src="imageUrl" :alt="title" class="image" />
     </section>
@@ -42,6 +43,14 @@
         default: '',
       },
       title: {
+        type: String,
+        default: '',
+      },
+      locationName: {
+        type: String,
+        default: '',
+      },
+      locationCity: {
         type: String,
         default: '',
       },

--- a/pages/manage/productions/create.vue
+++ b/pages/manage/productions/create.vue
@@ -14,6 +14,10 @@
             :key="suggestedEvent['@id']"
             :type="getEventType(suggestedEvent.terms)"
             :title="suggestedEvent.name[locale]"
+            :location-name="suggestedEvent.location.name[locale]"
+            :location-city="
+              suggestedEvent.location.address[locale].addressLocality
+            "
             :image-url="suggestedEvent.image"
             :production-name="
               suggestedEvent.production ? suggestedEvent.production.title : ''

--- a/pages/manage/productions/create.vue
+++ b/pages/manage/productions/create.vue
@@ -13,10 +13,16 @@
             :id="parseEventId(suggestedEvent['@id'])"
             :key="suggestedEvent['@id']"
             :type="getEventType(suggestedEvent.terms)"
-            :title="suggestedEvent.name[locale]"
-            :location-name="suggestedEvent.location.name[locale]"
+            :title="
+              suggestedEvent.name[locale] || fallbackTitle(suggestedEvent)
+            "
+            :location-name="
+              suggestedEvent.location.name[locale] ||
+              fallbackLocationName(suggestedEvent)
+            "
             :location-city="
-              suggestedEvent.location.address[locale].addressLocality
+              suggestedEvent.location.address[locale].addressLocality ||
+              fallbackLocationCity(suggestedEvent)
             "
             :image-url="suggestedEvent.image"
             :production-name="
@@ -169,6 +175,19 @@
       await this.getSuggestedEvents();
     },
     methods: {
+      fallbackTitle(suggestedEvent) {
+        return suggestedEvent.name[suggestedEvent.mainLanguage];
+      },
+      fallbackLocationName(suggestedEvent) {
+        return suggestedEvent.location.name[
+          suggestedEvent.location.mainLanguage
+        ];
+      },
+      fallbackLocationCity(suggestedEvent) {
+        return suggestedEvent.location.address[
+          suggestedEvent.location.mainLanguage
+        ].addressLocality;
+      },
       async getSuggestedProductionsByName(options) {
         const {
           member: suggestedProductions,


### PR DESCRIPTION

### Added

- feature/III-3491 - add locationName and locationCity information to event cards on create page

---

Ticket: https://jira.uitdatabank.be/browse/III-3491
