### PR TITLE
Bug/iii 3727 only redirects after 2 clicks

### DIFF
--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -418,6 +418,7 @@ const SideBar = () => {
   return [
     <Stack
       key="sidebar"
+      tabIndex={0}
       forwardedAs="nav"
       height="100%"
       css={`

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,6 +1,6 @@
 import getConfig from 'next/config';
 import PropTypes from 'prop-types';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Stack } from './publiq-ui/Stack';
 import { Link } from './publiq-ui/Link';
@@ -236,6 +236,7 @@ const SideBar = () => {
 
   const [isJobLoggerVisible, setIsJobLoggerVisible] = useState(true);
   const [jobLoggerState, setJobLoggerState] = useState(JobLoggerStates.IDLE);
+  const sideBarComponent = useRef();
 
   const [
     isAnnouncementsModalVisible,
@@ -430,7 +431,13 @@ const SideBar = () => {
       zIndex={1998}
       padding={{ default: 2, s: 0 }}
       spacing={3}
-      onMouseOver={() => setTimeout(window.focus, 200)}
+      ref={sideBarComponent}
+      onMouseOver={() => {
+        setTimeout(() => {
+          if (!sideBarComponent?.current) return;
+          sideBarComponent.current.focus();
+        }, 100);
+      }}
     >
       <Link
         justifyContent="center"

--- a/src/pages/[...params].js
+++ b/src/pages/[...params].js
@@ -10,7 +10,14 @@ const prefixWhenNotEmpty = (value, prefix) =>
   value ? `${prefix}${value}` : value;
 
 const IFrame = memo(({ url }) => (
-  <Box as="iframe" src={url} width="100%" height="100vh" flex={1} />
+  <Box
+    tabIndex={0}
+    as="iframe"
+    src={url}
+    width="100%"
+    height="100vh"
+    flex={1}
+  />
 ));
 
 IFrame.propTypes = {


### PR DESCRIPTION
### Fixed

- only redirects after 2 clicks

---

Ticket: https://jira.uitdatabank.be/browse/III-3727

Should work on Chrome an d Firefox now 😄 !!!
We couldn't use window.focus because it depends on the browsersettings if we can use it or not.

[It may fail due to user settings and the window isn't guaranteed to be frontmost before this method returns.](https://developer.mozilla.org/en-us/docs/Web/API/Window/focus)
