### PR TITLE
III-3522 - fix prefilled input similarity ui  

### DIFF
--- a/publiq-ui/pub-typeahead.vue
+++ b/publiq-ui/pub-typeahead.vue
@@ -22,7 +22,7 @@
       PubLabel,
     },
     props: {
-      searchTerm: {
+      value: {
         type: String,
         default: '',
       },
@@ -42,7 +42,7 @@
     computed: {
       searchTermModel: {
         get() {
-          return this.searchTerm;
+          return this.value;
         },
         set(newSearchTerm) {
           this.$emit('input', newSearchTerm);


### PR DESCRIPTION
### Fixed

- prefilled input similarity ui

The prop passed when using v-model has to be called `value` for it to work.

---

Ticket: https://jira.uitdatabank.be/browse/III-3522

Screenshot:
![Schermafbeelding 2020-10-05 om 15 31 06](https://user-images.githubusercontent.com/66943525/95085678-d858a200-071f-11eb-9fea-c344f91c3ace.png)

