### PR TITLE
Improvement - Refactor naming of react-query mutations and queries

### DIFF
--- a/src/components/StatusPageMultiple.js
+++ b/src/components/StatusPageMultiple.js
@@ -57,15 +57,12 @@ const StatusPageMultiple = ({ event, refetchEvent }) => {
     setIsModalVisible(false);
   };
 
-  const {
-    mutate: changeStatusSubEvents,
-    ...changeSubEventsMutation
-  } = useChangeStatusSubEvents({
+  const changeSubEventsMutation = useChangeStatusSubEvents({
     onSuccess: handleSuccess,
   });
 
   const handleConfirmChangeStatus = async (type, reason) =>
-    changeStatusSubEvents({
+    changeSubEventsMutation.mutate({
       eventId,
       subEventIds: selectedSubEventIds,
       subEvents,

--- a/src/components/StatusPageSingle.js
+++ b/src/components/StatusPageSingle.js
@@ -48,7 +48,7 @@ const StatusPageSingle = ({ offer, error, useChangeStatus }) => {
   const handleSuccessChangeStatus = () =>
     router.push(`/${offerType}/${offerId}/preview`);
 
-  const { mutate: changeStatus, ...changeStatusMutation } = useChangeStatus({
+  const changeStatusMutation = useChangeStatus({
     onSuccess: handleSuccessChangeStatus,
   });
 
@@ -78,12 +78,12 @@ const StatusPageSingle = ({ offer, error, useChangeStatus }) => {
                 disabled={!offer || reason.length > 200}
                 onClick={() => {
                   if (type === OfferStatus.AVAILABLE) {
-                    changeStatus({
+                    changeStatusMutation.mutate({
                       id: offerId,
                       type,
                     });
                   } else {
-                    changeStatus({
+                    changeStatusMutation.mutate({
                       id: offerId,
                       type,
                       reason: {

--- a/src/components/layouts/Sidebar.js
+++ b/src/components/layouts/Sidebar.js
@@ -246,15 +246,15 @@ const Sidebar = () => {
 
   const [searchQuery, setSearchQuery] = useState('');
 
-  const { data: dataWithAnnouncements = {} } = useGetAnnouncements({
+  const getAnnouncementsQuery = useGetAnnouncements({
     refetchInterval: 60000,
   });
 
-  const rawAnnouncements = dataWithAnnouncements?.data ?? [];
-  const { data: permissions = [] } = useGetPermissions();
-  const { data: roles = [] } = useGetRoles();
-  const { data: eventsToModerate = {} } = useGetEventsToModerate(searchQuery);
-  const countEventsToModerate = eventsToModerate?.totalItems || 0;
+  const rawAnnouncements = getAnnouncementsQuery.data?.data ?? [];
+  const getPermissionsQuery = useGetPermissions();
+  const getRolesQuery = useGetRoles();
+  const getEventsToModerateQuery = useGetEventsToModerate(searchQuery);
+  const countEventsToModerate = getEventsToModerateQuery.data?.totalItems || 0;
 
   const isSmallView = useMatchBreakpoint(Breakpoints.S);
 
@@ -307,11 +307,11 @@ const Sidebar = () => {
   }, [rawAnnouncements]);
 
   useEffect(() => {
-    if (roles.length === 0) {
+    if (!getRolesQuery.data) {
       return;
     }
 
-    const validationQuery = roles
+    const validationQuery = getRolesQuery.data
       .map((role) =>
         role.constraints !== undefined && role.constraints.v3
           ? role.constraints.v3
@@ -321,7 +321,7 @@ const Sidebar = () => {
       .join(' OR ');
 
     setSearchQuery(validationQuery);
-  }, [roles]);
+  }, [getRolesQuery.data]);
 
   const announcements = useMemo(
     () =>
@@ -407,14 +407,14 @@ const Sidebar = () => {
   ];
 
   const filteredManageMenu = useMemo(() => {
-    if (permissions.length === 0) {
+    if (!getPermissionsQuery.data) {
       return [];
     }
 
     return manageMenu.filter((menuItem) =>
-      permissions.includes(menuItem.permission),
+      getPermissionsQuery.data.includes(menuItem.permission),
     );
-  }, [permissions]);
+  }, [getPermissionsQuery.data]);
 
   return [
     <Stack

--- a/src/components/layouts/index.js
+++ b/src/components/layouts/index.js
@@ -26,7 +26,7 @@ const useChangeLanguage = () => {
 const useHandleAuthentication = () => {
   const { query, asPath, ...router } = useRouter();
   const { setCookie, cookies } = useCookiesWithOptions(['user', 'token']);
-  const { data: user } = useGetUser();
+  const getUserQuery = useGetUser();
 
   useEffect(() => {
     if (query?.jwt && cookies.token !== query?.jwt) {
@@ -35,9 +35,9 @@ const useHandleAuthentication = () => {
   }, [query]);
 
   useEffect(() => {
-    if (!user) return;
-    setCookie('user', user);
-  }, [user]);
+    if (!getUserQuery.data) return;
+    setCookie('user', getUserQuery.data);
+  }, [getUserQuery.data]);
 
   // redirect when there is no token or user cookie
   // manipulation from outside the application

--- a/src/components/pages/manage/productions/create/Event.js
+++ b/src/components/pages/manage/productions/create/Event.js
@@ -36,7 +36,7 @@ const Event = ({
     return t(`offerTypes*${typeId}`, { keySeparator: '*' });
   }, [terms]);
 
-  const { data: period } = useGetCalendarSummary({
+  const getCalendarSummaryQuery = useGetCalendarSummary({
     id,
     locale: i18n.language,
     format: calendarType === CalendarType.SINGLE ? 'lg' : 'sm',
@@ -57,7 +57,7 @@ const Event = ({
           <Text>{type}</Text>
           <Stack>
             <Title>{title}</Title>
-            <Text>{period}</Text>
+            <Text>{getCalendarSummaryQuery.data}</Text>
           </Stack>
           <Text>
             {locationName} {locationCity}

--- a/src/components/pages/manage/productions/create/index.js
+++ b/src/components/pages/manage/productions/create/index.js
@@ -33,13 +33,9 @@ const Create = () => {
   const [searchInput, setSearchInput] = useState('');
   const [selectedProductionId, setSelectedProductionId] = useState('');
 
-  const {
-    data: suggestedEvents,
-    status: suggestedEventsStatus,
-    refetch: refetchSuggestedEvents,
-  } = useGetSuggestedEvents({ retry: false });
+  const getSuggestedEventsQuery = useGetSuggestedEvents({ retry: false });
 
-  const { data: suggestedProductionsData } = useGetProductions({
+  const getProductionsQuery = useGetProductions({
     name: searchInput,
     limit: 10,
   });
@@ -47,7 +43,7 @@ const Create = () => {
   const handleSuccess = async () => {
     setSelectedProductionId('');
     setSearchInput('');
-    await refetchSuggestedEvents();
+    await getSuggestedEventsQuery.refetch();
   };
 
   const skipSuggestedEventsMutation = useSkipSuggestedEvents({
@@ -67,11 +63,11 @@ const Create = () => {
   });
 
   const suggestedProductions = searchInput
-    ? suggestedProductionsData?.member ?? []
+    ? getProductionsQuery.data?.member ?? []
     : [];
 
-  const events = suggestedEvents?.events ?? [];
-  const similarity = suggestedEvents?.similarity ?? 0;
+  const events = getSuggestedEventsQuery.data?.events ?? [];
+  const similarity = getSuggestedEventsQuery.data?.similarity ?? 0;
 
   const availableProductions = useMemo(
     () =>
@@ -158,7 +154,7 @@ const Create = () => {
     <Page>
       <Page.Title>{t('productions.create.title')}</Page.Title>
       <Page.Content>
-        {suggestedEventsStatus === QueryStatus.LOADING ? (
+        {getSuggestedEventsQuery.status === QueryStatus.LOADING ? (
           <Spinner marginTop={4} />
         ) : events.length === 0 ? (
           <Text>{t('productions.create.no_suggested_events_found')}</Text>

--- a/src/components/pages/manage/productions/index/Events.js
+++ b/src/components/pages/manage/productions/index/Events.js
@@ -36,7 +36,7 @@ const Event = ({
   className,
 }) => {
   const { i18n, t } = useTranslation();
-  const { data: period } = useGetCalendarSummary({
+  const getCalendarSummaryQuery = useGetCalendarSummary({
     id,
     locale: i18n?.language ?? '',
     format: calendarType === CalendarType.SINGLE ? 'lg' : 'sm',
@@ -87,7 +87,10 @@ const Event = ({
           <DetailTable
             items={[
               { header: t('productions.event.type'), value: type },
-              { header: t('productions.event.when'), value: period },
+              {
+                header: t('productions.event.when'),
+                value: getCalendarSummaryQuery.data,
+              },
               { header: t('productions.event.where'), value: location },
             ]}
           />

--- a/src/components/pages/manage/productions/index/index.js
+++ b/src/components/pages/manage/productions/index/index.js
@@ -96,7 +96,7 @@ const Index = () => {
     setSelectedEventIds([]);
   };
 
-  const { mutate: deleteEventsByIds } = useDeleteEventsByIds({
+  const deleteEventsByIdsMutation = useDeleteEventsByIds({
     onSuccess: handleSuccessDeleteEvents,
   });
 
@@ -119,7 +119,7 @@ const Index = () => {
     });
   };
 
-  const { mutate: addEventById } = useAddEventById({
+  const addEventByIdMutation = useAddEventById({
     onSuccess: handleSuccessAddEvent,
     onError: handleErrorAddEvent,
   });
@@ -187,7 +187,7 @@ const Index = () => {
                 }}
                 onAddEvent={() => {
                   setErrorMessageEvents('');
-                  addEventById({
+                  addEventByIdMutation.mutate({
                     productionId: activeProduction.id,
                     eventId: toBeAddedEventId,
                   });
@@ -210,7 +210,7 @@ const Index = () => {
           eventCount={selectedEventIds.length}
           productionName={activeProduction?.name ?? ''}
           onConfirm={() => {
-            deleteEventsByIds({
+            deleteEventsByIdsMutation.mutate({
               productionId: activeProduction.id,
               eventIds: selectedEventIds,
             });


### PR DESCRIPTION
### Changed

- Use the same naming for queries and mutations throughout the application
e.g. 
`const getProductionsQuery = useGetProductions()`
`const addEventsByIdsMutation = useAddEventsByIds()`
