### PR TITLE
Move hooks to own files / steps

### DIFF
--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -177,20 +177,10 @@ const MovieForm = () => {
   const handleChangeSuccess = (editedField: string) =>
     toast.trigger(editedField);
 
-  const editMap = useMemo(() => {
-    return {
-      eventTypeAndTheme: useEditTheme,
-      timeTable: useEditCalendar,
-      place: useEditLocation,
-      production: useEditNameAndProduction,
-    };
-  }, []);
-
   const { handleChange, fieldLoading } = useEditField({
     eventId,
     handleSubmit,
     onSuccess: handleChangeSuccess,
-    editMap,
   });
 
   const [isPublishLaterModalVisible, setIsPublishLaterModalVisible] = useState(

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -19,9 +19,7 @@ import type { EventArguments } from '@/hooks/api/events';
 import {
   useAddEventMutation,
   useAddLabelMutation,
-  useChangeCalendarMutation,
   useChangeLocationMutation,
-  useChangeNameMutation,
   useChangeThemeMutation,
   useChangeTypicalAgeRangeMutation,
   useGetEventByIdQuery,
@@ -30,7 +28,6 @@ import {
 import {
   useAddEventByIdMutation as useAddEventToProductionByIdMutation,
   useCreateWithEventsMutation as useCreateProductionWithEventsMutation,
-  useDeleteEventByIdMutation as useDeleteEventFromProductionByIdMutation,
 } from '@/hooks/api/productions';
 import type { StepsConfiguration } from '@/pages/Steps';
 import { Steps } from '@/pages/Steps';
@@ -41,7 +38,10 @@ import {
 import { EventTypeAndThemeStep } from '@/pages/steps/EventTypeAndThemeStep';
 import { PublishLaterModal } from '@/pages/steps/modals/PublishLaterModal';
 import { PlaceStep } from '@/pages/steps/PlaceStep';
-import { ProductionStep } from '@/pages/steps/ProductionStep';
+import {
+  ProductionStep,
+  useEditNameAndProduction,
+} from '@/pages/steps/ProductionStep';
 import {
   convertTimeTableToSubEvents,
   TimeTableStep,
@@ -225,53 +225,6 @@ const useAddEvent = ({ onSuccess }) => {
     }
 
     onSuccess(eventId);
-  };
-};
-
-const useEditNameAndProduction = ({ onSuccess, eventId }) => {
-  const getEventByIdQuery = useGetEventByIdQuery({ id: eventId });
-
-  const createProductionWithEventsMutation = useCreateProductionWithEventsMutation();
-  const addEventToProductionByIdMutation = useAddEventToProductionByIdMutation();
-  const deleteEventFromProductionByIdMutation = useDeleteEventFromProductionByIdMutation();
-
-  const changeNameMutation = useChangeNameMutation({
-    onSuccess: () => onSuccess('name'),
-  });
-
-  return async ({ production }: FormData) => {
-    if (!production) return;
-
-    // unlink event from current production
-    // @ts-expect-error
-    if (getEventByIdQuery.data?.production?.id) {
-      await deleteEventFromProductionByIdMutation.mutateAsync({
-        // @ts-expect-error
-        productionId: getEventByIdQuery.data.production.id,
-        eventId,
-      });
-    }
-
-    if (production.customOption) {
-      // make new production with name and event id
-      await createProductionWithEventsMutation.mutateAsync({
-        productionName: production.name,
-        eventIds: [eventId],
-      });
-    } else {
-      // link event to production
-      await addEventToProductionByIdMutation.mutateAsync({
-        productionId: production.production_id,
-        eventId,
-      });
-    }
-
-    // change name of event
-    await changeNameMutation.mutateAsync({
-      id: eventId,
-      lang: 'nl',
-      name: production.name,
-    });
   };
 };
 

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -13,7 +13,6 @@ import type { EventArguments } from '@/hooks/api/events';
 import {
   useAddEventMutation,
   useAddLabelMutation,
-  useChangeThemeMutation,
   useChangeTypicalAgeRangeMutation,
   useGetEventByIdQuery,
   usePublishMutation,

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -248,7 +248,7 @@ const useEditField = ({ onSuccess, eventId, handleSubmit, editMap }) => {
     return Object.entries(editMap).reduce((newMap, [key, hook]) => {
       return {
         // @ts-expect-error
-        [key]: hook({ eventId, onSuccess: handleSuccess }),
+        [key]: hook<FormData>({ eventId, onSuccess: handleSuccess }),
         ...newMap,
       };
     }, {});

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -133,8 +133,8 @@ const useFooterStatus = ({ event, form }) => {
     if (fetchedEventId && !availableFrom) {
       return FooterStatus.PUBLISH;
     }
-    if (isMutating) return FooterStatus.HIDDEN;
     if (router.route.includes('edit')) return FooterStatus.AUTO_SAVE;
+    if (isMutating) return FooterStatus.HIDDEN;
     if (isPlaceDirty) return FooterStatus.MANUAL_SAVE;
     return FooterStatus.HIDDEN;
   }, [fetchedEventId, availableFrom, isPlaceDirty, isMutating, router.route]);

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -28,7 +28,10 @@ import {
   AdditionalInformationStep,
   AdditionalInformationStepVariant,
 } from '@/pages/steps/AdditionalInformationStep';
-import { EventTypeAndThemeStep } from '@/pages/steps/EventTypeAndThemeStep';
+import {
+  EventTypeAndThemeStep,
+  useEditTheme,
+} from '@/pages/steps/EventTypeAndThemeStep';
 import { PublishLaterModal } from '@/pages/steps/modals/PublishLaterModal';
 import { PlaceStep, useEditLocation } from '@/pages/steps/PlaceStep';
 import {
@@ -217,19 +220,6 @@ const useAddEvent = ({ onSuccess }) => {
     }
 
     onSuccess(eventId);
-  };
-};
-
-const useEditTheme = ({ eventId, onSuccess }) => {
-  const changeThemeMutation = useChangeThemeMutation({
-    onSuccess: () => onSuccess('theme'),
-  });
-
-  return async ({ eventTypeAndTheme }) => {
-    await changeThemeMutation.mutateAsync({
-      id: eventId,
-      themeId: eventTypeAndTheme.theme.id,
-    });
   };
 };
 

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -46,6 +46,7 @@ import { useAddEvent } from './useAddEvent';
 import { useEditField } from './useEditField';
 import { useGetEvent } from './useGetEvent';
 import { usePublishEvent } from './usePublishEvent';
+import { useToast } from './useToast';
 
 type FormData = {
   eventTypeAndTheme: {
@@ -114,31 +115,6 @@ const convertSubEventsToTimeTable = (subEvents: SubEvent[] = []) => {
 
 const nextWeekWednesday = nextWednesday(new Date());
 const formatDate = (date: Date) => format(date, 'dd/MM/yyyy');
-
-const useToast = ({ messages, title }) => {
-  const [message, setMessage] = useState<string>();
-
-  const clear = () => setMessage(undefined);
-
-  const trigger = (key: string) => {
-    const foundMessage = messages[key];
-    if (!foundMessage) return;
-    setMessage(foundMessage);
-  };
-
-  const header = useMemo(
-    () => (
-      <Inline as="div" flex={1} justifyContent="space-between">
-        <Text>{title}</Text>
-        <Text>{format(new Date(), 'HH:mm')}</Text>
-      </Inline>
-    ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [message],
-  );
-
-  return { message, header, clear, trigger };
-};
 
 const MovieForm = () => {
   const form = useForm<FormData>({

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -1,11 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import {
-  format,
-  isMatch,
-  nextWednesday,
-  parse as parseDate,
-  set as setTime,
-} from 'date-fns';
+import { format, nextWednesday } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -19,7 +13,6 @@ import type { EventArguments } from '@/hooks/api/events';
 import {
   useAddEventMutation,
   useAddLabelMutation,
-  useChangeLocationMutation,
   useChangeThemeMutation,
   useChangeTypicalAgeRangeMutation,
   useGetEventByIdQuery,
@@ -37,7 +30,7 @@ import {
 } from '@/pages/steps/AdditionalInformationStep';
 import { EventTypeAndThemeStep } from '@/pages/steps/EventTypeAndThemeStep';
 import { PublishLaterModal } from '@/pages/steps/modals/PublishLaterModal';
-import { PlaceStep } from '@/pages/steps/PlaceStep';
+import { PlaceStep, useEditLocation } from '@/pages/steps/PlaceStep';
 import {
   ProductionStep,
   useEditNameAndProduction,
@@ -58,7 +51,6 @@ import { Link, LinkVariants } from '@/ui/Link';
 import { Page } from '@/ui/Page';
 import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
-import type { TimeTableValue } from '@/ui/TimeTable';
 import {
   areAllTimeSlotsValid,
   isOneTimeSlotValid,
@@ -225,21 +217,6 @@ const useAddEvent = ({ onSuccess }) => {
     }
 
     onSuccess(eventId);
-  };
-};
-
-const useEditLocation = ({ eventId, onSuccess }) => {
-  const changeLocationMutation = useChangeLocationMutation({
-    onSuccess: () => onSuccess('location'),
-  });
-
-  return async ({ place }: FormData) => {
-    if (!place) return;
-
-    await changeLocationMutation.mutateAsync({
-      id: eventId,
-      locationId: parseOfferId(place['@id']),
-    });
   };
 };
 

--- a/src/pages/manage/movies/useAddEvent.ts
+++ b/src/pages/manage/movies/useAddEvent.ts
@@ -1,0 +1,89 @@
+import { CalendarType } from '@/constants/CalendarType';
+import {
+  EventArguments,
+  useAddEventMutation,
+  useAddLabelMutation,
+  useChangeTypicalAgeRangeMutation,
+} from '@/hooks/api/events';
+import {
+  useAddEventByIdMutation as useAddEventToProductionByIdMutation,
+  useCreateWithEventsMutation as useCreateProductionWithEventsMutation,
+} from '@/hooks/api/productions';
+import { FormDataIntersection } from '@/pages/Steps';
+import { convertTimeTableToSubEvents } from '@/pages/steps/TimeTableStep';
+import { WorkflowStatusMap } from '@/types/WorkflowStatus';
+import { parseOfferId } from '@/utils/parseOfferId';
+
+const useAddEvent = <TFormData extends FormDataIntersection>({ onSuccess }) => {
+  const addEventMutation = useAddEventMutation();
+  const changeTypicalAgeRangeMutation = useChangeTypicalAgeRangeMutation();
+  const addLabelMutation = useAddLabelMutation();
+
+  const createProductionWithEventsMutation = useCreateProductionWithEventsMutation();
+  const addEventToProductionByIdMutation = useAddEventToProductionByIdMutation();
+
+  return async ({
+    production,
+    place,
+    eventTypeAndTheme: { eventType, theme },
+    timeTable,
+  }: TFormData) => {
+    if (!production) return;
+
+    const payload: EventArguments = {
+      mainLanguage: 'nl',
+      name: production.name,
+      calendar: {
+        calendarType: CalendarType.MULTIPLE,
+        timeSpans: convertTimeTableToSubEvents(timeTable),
+      },
+      type: {
+        id: eventType?.id,
+        label: eventType?.label,
+        domain: 'eventtype',
+      },
+      ...(theme && {
+        theme: {
+          id: theme?.id,
+          label: theme?.label,
+          domain: 'theme',
+        },
+      }),
+      location: {
+        id: parseOfferId(place['@id']),
+      },
+      workflowStatus: WorkflowStatusMap.DRAFT,
+      audienceType: 'everyone',
+    };
+
+    const { eventId } = await addEventMutation.mutateAsync(payload);
+
+    if (!eventId) return;
+
+    await changeTypicalAgeRangeMutation.mutateAsync({
+      eventId,
+      typicalAgeRange: '-',
+    });
+
+    await addLabelMutation.mutateAsync({
+      eventId,
+      label: 'udb-filminvoer',
+    });
+
+    if (production.customOption) {
+      await createProductionWithEventsMutation.mutateAsync({
+        productionName: production.name,
+        eventIds: [eventId],
+      });
+    } else {
+      await addEventToProductionByIdMutation.mutateAsync({
+        productionId: production.production_id,
+        eventId,
+      });
+    }
+
+    onSuccess(eventId);
+  };
+};
+
+export { useAddEvent };

--- a/src/pages/manage/movies/useEditField.ts
+++ b/src/pages/manage/movies/useEditField.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useQueryClient } from 'react-query';
+
+import { FormDataIntersection } from '@/pages/Steps';
+
+type HandleSuccessOptions = {
+  shouldInvalidateEvent?: boolean;
+};
+
+const useEditField = <TFormData extends FormDataIntersection>({
+  onSuccess,
+  eventId,
+  handleSubmit,
+  editMap,
+}) => {
+  const queryClient = useQueryClient();
+  const [fieldLoading, setFieldLoading] = useState<string>();
+
+  const handleSuccess = useCallback(
+    (
+      editedField: string,
+      { shouldInvalidateEvent = true }: HandleSuccessOptions = {},
+    ) => {
+      onSuccess(editedField);
+
+      if (!shouldInvalidateEvent) return;
+      queryClient.invalidateQueries(['events', { id: eventId }]);
+    },
+    [onSuccess, eventId, queryClient],
+  );
+
+  const preparedFieldToMutationFunctionMap = useMemo(() => {
+    return Object.entries(editMap).reduce((newMap, [key, hook]) => {
+      return {
+        // @ts-expect-error
+        [key]: hook<TFormData>({ eventId, onSuccess: handleSuccess }),
+        ...newMap,
+      };
+    }, {});
+  }, [editMap, eventId, handleSuccess]);
+
+  const editEvent = async (formData: TFormData, editedField?: string) => {
+    if (!editedField) return;
+
+    await preparedFieldToMutationFunctionMap[editedField]?.(formData);
+
+    setFieldLoading(undefined);
+  };
+
+  const handleChange = (editedField: string) => {
+    if (!eventId) return;
+    setFieldLoading(editedField);
+    handleSubmit(async (formData: TFormData) =>
+      editEvent(formData, editedField),
+    )();
+  };
+
+  return { handleChange, fieldLoading };
+};
+
+export { useEditField };

--- a/src/pages/manage/movies/useGetEvent.ts
+++ b/src/pages/manage/movies/useGetEvent.ts
@@ -1,0 +1,10 @@
+import { useGetEventByIdQuery } from '@/hooks/api/events';
+
+const useGetEvent = ({ id, onSuccess }) => {
+  const getEventByIdQuery = useGetEventByIdQuery({ id }, { onSuccess });
+
+  // @ts-expect-error
+  return getEventByIdQuery?.data;
+};
+
+export { useGetEvent };

--- a/src/pages/manage/movies/usePublishEvent.ts
+++ b/src/pages/manage/movies/usePublishEvent.ts
@@ -1,0 +1,26 @@
+import { useQueryClient } from 'react-query';
+
+import { usePublishMutation } from '@/hooks/api/events';
+import { formatDateToISO } from '@/utils/formatDateToISO';
+
+const usePublishEvent = ({ id, onSuccess }) => {
+  const queryClient = useQueryClient();
+
+  const publishMutation = usePublishMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries(['events', { id }]);
+      onSuccess();
+    },
+  });
+
+  return async (date: Date = new Date()) => {
+    if (!id) return;
+
+    await publishMutation.mutateAsync({
+      eventId: id,
+      publicationDate: formatDateToISO(date),
+    });
+  };
+};
+
+export { usePublishEvent };

--- a/src/pages/manage/movies/useToast.tsx
+++ b/src/pages/manage/movies/useToast.tsx
@@ -1,0 +1,32 @@
+import { format } from 'date-fns';
+import { useMemo, useState } from 'react';
+
+import { Inline } from '@/ui/Inline';
+import { Text } from '@/ui/Text';
+
+const useToast = ({ messages, title }) => {
+  const [message, setMessage] = useState<string>();
+
+  const clear = () => setMessage(undefined);
+
+  const trigger = (key: string) => {
+    const foundMessage = messages[key];
+    if (!foundMessage) return;
+    setMessage(foundMessage);
+  };
+
+  const header = useMemo(
+    () => (
+      <Inline as="div" flex={1} justifyContent="space-between">
+        <Text>{title}</Text>
+        <Text>{format(new Date(), 'HH:mm')}</Text>
+      </Inline>
+    ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [message],
+  );
+
+  return { message, header, clear, trigger };
+};
+
+export { useToast };

--- a/src/pages/steps/EventTypeAndThemeStep.tsx
+++ b/src/pages/steps/EventTypeAndThemeStep.tsx
@@ -13,7 +13,7 @@ import { getValueFromTheme } from '@/ui/theme';
 
 const getValue = getValueFromTheme('createPage');
 
-const useEditTheme = <T extends FormDataIntersection>({
+const useEditTheme = <TFormData extends FormDataIntersection>({
   eventId,
   onSuccess,
 }) => {
@@ -21,7 +21,7 @@ const useEditTheme = <T extends FormDataIntersection>({
     onSuccess: () => onSuccess('theme'),
   });
 
-  return async ({ eventTypeAndTheme }: T) => {
+  return async ({ eventTypeAndTheme }: TFormData) => {
     await changeThemeMutation.mutateAsync({
       id: eventId,
       themeId: eventTypeAndTheme.theme.id,

--- a/src/pages/steps/EventTypeAndThemeStep.tsx
+++ b/src/pages/steps/EventTypeAndThemeStep.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { useChangeThemeMutation } from '@/hooks/api/events';
 import { useGetThemesByEventTypeIdQuery } from '@/hooks/api/themes';
 import type { FormDataIntersection, StepProps } from '@/pages/Steps';
 import { Button, ButtonVariants } from '@/ui/Button';
@@ -11,6 +12,22 @@ import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
 
 const getValue = getValueFromTheme('createPage');
+
+const useEditTheme = <T extends FormDataIntersection>({
+  eventId,
+  onSuccess,
+}) => {
+  const changeThemeMutation = useChangeThemeMutation({
+    onSuccess: () => onSuccess('theme'),
+  });
+
+  return async ({ eventTypeAndTheme }: T) => {
+    await changeThemeMutation.mutateAsync({
+      id: eventId,
+      themeId: eventTypeAndTheme.theme.id,
+    });
+  };
+};
 
 const EventTypeAndThemeStep = <TFormData extends FormDataIntersection>({
   control,
@@ -91,4 +108,4 @@ const EventTypeAndThemeStep = <TFormData extends FormDataIntersection>({
   );
 };
 
-export { EventTypeAndThemeStep };
+export { EventTypeAndThemeStep, useEditTheme };

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -4,6 +4,7 @@ import { Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import type { EventTypes } from '@/constants/EventTypes';
+import { useChangeLocationMutation } from '@/hooks/api/events';
 import { useGetPlacesByQuery } from '@/hooks/api/places';
 import type { FormDataIntersection, StepProps } from '@/pages/Steps';
 import type { Place } from '@/types/Place';
@@ -17,8 +18,27 @@ import { getStackProps, Stack } from '@/ui/Stack';
 import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
 import { Typeahead } from '@/ui/Typeahead';
+import { parseOfferId } from '@/utils/parseOfferId';
 
 const getValue = getValueFromTheme('createPage');
+
+const useEditLocation = <T extends FormDataIntersection>({
+  eventId,
+  onSuccess,
+}) => {
+  const changeLocationMutation = useChangeLocationMutation({
+    onSuccess: () => onSuccess('location'),
+  });
+
+  return async ({ place }: T) => {
+    if (!place) return;
+
+    await changeLocationMutation.mutateAsync({
+      id: eventId,
+      locationId: parseOfferId(place['@id']),
+    });
+  };
+};
 
 type PlaceStepProps<TFormData extends FormDataIntersection> = StackProps &
   StepProps<TFormData> & { terms: Array<Values<typeof EventTypes>> };
@@ -124,4 +144,4 @@ PlaceStep.defaultProps = {
   terms: [],
 };
 
-export { PlaceStep };
+export { PlaceStep, useEditLocation };

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -22,7 +22,7 @@ import { parseOfferId } from '@/utils/parseOfferId';
 
 const getValue = getValueFromTheme('createPage');
 
-const useEditLocation = <T extends FormDataIntersection>({
+const useEditLocation = <TFormData extends FormDataIntersection>({
   eventId,
   onSuccess,
 }) => {
@@ -30,7 +30,7 @@ const useEditLocation = <T extends FormDataIntersection>({
     onSuccess: () => onSuccess('location'),
   });
 
-  return async ({ place }: T) => {
+  return async ({ place }: TFormData) => {
     if (!place) return;
 
     await changeLocationMutation.mutateAsync({

--- a/src/pages/steps/ProductionStep.tsx
+++ b/src/pages/steps/ProductionStep.tsx
@@ -30,7 +30,7 @@ type ProductionStepProps<TFormData extends FormDataIntersection> = StackProps &
 
 const getValue = getValueFromTheme('createPage');
 
-const useEditNameAndProduction = <T extends FormDataIntersection>({
+const useEditNameAndProduction = <TFormData extends FormDataIntersection>({
   onSuccess,
   eventId,
 }) => {
@@ -44,7 +44,7 @@ const useEditNameAndProduction = <T extends FormDataIntersection>({
     onSuccess: () => onSuccess('name'),
   });
 
-  return async ({ production }: T) => {
+  return async ({ production }: TFormData) => {
     if (!production) return;
 
     // unlink event from current production

--- a/src/pages/steps/ProductionStep.tsx
+++ b/src/pages/steps/ProductionStep.tsx
@@ -3,7 +3,16 @@ import { useMemo, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import {
+  useChangeNameMutation,
+  useGetEventByIdQuery,
+} from '@/hooks/api/events';
 import { useGetProductionsQuery } from '@/hooks/api/productions';
+import {
+  useAddEventByIdMutation as useAddEventToProductionByIdMutation,
+  useCreateWithEventsMutation as useCreateProductionWithEventsMutation,
+  useDeleteEventByIdMutation as useDeleteEventFromProductionByIdMutation,
+} from '@/hooks/api/productions';
 import type { FormDataIntersection, StepProps } from '@/pages/Steps';
 import type { Production } from '@/types/Production';
 import { Button, ButtonVariants } from '@/ui/Button';
@@ -20,6 +29,56 @@ type ProductionStepProps<TFormData extends FormDataIntersection> = StackProps &
   StepProps<TFormData>;
 
 const getValue = getValueFromTheme('createPage');
+
+const useEditNameAndProduction = <T extends FormDataIntersection>({
+  onSuccess,
+  eventId,
+}) => {
+  const getEventByIdQuery = useGetEventByIdQuery({ id: eventId });
+
+  const createProductionWithEventsMutation = useCreateProductionWithEventsMutation();
+  const addEventToProductionByIdMutation = useAddEventToProductionByIdMutation();
+  const deleteEventFromProductionByIdMutation = useDeleteEventFromProductionByIdMutation();
+
+  const changeNameMutation = useChangeNameMutation({
+    onSuccess: () => onSuccess('name'),
+  });
+
+  return async ({ production }: T) => {
+    if (!production) return;
+
+    // unlink event from current production
+    // @ts-expect-error
+    if (getEventByIdQuery.data?.production?.id) {
+      await deleteEventFromProductionByIdMutation.mutateAsync({
+        // @ts-expect-error
+        productionId: getEventByIdQuery.data.production.id,
+        eventId,
+      });
+    }
+
+    if (production.customOption) {
+      // make new production with name and event id
+      await createProductionWithEventsMutation.mutateAsync({
+        productionName: production.name,
+        eventIds: [eventId],
+      });
+    } else {
+      // link event to production
+      await addEventToProductionByIdMutation.mutateAsync({
+        productionId: production.production_id,
+        eventId,
+      });
+    }
+
+    // change name of event
+    await changeNameMutation.mutateAsync({
+      id: eventId,
+      lang: 'nl',
+      name: production.name,
+    });
+  };
+};
 
 const ProductionStep = <TFormData extends FormDataIntersection>({
   formState: { errors },
@@ -116,4 +175,4 @@ const ProductionStep = <TFormData extends FormDataIntersection>({
   );
 };
 
-export { ProductionStep };
+export { ProductionStep, useEditNameAndProduction };

--- a/src/pages/steps/TimeTableStep.tsx
+++ b/src/pages/steps/TimeTableStep.tsx
@@ -1,6 +1,9 @@
+import { isMatch, parse, set } from 'date-fns';
 import { Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { CalendarType } from '@/constants/CalendarType';
+import { useChangeCalendarMutation } from '@/hooks/api/events';
 import type { FormDataIntersection, StepProps } from '@/pages/Steps';
 import { Alert, AlertVariants } from '@/ui/Alert';
 import { Box } from '@/ui/Box';
@@ -12,6 +15,59 @@ import {
   isTimeTableEmpty,
   TimeTable,
 } from '@/ui/TimeTable';
+import { formatDateToISO } from '@/utils/formatDateToISO';
+
+type EncodedTimeTable = Array<{ start: string; end: string }>;
+
+const convertTimeTableToSubEvents = (timeTable: TimeTableValue) => {
+  const { data = {} } = timeTable;
+  return Object.keys(data).reduce<EncodedTimeTable>(
+    (acc, date) => [
+      ...acc,
+      ...Object.keys(data[date]).reduce<EncodedTimeTable>((acc, index) => {
+        const time = data[date][index];
+
+        if (!time || !isMatch(time, "HH'h'mm'm'")) {
+          return acc;
+        }
+
+        const isoDate = formatDateToISO(
+          set(parse(date, 'dd/MM/yyyy', new Date()), {
+            hours: parseInt(time.substring(0, 2)),
+            minutes: parseInt(time.substring(3, 5)),
+            seconds: 0,
+          }),
+        );
+
+        return [
+          ...acc,
+          {
+            start: isoDate,
+            end: isoDate,
+          },
+        ];
+      }, []),
+    ],
+    [],
+  );
+};
+
+const useEditCalendar = <T extends FormDataIntersection>({
+  eventId,
+  onSuccess,
+}) => {
+  const changeCalendarMutation = useChangeCalendarMutation({
+    onSuccess: () => onSuccess('calendar', { shouldInvalidateEvent: false }),
+  });
+
+  return async ({ timeTable }: T) => {
+    await changeCalendarMutation.mutateAsync({
+      id: eventId,
+      calendarType: CalendarType.MULTIPLE,
+      timeSpans: convertTimeTableToSubEvents(timeTable),
+    });
+  };
+};
 
 type TimeTableStepProps<TFormData extends FormDataIntersection> = StackProps &
   StepProps<TFormData>;
@@ -61,4 +117,4 @@ const TimeTableStep = <TFormData extends FormDataIntersection>({
   );
 };
 
-export { TimeTableStep };
+export { convertTimeTableToSubEvents, TimeTableStep, useEditCalendar };

--- a/src/pages/steps/TimeTableStep.tsx
+++ b/src/pages/steps/TimeTableStep.tsx
@@ -52,7 +52,7 @@ const convertTimeTableToSubEvents = (timeTable: TimeTableValue) => {
   );
 };
 
-const useEditCalendar = <T extends FormDataIntersection>({
+const useEditCalendar = <TFormData extends FormDataIntersection>({
   eventId,
   onSuccess,
 }) => {
@@ -60,7 +60,7 @@ const useEditCalendar = <T extends FormDataIntersection>({
     onSuccess: () => onSuccess('calendar', { shouldInvalidateEvent: false }),
   });
 
-  return async ({ timeTable }: T) => {
+  return async ({ timeTable }: TFormData) => {
     await changeCalendarMutation.mutateAsync({
       id: eventId,
       calendarType: CalendarType.MULTIPLE,


### PR DESCRIPTION
### Changed

- Moved the edit hooks to their own steps
- Moved the edit / publish / save / toast hooks to their own files.

### Reverted
- the editMap functionality

The next step is to move the "edit" logic to the steps themselves.
