### PR TITLE
III-3825 Use lodash flatten() instead of Array.prototype.flat()

### DIFF
--- a/src/hooks/api/authenticated-query.js
+++ b/src/hooks/api/authenticated-query.js
@@ -1,3 +1,4 @@
+import flatten from 'lodash/flatten';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import { Cookies } from 'react-cookie';
@@ -15,7 +16,7 @@ const QueryStatus = {
 
 const prepareKey = ({ queryKey = [], queryArguments = {} } = {}) =>
   [
-    ...[queryKey].flat(),
+    flatten(...[queryKey]),
     Object.keys(queryArguments).length > 0 ? queryArguments : undefined,
   ].filter((key) => key !== undefined);
 


### PR DESCRIPTION
### Changed

- Use lodash flatten() instead of Array.prototype.flat() for node 10 compatibility. (The servers and Vagrant box use node 10 right now, and while we should look into updating that it might take some work to get udb3-websockets etc compatible with newer versions, so we should make sure udb3-frontend can be deployed in the meantime.)

---

Ticket: https://jira.uitdatabank.be/browse/III-3825
