### PR TITLE
III-4181 Only show download button when export job finished

### DIFF
--- a/src/components/layouts/joblogger/Job.tsx
+++ b/src/components/layouts/joblogger/Job.tsx
@@ -118,7 +118,7 @@ const Job = ({
             <Icon name={Icons.TIMES} alignItems="center" />
           </Button>
         </Inline>
-        {!!exportUrl && (
+        {!!exportUrl && state === JobStates.FINISHED && (
           <Link href={exportUrl} variant={LinkVariants.BUTTON_SECONDARY}>
             {t('jobs.download')}
           </Link>


### PR DESCRIPTION
### Fixed
- Only show download button when export job finished

Note: I was not able to reproduce this but added an extra check to verify if the job finished before showing the download button

---

Ticket: https://jira.uitdatabank.be/browse/III-4181
