### PR TITLE
Remove swc/plugin-styled-components since it isn't used

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2564,11 +2564,6 @@
   dependencies:
     tslib "^2.4.0"
 
-"@swc/plugin-styled-components@^1.2.12":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@swc/plugin-styled-components/-/plugin-styled-components-1.2.12.tgz#28ce75241a50a64610d27608c96177787911ff9a"
-  integrity sha512-6BKtZD4ICQ+vnOMxfYRvjmtXpj7f1YyNd4kt9Q44rGg/vNAf1QVK4Lg3nkj/WcCIryKBHKPl5MZzfTa+dRcnzw==
-
 "@testing-library/dom@^7.28.1":
   version "7.30.3"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.3.tgz#779ea9bbb92d63302461800a388a5a890ac22519"


### PR DESCRIPTION
### Removed

- [swc/plugin-styled-components since it isn't used](https://github.com/cultuurnet/udb3-frontend/commit/a81f05e6598ceb67eca8a195cb9a82a07df6b16e)

I did:

`nvm use`
`rm -rf node_modules`
`yarn install`