### PR TITLE
III-3794 Add typeahead selection color

### DIFF
--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -33,6 +33,11 @@ const Typeahead = ({
           color: ${getValue('active.color')};
           background-color: ${getValue('active.backgroundColor')};
         }
+        .rbt-highlight-text {
+          color: ${getValue('highlight.color')};
+          font-weight: ${getValue('highlight.fontWeight')};
+          background-color: ${getValue('highlight.backgroundColor')};
+        }
       `}
       onSearch={onSearch}
       onInputChange={onInputChange}

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -30,6 +30,7 @@ const Typeahead = ({
       css={`
         .dropdown-item.active,
         .dropdown-item:active {
+          color: ${getValue('color')};
           background-color: ${getValue('activeBackgroundColor')};
         }
       `}

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -47,6 +47,7 @@ const Typeahead = ({
       placeholder={placeholder}
       emptyLabel={emptyLabel}
       delay={275}
+      highlightOnlyResult
       {...getBoxProps(props)}
     />
   );

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -73,6 +73,7 @@ Typeahead.propTypes = {
 
 const typeaheadDefaultProps = {
   options: [],
+  labelKey: (item) => item,
   onSearch: async () => {},
   disabled: false,
 };

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -65,7 +65,6 @@ Typeahead.propTypes = {
 
 const typeaheadDefaultProps = {
   options: [],
-  labelKey: (item) => item,
   onSearch: async () => {},
   disabled: false,
 };

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -30,8 +30,8 @@ const Typeahead = ({
       css={`
         .dropdown-item.active,
         .dropdown-item:active {
-          color: ${getValue('color')};
-          background-color: ${getValue('activeBackgroundColor')};
+          color: ${getValue('active.color')};
+          background-color: ${getValue('active.backgroundColor')};
         }
       `}
       onSearch={onSearch}

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -32,9 +32,11 @@ const Typeahead = ({
         .dropdown-item:active {
           color: ${getValue('active.color')};
           background-color: ${getValue('active.backgroundColor')};
+          .rbt-highlight-text {
+            color: ${getValue('active.color')};
+          }
         }
         .rbt-highlight-text {
-          color: ${getValue('highlight.color')};
           font-weight: ${getValue('highlight.fontWeight')};
           background-color: ${getValue('highlight.backgroundColor')};
         }

--- a/src/ui/Typeahead.stories.mdx
+++ b/src/ui/Typeahead.stories.mdx
@@ -5,8 +5,9 @@ import { Typeahead } from './Typeahead.js';
 
 export const cities = [
   { id: 1, name: 'Rome' },
-  { id: 2, name: 'Paris' },
-  { id: 3, name: 'Prague' },
+  { id: 2, name: 'Romania' },
+  { id: 3, name: 'Paris' },
+  { id: 4, name: 'Prague' },
 ];
 
 export const commonArgs = {

--- a/src/ui/Typeahead.stories.mdx
+++ b/src/ui/Typeahead.stories.mdx
@@ -11,7 +11,8 @@ export const cities = [
 
 export const commonArgs = {
   id: 'test',
-  options: cities.map((city) => city.name),
+  options: cities,
+  labelKey: (city) => city.name,
 };
 
 export const commonArgTypes = {

--- a/src/ui/TypeaheadWithLabel.js
+++ b/src/ui/TypeaheadWithLabel.js
@@ -1,4 +1,3 @@
-import uniqueId from 'lodash/uniqueId';
 import { Label, LabelVariants } from './Label';
 import {
   Typeahead,
@@ -6,9 +5,9 @@ import {
   typeaheadPropTypes,
 } from './Typeahead';
 import { getStackProps, Stack, stackPropTypes } from './Stack';
-import { useEffect, useState } from 'react';
 
 const TypeaheadWithLabel = ({
+  id,
   label,
   options,
   labelKey,
@@ -21,12 +20,6 @@ const TypeaheadWithLabel = ({
   onChange,
   ...props
 }) => {
-  const [id, setId] = useState('');
-
-  useEffect(() => {
-    setId(uniqueId('typeahead-'));
-  }, []);
-
   return (
     <Stack {...getStackProps(props)}>
       <Label htmlFor={id} variant={LabelVariants.BOLD}>

--- a/src/ui/TypeaheadWithLabel.stories.mdx
+++ b/src/ui/TypeaheadWithLabel.stories.mdx
@@ -11,8 +11,7 @@ export const cities = [
 
 export const commonArgs = {
   label: 'Search for a city:',
-  options: cities,
-  labelKey: (city) => city.name,
+  options: cities.map((city) => city.name),
 };
 
 export const commonArgTypes = {

--- a/src/ui/TypeaheadWithLabel.stories.mdx
+++ b/src/ui/TypeaheadWithLabel.stories.mdx
@@ -10,6 +10,7 @@ export const cities = [
 ];
 
 export const commonArgs = {
+  id: 'typeahead-test',
   label: 'Search for a city:',
   options: cities.map((city) => city.name),
 };

--- a/src/ui/TypeaheadWithLabel.stories.mdx
+++ b/src/ui/TypeaheadWithLabel.stories.mdx
@@ -12,7 +12,8 @@ export const cities = [
 export const commonArgs = {
   id: 'typeahead-test',
   label: 'Search for a city:',
-  options: cities.map((city) => city.name),
+  options: cities,
+  labelKey: (city) => city.name,
 };
 
 export const commonArgTypes = {

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -109,7 +109,8 @@ const theme = {
       paddingY: '0.44rem',
     },
     typeahead: {
-      activeBackgroundColor: colors.udbBlue,
+      color: colors.white,
+      activeBackgroundColor: colors.red2,
     },
     radioButtonWithLabel: {
       infoTextColor: colors.grey5,

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -109,8 +109,10 @@ const theme = {
       paddingY: '0.44rem',
     },
     typeahead: {
-      color: colors.white,
-      activeBackgroundColor: colors.red2,
+      active: {
+        color: colors.white,
+        backgroundColor: colors.red2,
+      },
     },
     radioButtonWithLabel: {
       infoTextColor: colors.grey5,

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -113,6 +113,10 @@ const theme = {
         color: colors.white,
         backgroundColor: colors.red2,
       },
+      highlight: {
+        fontWeight: 'bold',
+        backgroundColor: 'transparent',
+      },
     },
     radioButtonWithLabel: {
       infoTextColor: colors.grey5,


### PR DESCRIPTION
### Added

- Added the typeahead highlight to bold

### Changed

- Changed the typeahead selection color

### Fixed

- Fixed typeahead with label by removing autogenerated id

---

Ticket: https://jira.uitdatabank.be/browse/III-3794
