### PR TITLE
Remove incorrect boxPropTypes usage

### DIFF
--- a/src/components/pages/login/[language].js
+++ b/src/components/pages/login/[language].js
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { css, keyframes } from 'styled-components';
 
 import { useCookiesWithOptions } from '@/hooks/useCookiesWithOptions';
-import { Box, boxPropTypes } from '@/ui/Box';
+import { Box } from '@/ui/Box';
 import { Button, ButtonSizes, ButtonVariants } from '@/ui/Button';
 import { Image } from '@/ui/Image';
 import { Inline } from '@/ui/Inline';
@@ -28,13 +28,9 @@ const Svg = (props) => (
 );
 
 const Group = (props) => <Box as="g" fill="white" {...props} />;
-Group.propTypes = {
-  ...boxPropTypes,
-};
+Group.propTypes = {};
 const Path = (props) => <Box as="path" {...props} />;
-Path.propTypes = {
-  ...boxPropTypes,
-};
+Path.propTypes = {};
 
 const Animation = (props) => {
   const draw = keyframes`

--- a/src/components/pages/manage/productions/index/Events.js
+++ b/src/components/pages/manage/productions/index/Events.js
@@ -11,12 +11,12 @@ import { Button, ButtonVariants } from '@/ui/Button';
 import { CheckboxWithLabel } from '@/ui/CheckboxWithLabel';
 import { DetailTable } from '@/ui/DetailTable';
 import { Icon, Icons } from '@/ui/Icon';
-import { getInlineProps, Inline, inlinePropTypes } from '@/ui/Inline';
+import { getInlineProps, Inline } from '@/ui/Inline';
 import { Input } from '@/ui/Input';
 import { List } from '@/ui/List';
 import { Panel } from '@/ui/Panel';
 import { Spinner } from '@/ui/Spinner';
-import { getStackProps, Stack, stackPropTypes } from '@/ui/Stack';
+import { getStackProps, Stack } from '@/ui/Stack';
 import { Text } from '@/ui/Text';
 import { Breakpoints, getValueFromTheme } from '@/ui/theme';
 import { Title } from '@/ui/Title';
@@ -212,7 +212,6 @@ const AddAction = ({
 };
 
 AddAction.propTypes = {
-  ...inlinePropTypes,
   onAdd: PropTypes.func,
   onCancel: PropTypes.func,
   onToBeAddedEventIdInput: PropTypes.func,
@@ -314,7 +313,6 @@ const Events = ({
 };
 
 Events.propTypes = {
-  ...stackPropTypes,
   events: PropTypes.array,
   activeProductionName: PropTypes.string,
   loading: PropTypes.bool,

--- a/src/components/pages/manage/productions/index/Productions.js
+++ b/src/components/pages/manage/productions/index/Productions.js
@@ -6,7 +6,7 @@ import { List } from '@/ui/List';
 import { Pagination } from '@/ui/Pagination';
 import { Panel } from '@/ui/Panel';
 import { Spinner } from '@/ui/Spinner';
-import { getStackProps, Stack, stackPropTypes } from '@/ui/Stack';
+import { getStackProps, Stack } from '@/ui/Stack';
 import { getValueFromTheme } from '@/ui/theme';
 import { Title } from '@/ui/Title';
 
@@ -82,7 +82,6 @@ const Productions = ({
 };
 
 Productions.propTypes = {
-  ...stackPropTypes,
   productions: PropTypes.array,
   currentPage: PropTypes.number,
   totalItems: PropTypes.number,

--- a/src/ui/Alert.js
+++ b/src/ui/Alert.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Alert as BootstrapAlert } from 'react-bootstrap';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 import { getValueFromTheme } from './theme';
 
 const AlertVariants = {
@@ -45,7 +45,6 @@ const Alert = ({
 };
 
 Alert.propTypes = {
-  ...boxPropTypes,
   className: PropTypes.string,
   variant: PropTypes.oneOf(Object.values(AlertVariants)),
   visible: PropTypes.bool,

--- a/src/ui/Badge.js
+++ b/src/ui/Badge.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Badge as BootstrapBadge } from 'react-bootstrap';
 
-import { boxPropTypes, getBoxProps } from './Box';
+import { getBoxProps } from './Box';
 import { Text } from './Text';
 
 const BadgeVariants = {
@@ -25,7 +25,6 @@ const Badge = ({ children, className, variant, ...props }) => {
 };
 
 Badge.propTypes = {
-  ...boxPropTypes,
   className: PropTypes.string,
   children: PropTypes.node,
   variant: PropTypes.string,

--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -4,7 +4,7 @@ import { Button as BootstrapButton } from 'react-bootstrap';
 import { css } from 'styled-components';
 
 import { Icon } from './Icon';
-import { getInlineProps, Inline, inlinePropTypes } from './Inline';
+import { getInlineProps, Inline } from './Inline';
 import { Spinner, SpinnerSizes, SpinnerVariants } from './Spinner';
 import { Text } from './Text';
 import { getValueFromTheme } from './theme';
@@ -250,7 +250,6 @@ const Button = ({
 };
 
 Button.propTypes = {
-  ...inlinePropTypes,
   iconName: PropTypes.string,
   title: PropTypes.string,
   className: PropTypes.string,

--- a/src/ui/Card.js
+++ b/src/ui/Card.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Card as BootstrapCard } from 'react-bootstrap';
 
-import { getStackProps, Stack, stackPropTypes } from './Stack';
+import { getStackProps, Stack } from './Stack';
 
 const Card = ({ children, className, ...props }) => {
   return (
@@ -21,7 +21,6 @@ const Card = ({ children, className, ...props }) => {
 };
 
 Card.propTypes = {
-  ...stackPropTypes,
   className: PropTypes.string,
   children: PropTypes.node,
 };

--- a/src/ui/Checkbox.js
+++ b/src/ui/Checkbox.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 
 const Checkbox = ({
   id,
@@ -27,7 +27,6 @@ const Checkbox = ({
 );
 
 Checkbox.propTypes = {
-  ...boxPropTypes,
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
   name: PropTypes.string,

--- a/src/ui/CheckboxWithLabel.js
+++ b/src/ui/CheckboxWithLabel.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 import { Checkbox } from './Checkbox';
-import { getInlineProps, Inline, inlinePropTypes } from './Inline';
+import { getInlineProps, Inline } from './Inline';
 import { Label } from './Label';
 
 const CheckboxWithLabel = ({
@@ -37,7 +37,6 @@ const CheckboxWithLabel = ({
 };
 
 CheckboxWithLabel.propTypes = {
-  ...inlinePropTypes,
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
   name: PropTypes.string,

--- a/src/ui/DetailTable.js
+++ b/src/ui/DetailTable.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 import { Box, parseSpacing } from './Box';
 import { Inline } from './Inline';
-import { getStackProps, Stack, stackPropTypes } from './Stack';
+import { getStackProps, Stack } from './Stack';
 import { getValueFromTheme } from './theme';
 
 const getValue = getValueFromTheme('detailTable');
@@ -43,7 +43,6 @@ const DetailTable = ({ items, className, ...props }) => {
 };
 
 DetailTable.propTypes = {
-  ...stackPropTypes,
   items: PropTypes.arrayOf(
     PropTypes.shape({ header: PropTypes.string, value: PropTypes.string }),
   ),

--- a/src/ui/Icon.js
+++ b/src/ui/Icon.js
@@ -28,7 +28,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 
-import { Box, boxPropTypes, getBoxProps, parseDimension } from './Box';
+import { Box, getBoxProps, parseDimension } from './Box';
 
 const Icons = {
   HOME: 'home',
@@ -104,7 +104,6 @@ const Icon = ({ name, width, height, className, ...props }) => {
 };
 
 Icon.propTypes = {
-  ...boxPropTypes,
   name: PropTypes.string.isRequired,
   className: PropTypes.string,
 };

--- a/src/ui/Image.js
+++ b/src/ui/Image.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 
 const Image = ({ src, alt, className, ...props }) => (
   <Box
@@ -13,7 +13,6 @@ const Image = ({ src, alt, className, ...props }) => (
 );
 
 Image.propTypes = {
-  ...boxPropTypes,
   src: PropTypes.string,
   alt: PropTypes.string,
   className: PropTypes.string,

--- a/src/ui/Input.js
+++ b/src/ui/Input.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Form } from 'react-bootstrap';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 
 const BaseInput = (props) => <Box as="input" {...props} />;
 
@@ -37,7 +37,6 @@ const inputPropTypes = {
 };
 
 Input.propTypes = {
-  ...boxPropTypes,
   ...inputPropTypes,
 };
 

--- a/src/ui/InputWithLabel.js
+++ b/src/ui/InputWithLabel.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { getInlineProps, Inline, inlinePropTypes } from './Inline';
+import { getInlineProps, Inline } from './Inline';
 import { Input, inputPropTypes } from './Input';
 import { Label, LabelVariants } from './Label';
 
@@ -28,7 +28,6 @@ const InputWithLabel = ({
 );
 
 InputWithLabel.propTypes = {
-  ...inlinePropTypes,
   ...inputPropTypes,
   label: PropTypes.string,
 };

--- a/src/ui/Label.js
+++ b/src/ui/Label.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 
 export const LabelVariants = {
   BOLD: 'bold',
@@ -28,7 +28,6 @@ const Label = ({ htmlFor, children, className, variant, ...props }) => (
 );
 
 Label.propTypes = {
-  ...boxPropTypes,
   variant: PropTypes.string,
   htmlFor: PropTypes.string,
   className: PropTypes.string,

--- a/src/ui/Link.js
+++ b/src/ui/Link.js
@@ -5,7 +5,7 @@ import { cloneElement, forwardRef } from 'react';
 import { Button, ButtonVariants } from '@/ui/Button';
 
 import { Icon } from './Icon';
-import { getInlineProps, Inline, inlinePropTypes } from './Inline';
+import { getInlineProps, Inline } from './Inline';
 import { Text } from './Text';
 import { getValueFromTheme } from './theme';
 
@@ -148,7 +148,6 @@ const Link = ({
 };
 
 Link.propTypes = {
-  ...inlinePropTypes,
   href: PropTypes.string,
   title: PropTypes.string,
   iconName: PropTypes.string,

--- a/src/ui/List.js
+++ b/src/ui/List.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import { Children } from 'react';
 
-import { getInlineProps, Inline, inlinePropTypes } from './Inline';
-import { getStackProps, Stack, stackPropTypes } from './Stack';
+import { getInlineProps, Inline } from './Inline';
+import { getStackProps, Stack } from './Stack';
 
 const ListVariants = {
   ORDERED: 'ordered',
@@ -21,7 +21,6 @@ const List = ({ children, className, variant, ...props }) => (
 );
 
 List.propTypes = {
-  ...stackPropTypes,
   className: PropTypes.string,
   children: PropTypes.node,
 };
@@ -47,7 +46,6 @@ const ListItem = ({ children, className, onClick, ...props }) => {
 };
 
 ListItem.propTypes = {
-  ...inlinePropTypes,
   className: PropTypes.string,
   children: PropTypes.node,
   onClick: PropTypes.func,

--- a/src/ui/Logo.js
+++ b/src/ui/Logo.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 
 const LogoVariants = {
   DEFAULT: 'default',
@@ -70,7 +70,6 @@ Logo.defaultProps = {
 };
 
 Logo.propTypes = {
-  ...boxPropTypes,
   className: PropTypes.string,
   variant: PropTypes.string,
 };

--- a/src/ui/Pagination.js
+++ b/src/ui/Pagination.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { useMemo } from 'react';
 import { Pagination as BootstrapPagination } from 'react-bootstrap';
 
-import { getInlineProps, Inline, inlinePropTypes } from './Inline';
+import { getInlineProps, Inline } from './Inline';
 import { getValueFromTheme } from './theme';
 
 const getValue = getValueFromTheme(`pagination`);
@@ -135,7 +135,6 @@ const Pagination = ({
 };
 
 Pagination.propTypes = {
-  ...inlinePropTypes,
   className: PropTypes.string,
   currentPage: PropTypes.number.isRequired,
   totalItems: PropTypes.number.isRequired,

--- a/src/ui/Panel.js
+++ b/src/ui/Panel.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Children } from 'react';
 
-import { getStackProps, Stack, stackPropTypes } from './Stack';
+import { getStackProps, Stack } from './Stack';
 import { getValueFromTheme } from './theme';
 
 const getValue = getValueFromTheme('panel');
@@ -24,7 +24,6 @@ const Panel = ({ children, className, ...props }) => {
 };
 
 Panel.propTypes = {
-  ...stackPropTypes,
   className: PropTypes.string,
   children: PropTypes.node,
 };
@@ -53,7 +52,6 @@ const PanelFooter = ({ children, className, ...props }) => {
 };
 
 PanelFooter.propTypes = {
-  ...stackPropTypes,
   className: PropTypes.string,
   children: PropTypes.node,
 };

--- a/src/ui/RadioButton.js
+++ b/src/ui/RadioButton.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 
 const RadioButton = ({
   id,
@@ -40,7 +40,6 @@ const radioButtonPropTypes = {
 };
 
 RadioButton.propTypes = {
-  ...boxPropTypes,
   ...radioButtonPropTypes,
 };
 

--- a/src/ui/RadioButtonGroup.js
+++ b/src/ui/RadioButtonGroup.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 import { Label, LabelVariants } from './Label';
 import { RadioButtonWithLabel } from './RadioButtonWithLabel';
-import { getStackProps, Stack, stackPropTypes } from './Stack';
+import { getStackProps, Stack } from './Stack';
 
 const RadioButtonGroup = ({
   name,
@@ -35,7 +35,6 @@ const RadioButtonGroup = ({
 };
 
 RadioButtonGroup.propTypes = {
-  ...stackPropTypes,
   name: PropTypes.string.isRequired,
   groupLabel: PropTypes.string,
   items: PropTypes.array,

--- a/src/ui/RadioButtonWithLabel.js
+++ b/src/ui/RadioButtonWithLabel.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { getInlineProps, Inline, inlinePropTypes } from './Inline';
+import { getInlineProps, Inline } from './Inline';
 import { Label } from './Label';
 import {
   RadioButton,
@@ -54,7 +54,6 @@ const RadioButtonWithLabel = ({
 };
 
 RadioButtonWithLabel.propTypes = {
-  ...inlinePropTypes,
   ...radioButtonPropTypes,
   label: PropTypes.node,
   info: PropTypes.string,

--- a/src/ui/Small.js
+++ b/src/ui/Small.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 
 const Small = ({ children, className, ...props }) => (
   <Box
@@ -16,7 +16,6 @@ const Small = ({ children, className, ...props }) => (
 );
 
 Small.propTypes = {
-  ...boxPropTypes,
   className: PropTypes.string,
   children: PropTypes.node,
 };

--- a/src/ui/Spinner.js
+++ b/src/ui/Spinner.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Spinner as BootstrapSpinner } from 'react-bootstrap';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 import { getValueFromTheme } from './theme';
 
 const SpinnerVariants = {
@@ -43,7 +43,6 @@ const Spinner = ({ variant, size, className, ...props }) => {
 };
 
 Spinner.propTypes = {
-  ...boxPropTypes,
   variant: PropTypes.oneOf(Object.values(SpinnerVariants)),
   size: PropTypes.oneOf(Object.values(SpinnerSizes)),
   className: PropTypes.string,

--- a/src/ui/Text.js
+++ b/src/ui/Text.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 import { getValueFromTheme } from './theme';
 
 const getValue = getValueFromTheme('text');
@@ -24,7 +24,6 @@ const Text = ({ as, children, className, variant, ...props }) => {
 };
 
 Text.propTypes = {
-  ...boxPropTypes,
   as: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,

--- a/src/ui/TextArea.js
+++ b/src/ui/TextArea.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Form } from 'react-bootstrap';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 
 const BaseInput = (props) => <Box as="textarea" {...props} />;
 
@@ -32,7 +32,6 @@ const TextArea = ({
 };
 
 TextArea.propTypes = {
-  ...boxPropTypes,
   id: PropTypes.string,
   className: PropTypes.string,
   value: PropTypes.string,

--- a/src/ui/TextAreaWithLabel.js
+++ b/src/ui/TextAreaWithLabel.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 import { Label, LabelVariants } from './Label';
-import { getStackProps, Stack, stackPropTypes } from './Stack';
+import { getStackProps, Stack } from './Stack';
 import { TextArea } from './TextArea';
 
 const TextAreaWithLabel = ({
@@ -24,7 +24,6 @@ const TextAreaWithLabel = ({
 };
 
 TextAreaWithLabel.propTypes = {
-  ...stackPropTypes,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   className: PropTypes.string,

--- a/src/ui/Typeahead.js
+++ b/src/ui/Typeahead.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { forwardRef } from 'react';
 import { AsyncTypeahead as BootstrapTypeahead } from 'react-bootstrap-typeahead';
 
-import { Box, boxPropTypes, getBoxProps } from './Box';
+import { Box, getBoxProps } from './Box';
 import { getValueFromTheme } from './theme';
 
 const getValue = getValueFromTheme('typeahead');
@@ -78,7 +78,6 @@ const typeaheadPropTypes = {
 };
 
 Typeahead.propTypes = {
-  ...boxPropTypes,
   ...typeaheadPropTypes,
 };
 

--- a/src/ui/TypeaheadWithLabel.js
+++ b/src/ui/TypeaheadWithLabel.js
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 
 import { Label, LabelVariants } from './Label';
-import { getStackProps, Stack, stackPropTypes } from './Stack';
+import { getStackProps, Stack } from './Stack';
 import {
   Typeahead,
   typeaheadDefaultProps,
@@ -52,7 +52,6 @@ const TypeaheadWithLabel = forwardRef(
 );
 
 TypeaheadWithLabel.propTypes = {
-  ...stackPropTypes,
   ...typeaheadPropTypes,
 };
 


### PR DESCRIPTION
### Fixed

- boxPropTypes, stackPropTypes and inlinePropTypes aren't objects with proptypes anymore but an array of strings

```
Warning: Failed prop type: Checkbox: prop type `35` is invalid; it must be a function, usually from the `prop-types` package, but received `string`.This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.
```

