### PR TITLE
Use forwardAs instead of as

### DIFF
--- a/src/components/publiq-ui/Button.js
+++ b/src/components/publiq-ui/Button.js
@@ -168,7 +168,7 @@ const Button = ({
   ) : (
     [
       iconName && <Icon name={iconName} key="icon" />,
-      <Box as="span" flex={1} css="text-align: left" key="text">
+      <Box forwardAs="span" flex={1} css="text-align: left" key="text">
         {children}
       </Box>,
       clonedSuffix,

--- a/src/components/publiq-ui/Link.js
+++ b/src/components/publiq-ui/Link.js
@@ -66,7 +66,7 @@ const Link = ({
 
   const children = [
     iconName && <Icon name={iconName} key="icon" />,
-    <Box as="span" flex={1} css="text-align: left" key="text">
+    <Box forwardAs="span" flex={1} css="text-align: left" key="text">
       {label}
     </Box>,
     clonedSuffix,


### PR DESCRIPTION
### Fixed

- Fixed a layout issue by using `forwardAs` instead of `as` since we apply some custom CSS