### PR TITLE
III-4409 - Prevent /search to be refreshed when url params are added

### DIFF
--- a/src/components/layouts/index.js
+++ b/src/components/layouts/index.js
@@ -99,7 +99,9 @@ const Layout = ({ children }) => {
           `${window.location.protocol}//${window.location.host}${path}`,
         );
       } else {
-        router.push({ pathname: url.pathname, query });
+        if (url.pathname !== '/search') {
+          router.push({ pathname: url.pathname, query });
+        }
       }
     },
     [WindowMessageTypes.HTTP_ERROR_CODE]: ({ code }) => {


### PR DESCRIPTION
### Fixed
-  Prevent /search to be refreshed when url params are added (temporary fix until `/search` is ported to react

---
Ticket: https://jira.uitdatabank.be/browse/III-4409
