### PR TITLE
III-3893 Add minLength on TypeaheadWithLabel

### DIFF
--- a/src/components/pages/manage/productions/create/index.js
+++ b/src/components/pages/manage/productions/create/index.js
@@ -235,7 +235,6 @@ const Create = () => {
                   maxWidth="43rem"
                   label={t('productions.create.production_name')}
                   emptyLabel={t('productions.create.no_productions')}
-                  minLength={3}
                   onInputChange={throttle(handleInputSearch, 275)}
                   onChange={(selected) => {
                     if (!selected || selected.length !== 1) {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -69,7 +69,7 @@
       "production": "Production",
       "search": {
         "label": "Recherche par nom de production:",
-        "placeholder": "Écrivez une recherche d'au moins 4 caractères."
+        "placeholder": "Écrivez une recherche d'au moins 3 caractères."
       },
       "title": "Productions",
       "aria": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -71,7 +71,7 @@
       "production": "Productie",
       "search": {
         "label": "Zoeken op productienaam:",
-        "placeholder": "Schrijf een zoekopdracht van minstens 4 karakters."
+        "placeholder": "Schrijf een zoekopdracht van minstens 3 karakters."
       },
       "title": "Producties",
       "aria": {

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -86,6 +86,7 @@ const typeaheadDefaultProps = {
   labelKey: (item) => item,
   onSearch: async () => {},
   disabled: false,
+  minLength: 3,
 };
 
 Typeahead.defaultProps = {

--- a/src/ui/Typeahead.stories.mdx
+++ b/src/ui/Typeahead.stories.mdx
@@ -14,7 +14,6 @@ export const commonArgs = {
   id: 'test',
   options: cities,
   labelKey: (city) => city.name,
-  minLength: 3,
 };
 
 export const commonArgTypes = {

--- a/src/ui/TypeaheadWithLabel.js
+++ b/src/ui/TypeaheadWithLabel.js
@@ -17,6 +17,7 @@ const TypeaheadWithLabel = forwardRef(
       disabled,
       placeholder,
       emptyLabel,
+      minLength,
       className,
       onInputChange,
       onSearch,
@@ -36,6 +37,7 @@ const TypeaheadWithLabel = forwardRef(
           labelKey={labelKey}
           disabled={disabled}
           emptyLabel={emptyLabel}
+          minLength={minLength}
           placeholder={placeholder}
           className={className}
           onInputChange={onInputChange}


### PR DESCRIPTION
### Added
- Add minLength on TypeaheadWithLabel

### Changed
- Fixed placeholder for production search
- Give minLength a default value of 3

---

Ticket: https://jira.uitdatabank.be/browse/III-3893
