### PR TITLE
Add muted text variant

### DIFF
--- a/src/ui/Text.js
+++ b/src/ui/Text.js
@@ -1,9 +1,23 @@
 import PropTypes from 'prop-types';
+import { css } from 'styled-components';
 import { Box, boxPropTypes, getBoxProps } from './Box';
+import { getValueFromTheme } from './theme';
 
-const Text = ({ as, children, className, ...props }) => {
+const getValue = getValueFromTheme('text');
+
+const TextVariants = {
+  REGULAR: 'regular',
+  MUTED: 'muted',
+};
+
+const mutedCSS = css`
+  color: ${getValue('muted.color')};
+`;
+
+const Text = ({ as, children, className, variant, ...props }) => {
+  const css = variant === TextVariants.MUTED ? mutedCSS : ``;
   return (
-    <Box as={as} className={className} {...getBoxProps(props)}>
+    <Box as={as} className={className} css={css} {...getBoxProps(props)}>
       {children}
     </Box>
   );
@@ -14,10 +28,12 @@ Text.propTypes = {
   as: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
+  variant: PropTypes.string,
 };
 
 Text.defaultProps = {
   as: 'span',
+  variant: TextVariants.REGULAR,
 };
 
-export { Text };
+export { Text, TextVariants };

--- a/src/ui/Text.js
+++ b/src/ui/Text.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import { css } from 'styled-components';
 import { Box, boxPropTypes, getBoxProps } from './Box';
 import { getValueFromTheme } from './theme';
 
@@ -10,14 +9,14 @@ const TextVariants = {
   MUTED: 'muted',
 };
 
-const mutedCSS = css`
-  color: ${getValue('muted.color')};
-`;
-
 const Text = ({ as, children, className, variant, ...props }) => {
-  const css = variant === TextVariants.MUTED ? mutedCSS : ``;
   return (
-    <Box as={as} className={className} css={css} {...getBoxProps(props)}>
+    <Box
+      as={as}
+      className={className}
+      color={variant === TextVariants.MUTED && getValue('muted.color')}
+      {...getBoxProps(props)}
+    >
       {children}
     </Box>
   );

--- a/src/ui/Text.stories.mdx
+++ b/src/ui/Text.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import { Text } from './Text.js';
+import { Text, TextVariants } from './Text.js';
 
 <Meta title="Components/Text" component={Text} />
 
@@ -10,3 +10,15 @@ import { Text } from './Text.js';
 </Canvas>
 
 <ArgsTable story="Default" />
+
+<Canvas>
+  <Story name="Muted" args={{ as: 'span' }}>
+    {(args) => (
+      <Text {...args} variant={TextVariants.MUTED}>
+        muted text
+      </Text>
+    )}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Muted" />

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -238,6 +238,11 @@ const theme = {
       activeToggleBoxShadow: 'inset 0 3px 5px rgba(0, 0, 0, 0.125)',
       menuBorderRadius: 0,
     },
+    text: {
+      muted: {
+        color: colors.grey5,
+      },
+    },
   },
 };
 


### PR DESCRIPTION
### Added

- Added `MUTED` variant for `Text` component

---

Ticket: https://jira.uitdatabank.be/browse/III-3997

Will be needed on the dashboard for past events, for example on the current one in AngularJS:
![Screen Shot 2021-05-03 at 13 27 54](https://user-images.githubusercontent.com/959026/116870748-61cb4680-ac13-11eb-81e0-db8cc9fac116.png)
