### PR TITLE
III-4615 - Add ready with edit button on footer of film edit form

### DIFF
--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -270,6 +270,7 @@
         }
       },
       "footer": {
+        "done_editing": "Klaar met bewerken",
         "auto_save": "Je wijzigingen worden vanaf nu automatisch opgeslagen"
       }
     }

--- a/src/pages/manage/movies/MoviePage.tsx
+++ b/src/pages/manage/movies/MoviePage.tsx
@@ -35,6 +35,7 @@ import type { Production } from '@/types/Production';
 import { WorkflowStatusMap } from '@/types/WorkflowStatus';
 import { Button, ButtonVariants } from '@/ui/Button';
 import { Inline } from '@/ui/Inline';
+import { Link, LinkVariants } from '@/ui/Link';
 import { Page } from '@/ui/Page';
 import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
@@ -558,9 +559,17 @@ const MoviePage = () => {
                 {t('movies.create.actions.save')}
               </Button>
             ) : (
-              <Text color={getValue('footer.color')} fontSize="0.9rem">
-                {t('movies.create.footer.auto_save')}
-              </Text>
+              <Inline spacing={3} alignItems="center">
+                <Link
+                  href={`/event/${newEventId}/preview`}
+                  variant={LinkVariants.BUTTON_SUCCESS}
+                >
+                  <Text>{t('movies.create.footer.done_editing')}</Text>
+                </Link>
+                <Text color={getValue('footer.color')} fontSize="0.9rem">
+                  {t('movies.create.footer.auto_save')}
+                </Text>
+              </Inline>
             )}
           </Inline>
           <PublishLaterModal


### PR DESCRIPTION
### Added
- ready with edit button on footer of film edit form

<img width="1414" alt="Screenshot 2022-02-25 at 11 17 49" src="https://user-images.githubusercontent.com/9402377/155698698-60060ec3-e82f-40e2-a42d-0a4ccd931c86.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-4615
