### PR TITLE
Feature/iii 3151 - use different urls for the login page according to the language

### DIFF
--- a/components/login.vue
+++ b/components/login.vue
@@ -263,7 +263,6 @@
   import PubButton from '@/publiq-ui/pub-button';
 
   export default {
-    layout: 'login',
     components: {
       PubPageTitle,
       PubButton,
@@ -281,8 +280,7 @@
         login(this.$config.authUrl, this.$i18n.locale);
       },
       setLanguage(language) {
-        this.$i18n.locale = language;
-        this.$cookies.set('udb-language', language);
+        this.$router.push('/login/' + language);
       },
     },
   };

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -3,6 +3,8 @@
   "main": {
     "activities_info": "Vous proposez un concert, une représentation, une exposition ou un film? Ou plutôt un événement sportif, une randonnée, une soirée cartes, une kermesse? Ou encore des cours, des ateliers ou des événements? Tout cela trouvera sa place dans l’UiTdatabank.",
     "activities": "activités par an",
+    "channels_info_link_text": "500 agenda's",
+    "channels_info_link_url": "https://www.publiq.be/nl/publicatiekanalen",
     "channels_info": "UiTdatabank alimente en outre plus de 500 agendas de loisirs imprimés et numériques qui proposent des informations à jour. Ce sont les agendas de chaînes audio-visuelles et de médias locaux ou nationaux, de villes et communes, de services touristiques ou de grandes organisations de coordination.",
     "channels": "chaînes de publication",
     "lead_sub": "Ajoutez vos activités gratuitement et élargissez votre public",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -3,8 +3,8 @@
   "main": {
     "activities_info": "Vous proposez un concert, une représentation, une exposition ou un film? Ou plutôt un événement sportif, une randonnée, une soirée cartes, une kermesse? Ou encore des cours, des ateliers ou des événements? Tout cela trouvera sa place dans l’UiTdatabank.",
     "activities": "activités par an",
-    "channels_info_link_text": "500 agenda's",
-    "channels_info_link_url": "https://www.publiq.be/nl/publicatiekanalen",
+    "channels_info_link_text": "",
+    "channels_info_link_url": "",
     "channels_info": "UiTdatabank alimente en outre plus de 500 agendas de loisirs imprimés et numériques qui proposent des informations à jour. Ce sont les agendas de chaînes audio-visuelles et de médias locaux ou nationaux, de villes et communes, de services touristiques ou de grandes organisations de coordination.",
     "channels": "chaînes de publication",
     "lead_sub": "Ajoutez vos activités gratuitement et élargissez votre public",

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -15,7 +15,7 @@ export default async function (context) {
 
   if (!jwtInCookie) {
     // Prevent redirecting to login when you're already on login
-    if (context.route.path !== '/login') {
+    if (!context.route.path.includes('/login')) {
       context.redirect('/login');
     }
     return;

--- a/pages/login/fr.vue
+++ b/pages/login/fr.vue
@@ -1,0 +1,20 @@
+<template>
+  <login />
+</template>
+
+<script>
+  import Login from '@/components/login';
+
+  export default {
+    layout: 'login',
+    components: {
+      Login,
+    },
+    mounted() {
+      this.$i18n.locale = 'fr';
+      this.$cookies.set('udb-language', 'fr');
+    },
+  };
+</script>
+
+<style lang="scss" scoped></style>

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -1,0 +1,19 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {
+    layout: 'login',
+    computed: {
+      locale() {
+        return this.$i18n.locale || 'nl';
+      },
+    },
+    mounted() {
+      this.$router.push(`/login/${this.locale}`);
+    },
+  };
+</script>
+
+<style lang="scss" scoped></style>

--- a/pages/login/nl.vue
+++ b/pages/login/nl.vue
@@ -1,0 +1,20 @@
+<template>
+  <login />
+</template>
+
+<script>
+  import Login from '@/components/login';
+
+  export default {
+    layout: 'login',
+    components: {
+      Login,
+    },
+    mounted() {
+      this.$i18n.locale = 'nl';
+      this.$cookies.set('udb-language', 'nl');
+    },
+  };
+</script>
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
### Added

- new route `/login/nl`
- new route `/login/fr`

### Changed

- place of `login.vue` from `pages` to `components`

---

Ticket: https://jira.uitdatabank.be/browse/III-3151
