### PR TITLE
Return an empty array when loading

### DIFF
--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -322,7 +322,7 @@ const SideBar = () => {
 
   const filteredManageMenu = useMemo(() => {
     if (permissions.length === 0) {
-      return manageMenu;
+      return [];
     }
 
     return manageMenu.filter((menuItem) =>


### PR DESCRIPTION
### Fixed

- This should prevent all menu items from showing when the permissions aren't loaded yet
