### PR TITLE
Bugfix/iframe captures focus

### DIFF
--- a/src/components/layouts/Sidebar.js
+++ b/src/components/layouts/Sidebar.js
@@ -438,7 +438,8 @@ const Sidebar = () => {
       onMouseOver={() => {
         setTimeout(() => {
           if (!sidebarComponent?.current) return;
-          sidebarComponent.current.focus();
+          if (document.activeElement.tagName !== 'iframe') return;
+          document.activeElement.blur();
         }, 100);
       }}
     >

--- a/src/components/pages/[...params].js
+++ b/src/components/pages/[...params].js
@@ -10,14 +10,7 @@ const prefixWhenNotEmpty = (value, prefix) =>
   value ? `${prefix}${value}` : value;
 
 const IFrame = memo(({ url }) => (
-  <Box
-    tabIndex={0}
-    as="iframe"
-    src={url}
-    width="100%"
-    height="100vh"
-    flex={1}
-  />
+  <Box as="iframe" src={url} width="100%" height="100vh" flex={1} />
 ));
 
 IFrame.propTypes = {


### PR DESCRIPTION
### Fixed

- Fixed `iframe` trapping the focus again after removing the `tabindex` from the sidebar in #218. The new solution does not require `tabindex`, which would mess with keyboard navigation and add outlines around the sidebar and/or iframe.
