### PR TITLE
III-3759 Fix focus outlines

### DIFF
--- a/src/components/layouts/Sidebar.js
+++ b/src/components/layouts/Sidebar.js
@@ -419,7 +419,6 @@ const Sidebar = () => {
   return [
     <Stack
       key="sidebar"
-      tabIndex={0}
       forwardedAs="nav"
       height="100%"
       css={`

--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -30,6 +30,11 @@ const customCSS = css`
     border-radius: ${getValue('borderRadius')};
     padding: ${getValue('paddingY')} ${getValue('paddingX')};
     flex-shrink: 0;
+
+    &:focus,
+    &.focus {
+      outline: auto;
+    }
   }
 
   &.btn-primary {

--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -211,6 +211,9 @@ const Button = ({
         background: none;
         border: none;
 
+        :focus {
+          outline: auto;
+        }
         :focus:not(:focus-visible) {
           outline: none;
         }

--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -35,6 +35,11 @@ const customCSS = css`
     &.focus {
       outline: auto;
     }
+
+    &:focus:not(:focus-visible),
+    &.focus:not(:focus-visible) {
+      outline: none;
+    }
   }
 
   &.btn-primary {

--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -211,7 +211,7 @@ const Button = ({
         background: none;
         border: none;
 
-        :focus {
+        :focus:not(:focus-visible) {
           outline: none;
         }
       `}

--- a/src/ui/List.js
+++ b/src/ui/List.js
@@ -37,7 +37,6 @@ const ListItem = ({ children, className, onClick, ...props }) => {
   return (
     <Inline
       as="li"
-      tabIndex={0}
       className={className}
       onClick={onClick}
       {...getInlineProps(props)}


### PR DESCRIPTION
### Removed

- Removed `tabindex` from sidebar so it doesn't get focus when hovering or tabbing
- Removed `tabindex` from list items so you don't need to tab twice (once for the list item, and again for the link/button inside)

### Fixed

- Fixed invisble focus outlines on links and buttons when navigating by keyboard by resetting the outlines of buttons to `auto`, and only hiding it when not using the keyboard (see https://css-tricks.com/keyboard-only-focus-styles/)

---

Ticket: https://jira.uitdatabank.be/browse/III-3759

To test this I'd suggest to tab around a page (`/manage/productions` is a good one) in Chrome and look if the order makes sense, nothing gets skipped, and the focused element is always clearly visible.

If you use Firefox, links are not tab-able by default on macOS. So you will only be tabbing through buttons and inputs. To fix that, see https://stackoverflow.com/a/66208705 and restart Firefox afterwards. It's not something we can fix ourselves it seems (I tried setting a `tabindex` on the links but that didn't seem to work). It's especially annoying in the sidebar because some of the items in there are links and others are buttons, so it's confusing why some do not get focus if you don't know this.

On a general note, we will need to make sure that we keep using only links, buttons, or form inputs for interactive elements to make sure that keyboard navigation keeps working. We're already doing a good job at that but it's definitely something to keep in mind.
