### PR TITLE
Fix client side redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,17 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
   ],
+  async redirects() {
+    // Redirects to fix non-existing paths should go in `src/redirects.js`!!!
+    const env = process.env.NEXT_PUBLIC_ENVIRONMENT;
+    return [
+      {
+        source: '/',
+        destination: '/dashboard',
+        permanent: env !== 'development',
+      },
+    ];
+  },
   publicRuntimeConfig: {
     environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
     apiKey: process.env.NEXT_PUBLIC_API_KEY,

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+const { getRedirects } = require('./src/redirects');
+
 module.exports = {
   future: {
     webpack5: true,
@@ -9,27 +11,8 @@ module.exports = {
     '@storybook/addon-a11y',
   ],
   async redirects() {
-    // Only make the permanent redirects really permanent in environments other
-    // than development, so we don't get permanent redirects on localhost which
-    // may conflict with other projects.
     const env = process.env.NEXT_PUBLIC_ENVIRONMENT;
-    return [
-      {
-        source: '/',
-        destination: '/dashboard',
-        permanent: env !== 'development',
-      },
-      {
-        source: '/event/:eventId/status',
-        destination: '/events/:eventId/status',
-        permanent: env !== 'development',
-      },
-      {
-        source: '/place/:placeId/status',
-        destination: '/places/:placeId/status',
-        permanent: env !== 'development',
-      },
-    ];
+    return getRedirects(env);
   },
   publicRuntimeConfig: {
     environment: process.env.NEXT_PUBLIC_ENVIRONMENT,

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-const { getRedirects } = require('./src/redirects');
-
 module.exports = {
   future: {
     webpack5: true,
@@ -10,10 +8,6 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
   ],
-  async redirects() {
-    const env = process.env.NEXT_PUBLIC_ENVIRONMENT;
-    return getRedirects(env);
-  },
   publicRuntimeConfig: {
     environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
     apiKey: process.env.NEXT_PUBLIC_API_KEY,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^17.0.1",
     "react-i18next": "^11.7.3",
     "react-query": "^3.2.0",
-    "react-router-dom": "^5.2.0",
+    "react-router": "^5.2.0",
     "react-table": "^7.6.3",
     "sass": "^1.27.0",
     "sass-loader": "^10.0.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^17.0.1",
     "react-i18next": "^11.7.3",
     "react-query": "^3.2.0",
+    "react-router-dom": "^5.2.0",
     "react-table": "^7.6.3",
     "sass": "^1.27.0",
     "sass-loader": "^10.0.4",

--- a/src/components/layouts/index.js
+++ b/src/components/layouts/index.js
@@ -84,7 +84,6 @@ const Layout = ({ children }) => {
         router.push({ pathname: url.pathname, query });
       }
     },
-    [WindowMessageTypes.URL_UNKNOWN]: () => router.push('/404'),
     [WindowMessageTypes.HTTP_ERROR_CODE]: ({ code }) => {
       if ([401, 403].includes(code)) {
         removeAuthenticationCookies();

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -13,11 +13,12 @@ import {
 } from '@/hooks/useHandleWindowMessage';
 import PageNotFound from '@/pages/404';
 import { useIsClient } from '@/hooks/useIsClient';
+import { Cookies } from 'react-cookie';
 
 const prefixWhenNotEmpty = (value, prefix) =>
   value ? `${prefix}${value}` : value;
 
-const getRedirect = (originalPath, environment) => {
+const getRedirect = (originalPath, environment, cookies) => {
   const matches = getRedirects(environment)
     .map(({ source, destination, permanent }) => {
       const match = matchPath(originalPath, { path: source, exact: true });
@@ -109,15 +110,20 @@ const Fallback = () => {
 };
 
 export const getServerSideProps = getApplicationServerSideProps(
-  ({ req, query, cookies, queryClient }) => {
+  ({ req, query, cookies: rawCookies, queryClient }) => {
+    const cookies = new Cookies(rawCookies);
     const { publicRuntimeConfig } = getConfig();
     const path = '/' + query.params.join('/');
-    const redirect = getRedirect(path, publicRuntimeConfig.environment);
+    const redirect = getRedirect(
+      path,
+      publicRuntimeConfig.environment,
+      cookies.cookies,
+    );
     if (redirect) {
       return { redirect };
     }
 
-    return { props: { cookies } };
+    return { props: { cookies: rawCookies } };
   },
 );
 

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -63,15 +63,6 @@ const Fallback = () => {
 
   const { publicRuntimeConfig } = getConfig();
 
-  const redirect = getRedirect(asPath, publicRuntimeConfig.environment);
-  if (redirect) {
-    // Use replace() instead of push() so the back button behaviour still
-    // works as expected: The back button will go back to the url BEFORE the
-    // one that redirected. Otherwise you get stuck in an infinite loop of
-    // back -> redirect -> back -> redirect ...
-    router.replace(redirect.destination);
-  }
-
   // Keep track of which paths were not found. Do not store as a single boolean
   // for the current path, because it's possible to navigate from a 404 path to
   // another page that's handled by this same Fallback component and then the

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -35,7 +35,7 @@ const getRedirect = (originalPath, environment, cookies) => {
       if (match) {
         return {
           destination: generatePath(destination, match.params),
-          permanent,
+          permanent: featureFlag === undefined && permanent,
         };
       }
       return false;

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -20,7 +20,7 @@ const prefixWhenNotEmpty = (value, prefix) =>
   value ? `${prefix}${value}` : value;
 
 const getRedirect = (originalPath, environment, cookies) => {
-  const matches = getRedirects(environment)
+  return getRedirects(environment)
     .map(({ source, destination, permanent, featureFlag }) => {
       // Don't follow redirects that are behind a feature flag
       if (featureFlag) {
@@ -40,12 +40,7 @@ const getRedirect = (originalPath, environment, cookies) => {
       }
       return false;
     })
-    .filter((match) => !!match);
-
-  if (matches.length > 0) {
-    return matches[0];
-  }
-  return false;
+    .find((match) => !!match);
 };
 
 const IFrame = memo(({ url }) => (

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -23,11 +23,8 @@ const getRedirect = (originalPath, environment, cookies) => {
   return getRedirects(environment)
     .map(({ source, destination, permanent, featureFlag }) => {
       // Don't follow redirects that are behind a feature flag
-      if (featureFlag) {
-        const enabled = isFeatureFlagEnabledInCookies(featureFlag, cookies);
-        if (!enabled) {
-          return false;
-        }
+      if (featureFlag && !isFeatureFlagEnabledInCookies(featureFlag, cookies)) {
+        return false;
       }
 
       // Check if the redirect source matches the current path

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -52,11 +52,14 @@ const Fallback = () => {
     }
   });
 
-  const [notFound, setNotFound] = useState(false);
+  // Keep track of which paths were not found. Do not store as a single boolean
+  // for the current path, because it's possible to navigate from a 404 path to
+  // another page that's handled by this same Fallback component and then the
+  // boolean notFound state would not update.
+  const [notFoundPaths, setNotFoundPaths] = useState([]);
   useHandleWindowMessage({
-    [WindowMessageTypes.URL_UNKNOWN]: () => {
-      setNotFound(true);
-    },
+    [WindowMessageTypes.URL_UNKNOWN]: () =>
+      setNotFoundPaths([asPath, ...notFoundPaths]),
   });
 
   const isClientSide = useIsClient();
@@ -78,7 +81,7 @@ const Fallback = () => {
     return `${publicRuntimeConfig.legacyAppUrl}${path}${queryString}`;
   }, [asPath, cookies.token, cookies['udb-language']]);
 
-  if (notFound) {
+  if (notFoundPaths.includes(asPath)) {
     return <PageNotFound />;
   }
 

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -129,8 +129,23 @@ export const getServerSideProps = getApplicationServerSideProps(
       publicRuntimeConfig.environment,
       cookies.cookies,
     );
+
     if (redirect) {
-      return { redirect };
+      // Don't include the `params` in the redirect URL's query.
+      delete query.params;
+      const queryParameters = new URLSearchParams(query);
+
+      // Return the redirect as-is if there are no additional query parameters
+      // to append.
+      if (queryParameters.toString().length === 0) {
+        return { redirect };
+      }
+
+      // Append query parameters to the redirect destination.
+      const glue = redirect.destination.indexOf('?') !== -1 ? '&' : '?';
+      const redirectUrl =
+        redirect.destination + glue + queryParameters.toString();
+      return { redirect: { ...redirect, destination: redirectUrl } };
     }
 
     return { props: { cookies: rawCookies } };

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -7,6 +7,10 @@ import { getApplicationServerSideProps } from '@/utils/getApplicationServerSideP
 import { memo, useMemo } from 'react';
 import { generatePath, matchPath } from 'react-router';
 import { getRedirects } from '../../redirects';
+import {
+  useHandleWindowMessage,
+  WindowMessageTypes,
+} from '@/hooks/useHandleWindowMessage';
 
 const prefixWhenNotEmpty = (value, prefix) =>
   value ? `${prefix}${value}` : value;
@@ -44,6 +48,10 @@ const Fallback = () => {
       const destinationPath = generatePath(destination, match.params);
       router.replace(destinationPath);
     }
+  });
+
+  useHandleWindowMessage({
+    [WindowMessageTypes.URL_UNKNOWN]: () => router.push('/404'),
   });
 
   const { cookies } = useCookiesWithOptions(['token', 'udb-language']);

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -48,6 +48,10 @@ const Fallback = () => {
     const match = matchPath(asPath, { path: source, exact: true });
     if (match) {
       const destinationPath = generatePath(destination, match.params);
+      // Use replace() instead of push() so the back button behaviour still
+      // works as expected: The back button will go back to the url BEFORE the
+      // one that redirected. Otherwise you get stuck in an infinite loop of
+      // back -> redirect -> back -> redirect ...
       router.replace(destinationPath);
     }
   });

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -4,13 +4,14 @@ import { useRouter } from 'next/router';
 import { Box } from '@/ui/Box';
 import { useCookiesWithOptions } from '@/hooks/useCookiesWithOptions';
 import { getApplicationServerSideProps } from '@/utils/getApplicationServerSideProps';
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { generatePath, matchPath } from 'react-router';
 import { getRedirects } from '../../redirects';
 import {
   useHandleWindowMessage,
   WindowMessageTypes,
 } from '@/hooks/useHandleWindowMessage';
+import PageNotFound from '@/pages/404';
 
 const prefixWhenNotEmpty = (value, prefix) =>
   value ? `${prefix}${value}` : value;
@@ -50,8 +51,11 @@ const Fallback = () => {
     }
   });
 
+  const [notFound, setNotFound] = useState(false);
   useHandleWindowMessage({
-    [WindowMessageTypes.URL_UNKNOWN]: () => router.push('/404'),
+    [WindowMessageTypes.URL_UNKNOWN]: () => {
+      setNotFound(true);
+    },
   });
 
   const { cookies } = useCookiesWithOptions(['token', 'udb-language']);
@@ -70,6 +74,10 @@ const Fallback = () => {
 
     return `${publicRuntimeConfig.legacyAppUrl}${path}${queryString}`;
   }, [asPath, cookies.token, cookies['udb-language']]);
+
+  if (notFound) {
+    return <PageNotFound />;
+  }
 
   return <IFrame url={legacyPath} />;
 };

--- a/src/hooks/useFeatureFlag.js
+++ b/src/hooks/useFeatureFlag.js
@@ -15,9 +15,9 @@ const useFeatureFlag = (featureFlagName) => {
   const cookieName = createCookieName(featureFlagName);
 
   const set = (value) => setCookie(cookieName, value);
-  const value = isFeatureFlagEnabledInCookies(featureFlagName, cookies);
+  const enabled = isFeatureFlagEnabledInCookies(featureFlagName, cookies);
 
-  return [value, set];
+  return [enabled, set];
 };
 
 const isFeatureFlagEnabledInCookies = (featureFlagName, cookies) => {

--- a/src/hooks/useFeatureFlag.js
+++ b/src/hooks/useFeatureFlag.js
@@ -15,9 +15,9 @@ const useFeatureFlag = (featureFlagName) => {
   const cookieName = createCookieName(featureFlagName);
 
   const set = (value) => setCookie(cookieName, value);
-  const enabled = isFeatureFlagEnabledInCookies(featureFlagName, cookies);
+  const isEnabled = isFeatureFlagEnabledInCookies(featureFlagName, cookies);
 
-  return [enabled, set];
+  return [isEnabled, set];
 };
 
 const isFeatureFlagEnabledInCookies = (featureFlagName, cookies) => {

--- a/src/hooks/useFeatureFlag.js
+++ b/src/hooks/useFeatureFlag.js
@@ -15,9 +15,19 @@ const useFeatureFlag = (featureFlagName) => {
   const cookieName = createCookieName(featureFlagName);
 
   const set = (value) => setCookie(cookieName, value);
-  const value = cookies?.[cookieName] ?? false;
+  const value = isFeatureFlagEnabledInCookies(featureFlagName, cookies);
 
-  return [value === 'true', set];
+  return [value, set];
 };
 
-export { useFeatureFlag, createCookieName, FeatureFlags };
+const isFeatureFlagEnabledInCookies = (featureFlagName, cookies) => {
+  const cookieName = createCookieName(featureFlagName);
+  return cookies?.[cookieName] === 'true' ?? false;
+};
+
+export {
+  useFeatureFlag,
+  createCookieName,
+  isFeatureFlagEnabledInCookies,
+  FeatureFlags,
+};

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -3,11 +3,6 @@ exports.getRedirects = (environment) => [
   // than development, so we don't get permanent redirects on localhost which
   // may conflict with other projects.
   {
-    source: '/',
-    destination: '/dashboard',
-    permanent: environment !== 'development',
-  },
-  {
     source: '/event/:eventId/status',
     destination: '/events/:eventId/status',
     permanent: environment !== 'development',

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -1,0 +1,20 @@
+exports.getRedirects = (environment) => [
+  // Only make the permanent redirects really permanent in environments other
+  // than development, so we don't get permanent redirects on localhost which
+  // may conflict with other projects.
+  {
+    source: '/',
+    destination: '/dashboard',
+    permanent: environment !== 'development',
+  },
+  {
+    source: '/event/:eventId/status',
+    destination: '/events/:eventId/status',
+    permanent: environment !== 'development',
+  },
+  {
+    source: '/place/:placeId/status',
+    destination: '/places/:placeId/status',
+    permanent: environment !== 'development',
+  },
+];

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -1,3 +1,5 @@
+import { FeatureFlags } from '@/hooks/useFeatureFlag';
+
 const getRedirects = (environment) => [
   // Only make the permanent redirects really permanent in environments other
   // than development, so we don't get permanent redirects on localhost which
@@ -11,6 +13,12 @@ const getRedirects = (environment) => [
     source: '/place/:placeId/status',
     destination: '/places/:placeId/status',
     permanent: environment !== 'development',
+  },
+  {
+    source: '/dashboard',
+    destination: '/events',
+    permanent: environment !== 'development',
+    featureFlag: FeatureFlags.REACT_DASHBOARD,
   },
 ];
 

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -1,4 +1,4 @@
-exports.getRedirects = (environment) => [
+const getRedirects = (environment) => [
   // Only make the permanent redirects really permanent in environments other
   // than development, so we don't get permanent redirects on localhost which
   // may conflict with other projects.
@@ -13,3 +13,5 @@ exports.getRedirects = (environment) => [
     permanent: environment !== 'development',
   },
 ];
+
+export { getRedirects };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10750,20 +10750,7 @@ react-refresh@0.8.3, react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-router-dom@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
-  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.2.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-
-react-router@5.2.0:
+react-router@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
   integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7025,6 +7025,18 @@ highlight.js@^10.1.1, highlight.js@~10.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
   integrity sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -7034,7 +7046,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7753,6 +7765,11 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -8633,7 +8650,7 @@ lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -8944,6 +8961,14 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -9842,6 +9867,13 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-to-regexp@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
@@ -10631,7 +10663,7 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
+react-is@16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -10717,6 +10749,35 @@ react-refresh@0.8.3, react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-router-dom@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
+  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
+  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -11143,6 +11204,11 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -12323,6 +12389,16 @@ tiny-emitter@^2.0.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
+tiny-invariant@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -12913,6 +12989,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
### Added

- Added "client-side" redirects (you can test this by going to the detail page of an event and clicking the "Status wijzigen" button -> This should redirect from `/event/:eventId/status` to `/events/:eventId/status`)
- Added possibility to put redirects handled by `[...params].js` behind feature flags (so only works for paths that don't exist in React, which should be fine for the porting of AngularJS pages to React and making the AngularJS pages redirect when the React page is finished)

### Changed

- Changed 404 logic to only listen for `URL_UNKNOWN` messages in the `Fallback` component, because if it was registered sooner in the app itself the 404 logic would conflict with the redirect logic and sometimes a page that should redirect would show 404 instead because the iframe would be rendered and the AngularJS app would send a message that the page was not found before the redirect logic had kicked in
- 404 pages are now rendered on the current path instead of redirecting to `/404`

---

**Note!** This points to #231 because that fix made it easier to test that the client-side and server-side rendering still works as expected with these redirects in place.

Screenshot of how the 404 now looks (notice the unchanged URL)

<img width="1722" alt="Screen Shot 2021-04-16 at 15 38 31" src="https://user-images.githubusercontent.com/959026/115034886-469ad000-9ecc-11eb-82fc-09fe04aa5927.png">

