### PR TITLE
set styling a-tag for v-html section

### DIFF
--- a/components/giftbox.vue
+++ b/components/giftbox.vue
@@ -260,6 +260,17 @@
         vertical-align: middle;
       }
 
+      .feature-content {
+        /deep/ a {
+          font-weight: 400;
+          color: $udb-blue;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+
       .btn-call-to-action {
         display: inline-block;
         overflow: hidden;


### PR DESCRIPTION
### Fixed

- styling a-tag for v-html section

---

Screenshot after changes:
![Schermafbeelding 2020-09-24 om 16 29 10](https://user-images.githubusercontent.com/66943525/94158978-50eb7300-fe83-11ea-9665-849288fed046.png)


Ticket: https://jira.uitdatabank.be/browse/III-3518
