### PR TITLE
III-3816 Prevent jobs from transitioning from failed to finished

### DIFF
--- a/src/components/layouts/joblogger/JobLogger.js
+++ b/src/components/layouts/joblogger/JobLogger.js
@@ -79,10 +79,10 @@ const JobLogger = ({ visible, onClose, onStatusChange }) => {
   const updateJobState = (newJobState) => ({ job_id: jobId, location }) =>
     setJobs((previousJobs) =>
       previousJobs.map((job) => {
-        const { id, finishedAt, exportUrl } = job;
+        const { id, finishedAt, exportUrl, state } = job;
         if (id !== jobId) return job;
 
-        if (job.state === JobStates.FAILED) {
+        if (state === JobStates.FAILED) {
           // Jobs can't transition from a failed status to another status.
           return job;
         }

--- a/src/components/layouts/joblogger/JobLogger.js
+++ b/src/components/layouts/joblogger/JobLogger.js
@@ -82,6 +82,11 @@ const JobLogger = ({ visible, onClose, onStatusChange }) => {
         const { id, finishedAt, exportUrl } = job;
         if (id !== jobId) return job;
 
+        if (job.state === JobStates.FAILED) {
+          // Jobs can't transition from a failed status to another status.
+          return job;
+        }
+
         return {
           ...job,
           state: newJobState,


### PR DESCRIPTION
### Fixed

- Fixed failed jobs showing up as succeeded. The backend still sends a "finished" message for every job, even if it failed. We don't want to treat those failed jobs as succeeded though. (Noticed this while testing some exceptions/errors in context of III-3816)

---

Ticket: https://jira.uitdatabank.be/browse/III-3816
