### PR TITLE
III-3893 Add min length to typeahead

### DIFF
--- a/src/components/pages/manage/productions/create/index.js
+++ b/src/components/pages/manage/productions/create/index.js
@@ -235,6 +235,7 @@ const Create = () => {
                   maxWidth="43rem"
                   label={t('productions.create.production_name')}
                   emptyLabel={t('productions.create.no_productions')}
+                  minLength={3}
                   onInputChange={throttle(handleInputSearch, 275)}
                   onChange={(selected) => {
                     if (!selected || selected.length !== 1) {

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -15,6 +15,7 @@ const Typeahead = forwardRef(
       disabled,
       placeholder,
       emptyLabel,
+      minLength,
       className,
       onInputChange,
       onSearch,
@@ -51,6 +52,7 @@ const Typeahead = forwardRef(
         onChange={onChange}
         placeholder={placeholder}
         emptyLabel={emptyLabel}
+        minLength={minLength}
         delay={275}
         highlightOnlyResult
         ref={ref}
@@ -67,6 +69,7 @@ const typeaheadPropTypes = {
   disabled: PropTypes.bool,
   placeholder: PropTypes.string,
   emptyLabel: PropTypes.string,
+  minLength: PropTypes.number,
   className: PropTypes.string,
   onInputChange: PropTypes.func,
   onSearch: PropTypes.func,

--- a/src/ui/Typeahead.stories.mdx
+++ b/src/ui/Typeahead.stories.mdx
@@ -14,6 +14,7 @@ export const commonArgs = {
   id: 'test',
   options: cities,
   labelKey: (city) => city.name,
+  minLength: 3,
 };
 
 export const commonArgTypes = {


### PR DESCRIPTION
### Added
- Add min length to typeahead to only trigger search when this min length is reached

---

Ticket: https://jira.uitdatabank.be/browse/III-3893
