### PR TITLE
III-3459 - change variant from 'alert' to 'warning'

### DIFF
--- a/components/productions/index/events.vue
+++ b/components/productions/index/events.vue
@@ -58,7 +58,7 @@
       <pub-alert
         v-for="(errorMessage, index) in errorMessages"
         :key="index"
-        variant="alert"
+        variant="warning"
         :visible="errorMessages.length > 0"
         dismissible
         >{{ errorMessage }}

--- a/pages/manage/productions/create.vue
+++ b/pages/manage/productions/create.vue
@@ -83,7 +83,7 @@
       <pub-alert
         v-for="(errorMessage, index) in errorMessages"
         :key="index"
-        variant="alert"
+        variant="warning"
         :visible="errorMessages.length > 0"
         dismissible
       >

--- a/publiq-ui/pub-alert.stories.mdx
+++ b/publiq-ui/pub-alert.stories.mdx
@@ -70,10 +70,10 @@ export const commonArgTypes = {
 </Canvas>
 
 ```javascript
-<pub-alert variant="danger">Lorem Ipsum</pub-alert>
+<pub-alert variant="warning">Lorem Ipsum</pub-alert>
 ```
 
-<ArgsTable story="Danger" />
+<ArgsTable story="Warning" />
 
 ## Danger
 

--- a/publiq-ui/pub-alert.vue
+++ b/publiq-ui/pub-alert.vue
@@ -10,6 +10,9 @@
       variant: {
         type: String,
         default: 'info',
+        validator(val) {
+          return ['info', 'success', 'danger', 'warning'].includes(val);
+        },
       },
       visible: {
         type: Boolean,


### PR DESCRIPTION
'alert' isn't a known variant, thus was a typo

### Changed

- change variant from 'alert' to 'warning'

### Fixed

- pub-alert styling

---

Screenshot:
![Schermafbeelding 2020-09-21 om 16 05 35](https://user-images.githubusercontent.com/66943525/93777283-d9b8a380-fc24-11ea-971b-7c42cdf14477.png)

Ticket: https://jira.uitdatabank.be/browse/III-3459
