### PR TITLE
Regain focus on MouseOver

### DIFF
--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -423,6 +423,7 @@ const SideBar = () => {
       zIndex={1998}
       padding={{ default: 2, s: 0 }}
       spacing={3}
+      onMouseOver={() => setTimeout(window.focus, 0)}
     >
       <Link
         justifyContent="center"

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -423,7 +423,7 @@ const SideBar = () => {
       zIndex={1998}
       padding={{ default: 2, s: 0 }}
       spacing={3}
-      onMouseOver={() => setTimeout(window.focus, 0)}
+      onMouseOver={() => setTimeout(window.focus, 200)}
     >
       <Link
         justifyContent="center"


### PR DESCRIPTION
### Fixed

- regain focus on mouse over on sidebar (need to do a setTimeout trick to make it work)

---

Ticket: https://jira.uitdatabank.be/browse/III-3727
