### PR TITLE
Use Promise.all

### DIFF
--- a/src/components/pages/dashboard.tsx
+++ b/src/components/pages/dashboard.tsx
@@ -471,7 +471,8 @@ const getServerSideProps = getApplicationServerSideProps(
       };
     }
 
-    await Promise.allSettled(
+    await Promise.all(
+      // @ts-expect-error
       Object.entries(UseGetItemsByCreatorMap).map(([key, hook]) => {
         const page =
           query.tab === key ? (query.page ? parseInt(query.page) : 1) : 1;

--- a/src/utils/fetchFromApi.ts
+++ b/src/utils/fetchFromApi.ts
@@ -32,9 +32,6 @@ const fetchFromApi = async ({
 }): Promise<ErrorObject | Response> => {
   const { publicRuntimeConfig } = getConfig();
 
-  // eslint-disable-next-line no-console
-  console.log({ publicRuntimeConfig });
-
   let response: Response;
   let url: URL;
 


### PR DESCRIPTION
### Fixed

- Use Promise.all instead of Promise.allSettled

We're currently using node 10 in the vragant box, Promise.allSettled is only supported in Node 12.19 and upwards

---

Ticket: https://jira.uitdatabank.be/browse/...
