### PR TITLE
Fix pub-link's color

### DIFF
--- a/publiq-ui/pub-link.stories.mdx
+++ b/publiq-ui/pub-link.stories.mdx
@@ -8,7 +8,7 @@ export const Template = (args, { argTypes }) => {
   return {
     props: Object.keys(argTypes),
     components: { PubLink },
-    template: '<pub-link v-bind="$attrs">Link</pub-link>',
+    template: '<pub-link href="#" v-bind="$attrs">Link</pub-link>',
   };
 };
 

--- a/publiq-ui/pub-link.vue
+++ b/publiq-ui/pub-link.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="as" v-bind="$attrs" v-on="$listeners" @click="handleClick" class="link">
+  <component :is="as" :class="className" v-bind="$attrs" v-on="$listeners" @click="handleClick">
     <slot />
   </component>
 </template>
@@ -12,6 +12,11 @@
         default: 'a',
       },
     },
+    computed: {
+      className() {
+          return this.as === 'a' ? 'link' : '';
+      }
+    },
     methods: {
       handleClick() {
         this.$emit('click');
@@ -21,7 +26,7 @@
 </script>
 
 <style lang="scss" scoped>
-  .link {
+  a.link {
     font-weight: 400;
     color: $udb-blue;
 

--- a/publiq-ui/pub-link.vue
+++ b/publiq-ui/pub-link.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="as" :class="className" v-bind="$attrs" v-on="$listeners" @click="handleClick">
+  <component :is="as" :class="pub-link" v-bind="$attrs" v-on="$listeners" @click="handleClick">
     <slot />
   </component>
 </template>
@@ -12,11 +12,6 @@
         default: 'a',
       },
     },
-    computed: {
-      className() {
-          return this.as === 'a' ? 'link' : '';
-      }
-    },
     methods: {
       handleClick() {
         this.$emit('click');
@@ -26,7 +21,7 @@
 </script>
 
 <style lang="scss" scoped>
-  a.link {
+  a.pub-link {
     font-weight: 400;
     color: $udb-blue;
 

--- a/publiq-ui/pub-link.vue
+++ b/publiq-ui/pub-link.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="as" v-bind="$attrs" v-on="$listeners" @click="handleClick">
+  <component :is="as" v-bind="$attrs" v-on="$listeners" @click="handleClick" class="link">
     <slot />
   </component>
 </template>
@@ -21,7 +21,7 @@
 </script>
 
 <style lang="scss" scoped>
-  a {
+  .link {
     font-weight: 400;
     color: $udb-blue;
 


### PR DESCRIPTION
### Fixed

- Fixed `pub-link`'s color. Reboot.css was overwriting the color of all `a` tags. By adding a class and making our selector more specific, our selector has precedence.
