### PR TITLE
Add footer to dashboard page

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -39,20 +39,19 @@ const FooterLink = (props) => (
 type Props = {
   wrapper?: ElementType;
   onChangeLanguage?: (language: string) => () => Promise<boolean>;
-  isLogoVisible?: boolean;
   isLanguageSwitcherVisible?: boolean;
 };
 
 const Footer = ({
   wrapper: Wrapper,
   onChangeLanguage,
-  isLogoVisible,
   isLanguageSwitcherVisible,
+  ...props
 }: Props) => {
   const { t, i18n } = useTranslation();
 
   return (
-    <Wrapper>
+    <Wrapper {...props}>
       <Stack alignItems="flex-start">
         <List alignItems={{ xs: 'center' }}>
           <List.Item>
@@ -96,14 +95,12 @@ const Footer = ({
           <Box as="span">{t('footer.by')}</Box>
           <FooterLink href="http://www.publiq.be">publiq vzw</FooterLink>
         </Inline>
-        {isLogoVisible && (
-          <Image
-            alt="logo vlaanderen"
-            src={`/assets/${t('main.flanders_image')}`}
-            width={150}
-          />
-        )}
-        {isLanguageSwitcherVisible && (
+        <Image
+          alt="logo vlaanderen"
+          src={`/assets/${t('main.flanders_image')}`}
+          width={150}
+        />
+        {isLanguageSwitcherVisible && onChangeLanguage && (
           <Inline>
             <LanguageSwitcherButton onClick={onChangeLanguage('nl')}>
               Nederlands

--- a/src/components/pages/dashboard/NewsletterSingupForm.tsx
+++ b/src/components/pages/dashboard/NewsletterSingupForm.tsx
@@ -20,7 +20,7 @@ import { Title } from '@/ui/Title';
 const isEmail = (value: string) =>
   yup.string().required().email().isValidSync(value);
 
-const NewsletterSignupForm = () => {
+const NewsletterSignupForm = (props) => {
   const formRef = useRef<HTMLFormElement>();
   const [email, setEmail] = useState('');
   const [isValid, setIsValid] = useState(true);
@@ -42,7 +42,7 @@ const NewsletterSignupForm = () => {
   };
 
   return (
-    <Stack spacing={4}>
+    <Stack spacing={4} {...props}>
       <Text>
         {t('dashboard.newsletter.questions_or_feedback')}{' '}
         <Link href="#">{t('dashboard.newsletter.contact')}</Link>

--- a/src/components/pages/dashboard/index.tsx
+++ b/src/components/pages/dashboard/index.tsx
@@ -8,6 +8,7 @@ import { useQueryClient } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
 import { css } from 'styled-components';
 
+import { Footer } from '@/components/Footer';
 import { QueryStatus } from '@/hooks/api/authenticated-query';
 import { useDeleteEventById, useGetEventsByCreator } from '@/hooks/api/events';
 import {
@@ -457,6 +458,7 @@ const Dashboard = (): any => {
           </Tabs>
         </Stack>
         <NewsletterSignupForm />
+        <Footer isLanguageSwitcherVisible={false} />
       </Page.Content>
     </Page>,
     <Modal

--- a/src/components/pages/login/Footer.tsx
+++ b/src/components/pages/login/Footer.tsx
@@ -1,0 +1,132 @@
+import type { ElementType } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Box } from '@/ui/Box';
+import { Button, ButtonVariants } from '@/ui/Button';
+import { Image } from '@/ui/Image';
+import { Inline } from '@/ui/Inline';
+import { Link } from '@/ui/Link';
+import { List } from '@/ui/List';
+import { Stack } from '@/ui/Stack';
+
+const LanguageSwitcherButton = (props) => (
+  <Button
+    {...props}
+    variant={ButtonVariants.UNSTYLED}
+    css={`
+      text-decoration: underline;
+      color: #004f94;
+      &:hover {
+        color: #222;
+      }
+    `}
+  />
+);
+
+const FooterLink = (props) => (
+  <Link
+    {...props}
+    css={`
+      text-decoration: underline;
+      color: #555;
+      &:hover {
+        color: #222;
+      }
+    `}
+  />
+);
+
+type Props = {
+  wrapper?: ElementType;
+  onChangeLanguage?: (language: string) => () => Promise<boolean>;
+  isLogoVisible?: boolean;
+  isLanguageSwitcherVisible?: boolean;
+};
+
+const Footer = ({
+  wrapper: Wrapper,
+  onChangeLanguage,
+  isLogoVisible,
+  isLanguageSwitcherVisible,
+}: Props) => {
+  const { t, i18n } = useTranslation();
+
+  return (
+    <Wrapper>
+      <Stack alignItems="flex-start">
+        <List alignItems={{ xs: 'center' }}>
+          <List.Item>
+            <FooterLink href="mailto:vragen@uitdatabank.be">
+              {t('footer.contact')}
+            </FooterLink>
+          </List.Item>
+          <List.Item>
+            <FooterLink href="http://www.publiq.be/nl/project/uitdatabank">
+              {t('footer.about')}
+            </FooterLink>
+          </List.Item>
+          <List.Item>
+            <FooterLink href="http://documentatie.uitdatabank.be">
+              {t('footer.dev')}
+            </FooterLink>
+          </List.Item>
+          <List.Item>
+            <Inline spacing={3}>
+              <FooterLink
+                href={`http://www.publiq.be/${i18n.language}/${t(
+                  'footer.legal_path',
+                )}`}
+              >
+                {t('footer.legal')}
+              </FooterLink>
+              <FooterLink href="http://www.publiq.be/nl/privacy-uitdatabank">
+                {t('footer.privacy')}
+              </FooterLink>
+            </Inline>
+          </List.Item>
+        </List>
+      </Stack>
+
+      <Stack
+        spacing={3}
+        alignItems={{ default: 'flex-end', xs: 'center' }}
+        justifyContent="flex-start"
+      >
+        <Inline as="p" spacing={2} className="footer-by">
+          <Box as="span">{t('footer.by')}</Box>
+          <FooterLink href="http://www.publiq.be">publiq vzw</FooterLink>
+        </Inline>
+        {isLogoVisible && (
+          <Image
+            alt="logo vlaanderen"
+            src={`/assets/${t('main.flanders_image')}`}
+            width={150}
+          />
+        )}
+        {isLanguageSwitcherVisible && (
+          <Inline>
+            <LanguageSwitcherButton onClick={onChangeLanguage('nl')}>
+              Nederlands
+            </LanguageSwitcherButton>
+            <LanguageSwitcherButton
+              variant={ButtonVariants.UNSTYLED}
+              onClick={onChangeLanguage('fr')}
+            >
+              Français
+            </LanguageSwitcherButton>
+          </Inline>
+        )}
+      </Stack>
+    </Wrapper>
+  );
+};
+
+Footer.defaultProps = {
+  isLogoVisible: true,
+  isLanguageSwitcherVisible: true,
+  wrapper: (props) => (
+    <Inline width="100%" justifyContent="space-between" {...props} />
+  ),
+};
+
+export { Footer };

--- a/src/components/pages/login/[language].tsx
+++ b/src/components/pages/login/[language].tsx
@@ -7,13 +7,13 @@ import { css, keyframes } from 'styled-components';
 
 import { useCookiesWithOptions } from '@/hooks/useCookiesWithOptions';
 import { Box } from '@/ui/Box';
-import { Button, ButtonSizes, ButtonVariants } from '@/ui/Button';
-import { Image } from '@/ui/Image';
+import { Button, ButtonSizes } from '@/ui/Button';
 import { Inline } from '@/ui/Inline';
 import { Link } from '@/ui/Link';
-import { List } from '@/ui/List';
 import { Stack } from '@/ui/Stack';
 import { Breakpoints, getValueFromTheme } from '@/ui/theme';
+
+import { Footer } from './Footer';
 
 const getValueForPage = getValueFromTheme('loginPage');
 const getValueForLogo = getValueFromTheme('loginLogo');
@@ -28,9 +28,7 @@ const Svg = (props) => (
 );
 
 const Group = (props) => <Box as="g" fill="white" {...props} />;
-Group.propTypes = {};
 const Path = (props) => <Box as="path" {...props} />;
-Path.propTypes = {};
 
 const Animation = (props) => {
   const draw = keyframes`
@@ -325,8 +323,8 @@ const useRedirectToLanguage = () => {
   useEffect(() => {
     if (!language) return;
 
-    if (['nl', 'fr'].includes(language)) {
-      i18n.changeLanguage(language);
+    if (['nl', 'fr'].includes(language as string)) {
+      i18n.changeLanguage(language as string);
       setCookie('udb-language', language);
     } else {
       router.push('/login/nl');
@@ -343,39 +341,22 @@ const ResponsiveContainer = (props) => (
   />
 );
 
-const FooterLink = (props) => (
-  <Link
-    {...props}
-    css={`
+const MainChannelLink = () => {
+  const { t } = useTranslation();
+  return (
+    <Link
+      css={`
+      display: inline
       text-decoration: underline;
       color: #555;
       &:hover {
         color: #222;
       }
     `}
-  />
-);
-
-const LanguageSwitcherButton = (props) => (
-  <Button
-    {...props}
-    variant={ButtonVariants.UNSTYLED}
-    css={`
-      text-decoration: underline;
-      color: #004f94;
-      &:hover {
-        color: #222;
-      }
-    `}
-  />
-);
-
-const MainChannelLink = () => {
-  const { t } = useTranslation();
-  return (
-    <FooterLink href={t('main.channels_info_link_url')} css="display: inline">
+      href={t('main.channels_info_link_url')}
+    >
       {t('main.channels_info_link_text')}
-    </FooterLink>
+    </Link>
   );
 };
 
@@ -385,13 +366,14 @@ const Index = () => {
   const { removeAuthenticationCookies } = useCookiesWithOptions();
   const { publicRuntimeConfig } = getConfig();
 
-  const changeLanguage = (language) => () => router.push(`/login/${language}`);
+  const handleChangeLanguage = (language: string) => async () =>
+    router.push(`/login/${language}`, undefined, { shallow: true });
 
   const handleClickLogin = () => {
     removeAuthenticationCookies();
 
     const destination = new URL(
-      router.query?.referer ||
+      (router.query?.referer as string) ||
         `${window.location.protocol}//${window.location.host}`,
     );
     destination.searchParams.delete('jwt');
@@ -490,73 +472,21 @@ const Index = () => {
       </Stack>
 
       <Inline width="100%" backgroundColor="#ccc" justifyContent="center">
-        <ResponsiveContainer
-          justifyContent={{ default: 'space-between', xs: 'flex-start' }}
-          alignItems={{ xs: 'center' }}
-          stackOn={Breakpoints.XS}
-          spacing={5}
-          paddingY={5}
-        >
-          <Stack alignItems="flex-start">
-            <List alignItems={{ xs: 'center' }}>
-              <List.Item>
-                <FooterLink href="mailto:vragen@uitdatabank.be">
-                  {t('footer.contact')}
-                </FooterLink>
-              </List.Item>
-              <List.Item>
-                <FooterLink href="http://www.publiq.be/nl/project/uitdatabank">
-                  {t('footer.about')}
-                </FooterLink>
-              </List.Item>
-              <List.Item>
-                <FooterLink href="http://documentatie.uitdatabank.be">
-                  {t('footer.dev')}
-                </FooterLink>
-              </List.Item>
-              <List.Item>
-                <Inline spacing={3}>
-                  <FooterLink
-                    href={
-                      'http://www.publiq.be/' +
-                      i18n.language +
-                      '/' +
-                      t('footer.legal_path')
-                    }
-                  >
-                    {t('footer.legal')}
-                  </FooterLink>
-                  <FooterLink href="http://www.publiq.be/nl/privacy-uitdatabank">
-                    {t('footer.privacy')}
-                  </FooterLink>
-                </Inline>
-              </List.Item>
-            </List>
-          </Stack>
-
-          <Stack
-            spacing={3}
-            alignItems={{ default: 'flex-end', xs: 'center' }}
-            justifyContent="flex-start"
-          >
-            <Inline as="p" spacing={2} className="footer-by">
-              <Box as="span">{t('footer.by')}</Box>
-              <FooterLink href="http://www.publiq.be">publiq vzw</FooterLink>
-            </Inline>
-            <Image src={`/assets/${t('main.flanders_image')}`} width={150} />
-            <Inline>
-              <LanguageSwitcherButton onClick={changeLanguage('nl')}>
-                Nederlands
-              </LanguageSwitcherButton>
-              <LanguageSwitcherButton
-                variant={ButtonVariants.UNSTYLED}
-                onClick={changeLanguage('fr')}
-              >
-                Français
-              </LanguageSwitcherButton>
-            </Inline>
-          </Stack>
-        </ResponsiveContainer>
+        <Footer
+          isLogoVisible={false}
+          isLanguageSwitcherVisible={false}
+          onChangeLanguage={handleChangeLanguage}
+          wrapper={(props) => (
+            <ResponsiveContainer
+              justifyContent={{ default: 'space-between', xs: 'flex-start' }}
+              alignItems={{ xs: 'center' }}
+              stackOn={Breakpoints.XS}
+              spacing={5}
+              paddingY={5}
+              {...props}
+            />
+          )}
+        />
       </Inline>
     </Stack>
   );

--- a/src/components/pages/login/[language].tsx
+++ b/src/components/pages/login/[language].tsx
@@ -473,8 +473,6 @@ const Index = () => {
 
       <Inline width="100%" backgroundColor="#ccc" justifyContent="center">
         <Footer
-          isLogoVisible={false}
-          isLanguageSwitcherVisible={false}
           onChangeLanguage={handleChangeLanguage}
           wrapper={(props) => (
             <ResponsiveContainer

--- a/src/components/pages/login/[language].tsx
+++ b/src/components/pages/login/[language].tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { css, keyframes } from 'styled-components';
 
+import { Footer } from '@/components/Footer';
 import { useCookiesWithOptions } from '@/hooks/useCookiesWithOptions';
 import { Box } from '@/ui/Box';
 import { Button, ButtonSizes } from '@/ui/Button';
@@ -12,8 +13,6 @@ import { Inline } from '@/ui/Inline';
 import { Link } from '@/ui/Link';
 import { Stack } from '@/ui/Stack';
 import { Breakpoints, getValueFromTheme } from '@/ui/theme';
-
-import { Footer } from './Footer';
 
 const getValueForPage = getValueFromTheme('loginPage');
 const getValueForLogo = getValueFromTheme('loginLogo');


### PR DESCRIPTION
### Added

- Extracted Footer from login page and reused it on the dashboard page
- added a boolean to disable the language switcher on the dashboard page


<img width="862" alt="Screenshot 2021-06-24 at 10 52 56" src="https://user-images.githubusercontent.com/89046/123233974-d23b6900-d4da-11eb-8372-31e777adf000.png">
