### PR TITLE
III-4090 - calendar summary

### DIFF
--- a/src/components/pages/dashboard/index.tsx
+++ b/src/components/pages/dashboard/index.tsx
@@ -200,7 +200,10 @@ const PlaceRow = ({ item: place, onDelete, ...props }: PlaceRowProps) => {
   // The custom keySeparator was necessary because the ids contain '.' which i18n uses as default keySeparator
   const placeType = t(`offerTypes*${typeId}`, { keySeparator: '*' });
 
-  const period = place.calendarSummary[i18n.language]?.text?.md;
+  const period =
+    place.calendarSummary[i18n.language]?.text?.[
+      place.calendarType === 'single' ? 'lg' : 'md'
+    ];
 
   return (
     <Row

--- a/src/components/pages/dashboard/index.tsx
+++ b/src/components/pages/dashboard/index.tsx
@@ -143,7 +143,10 @@ const EventRow = ({ item: event, onDelete, ...props }: EventRowProps) => {
   // The custom keySeparator was necessary because the ids contain '.' which i18n uses as default keySeparator
   const eventType = t(`offerTypes*${typeId}`, { keySeparator: '*' });
 
-  const period = event.calendarSummary[i18n.language]?.text?.md;
+  const period =
+    event.calendarSummary[i18n.language]?.text?.[
+      event.calendarType === 'single' ? 'lg' : 'md'
+    ];
 
   return (
     <Row

--- a/src/hooks/api/authenticated-query.ts
+++ b/src/hooks/api/authenticated-query.ts
@@ -7,6 +7,7 @@ import type { QueryClient, UseQueryResult } from 'react-query';
 import { useMutation, useQueries, useQuery } from 'react-query';
 
 import { useCookiesWithOptions } from '@/hooks/useCookiesWithOptions';
+import type { CalendarSummaryFormat } from '@/utils/createEmbededCalendarSummaries';
 import type { FetchError } from '@/utils/fetchFromApi';
 import { isTokenValid } from '@/utils/isTokenValid';
 
@@ -31,6 +32,10 @@ type SortOptions = {
     field: string;
     order: string;
   };
+};
+
+type CalendarSummaryFormats = {
+  calendarSummaryFormats?: CalendarSummaryFormat[];
 };
 
 const QueryStatus = {
@@ -303,6 +308,7 @@ export {
 
 export type {
   AuthenticatedQueryOptions,
+  CalendarSummaryFormats,
   PaginationOptions,
   ServerSideQueryOptions,
   SortOptions,

--- a/src/hooks/api/events.ts
+++ b/src/hooks/api/events.ts
@@ -2,12 +2,14 @@ import type { UseQueryOptions } from 'react-query';
 
 import type { Event } from '@/types/Event';
 import type { User } from '@/types/User';
+import { createEmbededCalendarSummaries } from '@/utils/createEmbededCalendarSummaries';
 import { createSortingArgument } from '@/utils/createSortingArgument';
 import { fetchFromApi, isErrorObject } from '@/utils/fetchFromApi';
 import { formatDate } from '@/utils/formatDate';
 
 import type {
   AuthenticatedQueryOptions,
+  CalendarSummaryFormats,
   PaginationOptions,
   SortOptions,
 } from './authenticated-query';
@@ -123,9 +125,11 @@ const useGetEventsByCreator = (
     creator,
     paginationOptions = { start: 0, limit: 50 },
     sortOptions = { field: 'modified', order: 'desc' },
+    calendarSummaryFormats = ['lg-text', 'md-text'],
   }: AuthenticatedQueryOptions<
     PaginationOptions &
-      SortOptions & {
+      SortOptions &
+      CalendarSummaryFormats & {
         creator: User;
       }
   >,
@@ -144,7 +148,7 @@ const useGetEventsByCreator = (
       start: paginationOptions.start,
       workflowStatus: 'DRAFT,READY_FOR_VALIDATION,APPROVED,REJECTED',
       ...createSortingArgument(sortOptions),
-      embedCalendarSummaries: 'md-text',
+      ...createEmbededCalendarSummaries(calendarSummaryFormats),
     },
     enabled: !!(creator.id && creator.email),
     ...configuration,

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -5,11 +5,13 @@ import type { SupportedLanguage } from '@/i18n/index';
 import type { Place } from '@/types/Place';
 import type { User } from '@/types/User';
 import type { Values } from '@/types/Values';
+import { createEmbededCalendarSummaries } from '@/utils/createEmbededCalendarSummaries';
 import { createSortingArgument } from '@/utils/createSortingArgument';
 import { fetchFromApi, isErrorObject } from '@/utils/fetchFromApi';
 
 import type {
   AuthenticatedQueryOptions,
+  CalendarSummaryFormats,
   PaginationOptions,
   SortOptions,
 } from './authenticated-query';
@@ -71,9 +73,11 @@ const useGetPlacesByCreator = (
     creator,
     paginationOptions = { start: 0, limit: 50 },
     sortOptions = { field: 'modified', order: 'desc' },
+    calendarSummaryFormats = ['lg-text', 'md-text'],
   }: AuthenticatedQueryOptions<
     PaginationOptions &
-      SortOptions & {
+      SortOptions &
+      CalendarSummaryFormats & {
         creator: User;
       }
   >,
@@ -92,7 +96,7 @@ const useGetPlacesByCreator = (
       start: paginationOptions.start,
       workflowStatus: 'DRAFT,READY_FOR_VALIDATION,APPROVED,REJECTED',
       ...createSortingArgument(sortOptions),
-      embedCalendarSummaries: 'md-text',
+      ...createEmbededCalendarSummaries(calendarSummaryFormats),
     },
     enabled: !!(creator.id && creator.email),
     ...configuration,

--- a/src/utils/createEmbededCalendarSummaries.ts
+++ b/src/utils/createEmbededCalendarSummaries.ts
@@ -1,5 +1,5 @@
 type TextFormat = 'xs-text' | 'sm-text' | 'md-text' | 'lg-text';
-type HtmlFormat = 'xs-hmtl' | 'sm-html' | 'md-html' | 'lg-html';
+type HtmlFormat = 'xs-html' | 'sm-html' | 'md-html' | 'lg-html';
 type Format = TextFormat | HtmlFormat;
 
 type CalendarSummaries = {

--- a/src/utils/createEmbededCalendarSummaries.ts
+++ b/src/utils/createEmbededCalendarSummaries.ts
@@ -8,9 +8,9 @@ type CalendarSummaries = {
 
 const createEmbededCalendarSummaries = (formats: Format[]): CalendarSummaries =>
   formats.reduce(
-    (accumulator, currentValue, currentIndex) => ({
+    (accumulator, currentFormat, currentIndex) => ({
       ...accumulator,
-      [`embedCalendarSummaries[${currentIndex}]`]: currentValue,
+      [`embedCalendarSummaries[${currentIndex}]`]: currentFormat,
     }),
     {},
   );

--- a/src/utils/createEmbededCalendarSummaries.ts
+++ b/src/utils/createEmbededCalendarSummaries.ts
@@ -1,0 +1,19 @@
+type TextFormat = 'xs-text' | 'sm-text' | 'md-text' | 'lg-text';
+type HtmlFormat = 'xs-hmtl' | 'sm-html' | 'md-html' | 'lg-html';
+type Format = TextFormat | HtmlFormat;
+
+type CalendarSummaries = {
+  [key: string]: Format;
+};
+
+const createEmbededCalendarSummaries = (formats: Format[]): CalendarSummaries =>
+  formats.reduce(
+    (accumulator, currentValue, currentIndex) => ({
+      ...accumulator,
+      [`embedCalendarSummaries[${currentIndex}]`]: currentValue,
+    }),
+    {},
+  );
+
+export { createEmbededCalendarSummaries };
+export type { Format as CalendarSummaryFormat };

--- a/src/utils/createSortingArgument.ts
+++ b/src/utils/createSortingArgument.ts
@@ -1,4 +1,7 @@
-const createSortingArgument = (sortOptions): { [field: string]: string } => {
+const createSortingArgument = (sortOptions: {
+  field: string;
+  order: string;
+}) => {
   return { [`sort[${sortOptions.field}]`]: `${sortOptions.order}` };
 };
 


### PR DESCRIPTION
### Added

- option for calendarSummaryFormats in api calls
- conditional to show lg-text when calendarType is single

### Changed

- fetch md-text and lg-text for getByCreator


---

Ticket: https://jira.uitdatabank.be/browse/III-4090
