### PR TITLE
Make label font-weight consistent

### DIFF
--- a/publiq-ui/pub-checkbox.vue
+++ b/publiq-ui/pub-checkbox.vue
@@ -59,10 +59,6 @@
     cursor: pointer;
   }
 
-  label {
-    font-weight: normal;
-  }
-
   label:hover {
     cursor: pointer;
   }

--- a/publiq-ui/pub-label.vue
+++ b/publiq-ui/pub-label.vue
@@ -17,7 +17,7 @@
 <style lang="scss" scoped>
   label {
     font-size: 1rem;
-    font-weight: 700;
+    font-weight: 400;
     margin-bottom: 0;
   }
 </style>

--- a/publiq-ui/pub-radio-group.vue
+++ b/publiq-ui/pub-radio-group.vue
@@ -76,10 +76,6 @@
     cursor: pointer;
   }
 
-  label {
-    font-weight: normal;
-  }
-
   label:hover {
     cursor: pointer;
   }


### PR DESCRIPTION
### Changed

- Changed `font-weight` of `pub-label` component to always be `400` instead of `700` and then resetting it everywhere.