### PR TITLE
III-3789 - fix bootstrap styles serverside

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,6 @@
 <link
   key="fonts"
-  href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,300,400,700&display=optional"
+  href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700&display=optional"
   rel="stylesheet"
 />
 <link

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,12 @@
+<link
+  key="fonts"
+  href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,300,400,700&display=optional"
+  rel="stylesheet"
+/>
+<link
+  key="bootstrap"
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css"
+  integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l"
+  crossorigin="anonymous"
+/>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,3 @@
-import '@/styles/global.scss';
-
 import { I18nextProvider } from 'react-i18next';
 import i18n from '@/i18n/index';
 

--- a/src/components/pages/_app.js
+++ b/src/components/pages/_app.js
@@ -77,13 +77,6 @@ const Head = () => {
         name="viewport"
         content="initial-scale=1.0, width=device-width"
       />
-      <link
-        key="icon"
-        rel="icon"
-        type="image/png"
-        sizes="32x32"
-        href="/favicon.png"
-      />
       <title key="title">UiTdatabank</title>
       <meta name="description" content={t('description')} />
     </NextHead>

--- a/src/components/pages/_document.js
+++ b/src/components/pages/_document.js
@@ -42,7 +42,7 @@ class Document extends NextDocument {
           {/* eslint-disable-next-line @next/next/no-page-custom-font */}
           <link
             key="fonts"
-            href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,300,400,700&display=optional"
+            href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700&display=optional"
             rel="stylesheet"
           />
           <link

--- a/src/components/pages/_document.js
+++ b/src/components/pages/_document.js
@@ -1,4 +1,4 @@
-import NextDocument from 'next/document';
+import NextDocument, { Head, Html, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 
 class Document extends NextDocument {
@@ -26,6 +26,39 @@ class Document extends NextDocument {
     } finally {
       sheet.seal();
     }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link
+            key="icon"
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="/favicon.png"
+          />
+          {/* eslint-disable-next-line @next/next/no-page-custom-font */}
+          <link
+            key="fonts"
+            href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,300,400,700&display=optional"
+            rel="stylesheet"
+          />
+          <link
+            key="bootstrap"
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css"
+            integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l"
+            crossOrigin="anonymous"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
   }
 }
 

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,4 +1,1 @@
-// we can only import global css from _app in /pages
-import '@/styles/global.scss';
-
 export { default } from '@/pages/_app';

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,2 +1,0 @@
-@import '../../node_modules/bootstrap/scss/bootstrap.scss';
-@import url('//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,300,400,700');


### PR DESCRIPTION
### Fixed

- Server Side render not including all styles (bootstrap)

We're now also making use of https://nextjs.org/docs/basic-features/font-optimization

---

Ticket: https://jira.uitdatabank.be/browse/III-3789

Screenshot BEFORE:
![Schermafbeelding 2021-06-29 om 16 21 03](https://user-images.githubusercontent.com/66943525/123815276-a531f080-d8f6-11eb-8e15-3020b0cfb2aa.png)

Screenshot AFTER:
![Schermafbeelding 2021-06-29 om 16 24 50](https://user-images.githubusercontent.com/66943525/123815312-ac58fe80-d8f6-11eb-9502-c201f918e22b.png)

