### PR TITLE
Pass id prop correctly to typeahead

### DIFF
--- a/src/ui/Box.tsx
+++ b/src/ui/Box.tsx
@@ -5,6 +5,7 @@ import type {
   ClipboardEvent,
   ComponentType,
   FormEvent,
+  HTMLProps,
   MouseEvent,
   ReactNode,
 } from 'react';
@@ -102,6 +103,7 @@ type TypeaheadProps = {
     | boolean
     | ((results: Array<Object | string>, props: Object) => boolean);
   newSelectionPrefix: string;
+  inputProps: HTMLProps<HTMLInputElement>;
 };
 
 type SpecificComponentProps = InlineProps &

--- a/src/ui/Typeahead.tsx
+++ b/src/ui/Typeahead.tsx
@@ -9,6 +9,7 @@ import { getValueFromTheme } from './theme';
 const getValue = getValueFromTheme('typeahead');
 
 type TypeaheadProps<T> = {
+  id: string;
   options: T[];
   labelKey: ((option: T) => string) | string;
   disabled?: boolean;
@@ -23,7 +24,7 @@ type TypeaheadProps<T> = {
   selected: T[];
 };
 
-type Props<T> = Omit<BoxProps, 'onChange'> &
+type Props<T> = Omit<BoxProps, 'onChange' | 'id'> &
   TypeaheadProps<T> & { isInvalid?: boolean };
 
 type TypeaheadFunc = (<T>(
@@ -96,9 +97,12 @@ const Typeahead: TypeaheadFunc = forwardRef(
         minLength={minLength}
         delay={275}
         highlightOnlyResult={!allowNew}
-        ref={ref}
         isInvalid={isInvalid}
         selected={selected}
+        inputProps={{
+          id,
+          ref,
+        }}
         {...getBoxProps(props)}
       />
     );


### PR DESCRIPTION
Context: Labels weren't properly linked to the typeaheads because the id wasn't passed the propper way.

https://github.com/ericgio/react-bootstrap-typeahead/issues/563#issuecomment-650303061

### Fixed

- id being passed incorrectly
