### PR TITLE
Bug with display: flex on links

### DIFF
--- a/src/ui/Link.js
+++ b/src/ui/Link.js
@@ -18,6 +18,7 @@ const BaseLink = forwardRef(({ variant, ...props }, ref) => {
       <Inline
         ref={ref}
         forwardedAs="a"
+        width="min-content"
         color={{ default: 'inherit', hover: 'inherit' }}
         alignItems="center"
         css={`

--- a/src/ui/Link.js
+++ b/src/ui/Link.js
@@ -21,9 +21,6 @@ const BaseLink = forwardRef(({ variant, ...props }, ref) => {
         width="min-content"
         color={{ default: 'inherit', hover: 'inherit' }}
         alignItems="center"
-        css={`
-          display: inline-block;
-        `}
         {...props}
       />
     );
@@ -35,7 +32,6 @@ const BaseLink = forwardRef(({ variant, ...props }, ref) => {
       forwardedAs="a"
       color={{ default: getValue('color'), hover: getValue('color') }}
       css={`
-        display: inline-block;
         font-weight: 400;
         &:hover {
           text-decoration: underline;

--- a/src/ui/Link.js
+++ b/src/ui/Link.js
@@ -21,6 +21,9 @@ const BaseLink = forwardRef(({ variant, ...props }, ref) => {
         width="min-content"
         color={{ default: 'inherit', hover: 'inherit' }}
         alignItems="center"
+        css={`
+          display: inline-block;
+        `}
         {...props}
       />
     );
@@ -32,6 +35,7 @@ const BaseLink = forwardRef(({ variant, ...props }, ref) => {
       forwardedAs="a"
       color={{ default: getValue('color'), hover: getValue('color') }}
       css={`
+        display: inline-block;
         font-weight: 400;
         &:hover {
           text-decoration: underline;

--- a/src/ui/Link.js
+++ b/src/ui/Link.js
@@ -31,6 +31,7 @@ const BaseLink = forwardRef(({ variant, ...props }, ref) => {
       ref={ref}
       forwardedAs="a"
       color={{ default: getValue('color'), hover: getValue('color') }}
+      display="inline-flex"
       css={`
         font-weight: 400;
         &:hover {

--- a/src/ui/Link.js
+++ b/src/ui/Link.js
@@ -18,7 +18,7 @@ const BaseLink = forwardRef(({ variant, ...props }, ref) => {
       <Inline
         ref={ref}
         forwardedAs="a"
-        width="min-content"
+        display="inline-flex"
         color={{ default: 'inherit', hover: 'inherit' }}
         alignItems="center"
         {...props}

--- a/src/ui/Link.js
+++ b/src/ui/Link.js
@@ -18,7 +18,6 @@ const BaseLink = forwardRef(({ variant, ...props }, ref) => {
       <Inline
         ref={ref}
         forwardedAs="a"
-        width="min-content"
         color={{ default: 'inherit', hover: 'inherit' }}
         alignItems="center"
         css={`

--- a/src/ui/Link.stories.mdx
+++ b/src/ui/Link.stories.mdx
@@ -2,12 +2,17 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { Link, LinkVariants } from './Link.js';
 import { Box } from './Box.js';
 import { Icon, Icons } from './Icon.js';
+import { Text } from '@/ui/Text';
 
 <Meta title="Components/Link" component={Link} />
 
 <Canvas>
   <Story name="Internal" args={{ children: 'internal', href: '/test' }}>
-    {(args) => <Link {...args} />}
+    {(args) => (
+      <Text>
+        This is an <Link {...args} /> link
+      </Text>
+    )}
   </Story>
 </Canvas>
 


### PR DESCRIPTION
This PR illustrates the issue with `display: flex` on links.

You can view the Story that illustrates it on https://5f69c0eb52e6b60022561d99-jyexhyrsvo.chromatic.com/?path=/story/components-link--internal

<img width="1722" alt="Screen Shot 2021-04-14 at 17 27 50" src="https://user-images.githubusercontent.com/959026/114736916-d0209580-9d46-11eb-8706-55f9719d07e2.png">

On the Story for the unstyled variant with text, there is a similar/related issue: https://5f69c0eb52e6b60022561d99-jyexhyrsvo.chromatic.com/?path=/story/components-link--unstyled-external

The unstyled variant has `width: min-content`, which was probably meant to undo the 100% width set by `display: flex`, but makes the text inside the link wrap to multiple lines while it could fit on a single line.

<img width="1722" alt="Screen Shot 2021-04-14 at 17 28 41" src="https://user-images.githubusercontent.com/959026/114737178-0a8a3280-9d47-11eb-8880-e03ab5e4558a.png">