### PR TITLE
III-3688 - Empty modal header in productions frontend

### DIFF
--- a/src/components/manage/productions/index/DeleteModal.js
+++ b/src/components/manage/productions/index/DeleteModal.js
@@ -18,6 +18,7 @@ const DeleteModal = ({
       visible={visible}
       onConfirm={onConfirm}
       onClose={onClose}
+      title={t('productions.delete.title')}
       confirmTitle={t('productions.overview.confirm')}
       cancelTitle={t('productions.overview.cancel')}
     >

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -50,6 +50,9 @@
     "previous": "Dernier"
   },
   "productions": {
+    "delete": {
+      "title": "Supprimer des événements de la production"
+    },
     "overview": {
       "cancel": "Annuler",
       "confirm": "Confirmer",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -52,6 +52,9 @@
     "previous": "Vorige"
   },
   "productions": {
+    "delete": {
+      "title": "Evenement(en) verwijderen van productie"
+    },
     "overview": {
       "cancel": "Annuleren",
       "confirm": "Bevestigen",


### PR DESCRIPTION
### Fixed
- Modal that is shown when removing an event from a production now has a proper title

---

Ticket: https://jira.uitdatabank.be/browse/III-3688
