### PR TITLE
Default empty cookie when there is none found

### DIFF
--- a/src/utils/getApplicationServerSideProps.js
+++ b/src/utils/getApplicationServerSideProps.js
@@ -10,7 +10,7 @@ const getApplicationServerSideProps = (callbackFn) => async ({
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
   }
 
-  const rawCookies = req?.headers?.cookie;
+  const rawCookies = req?.headers?.cookie ?? '';
 
   const cookies = new Cookies(rawCookies);
 


### PR DESCRIPTION
### Fixed

- error would trigger in Firefox when there was no cookie