### PR TITLE
III-4923 - Improve layout of description

### DIFF
--- a/src/pages/steps/DescriptionStep.tsx
+++ b/src/pages/steps/DescriptionStep.tsx
@@ -10,6 +10,7 @@ import { Alert } from '@/ui/Alert';
 import { Box, parseSpacing } from '@/ui/Box';
 import { Button, ButtonVariants } from '@/ui/Button';
 import { FormElement } from '@/ui/FormElement';
+import { Inline } from '@/ui/Inline';
 import { ProgressBar, ProgressBarVariants } from '@/ui/ProgressBar';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
 import { Text, TextVariants } from '@/ui/Text';
@@ -65,35 +66,6 @@ const DescriptionInfo = ({
       <Button variant={ButtonVariants.LINK} onClick={onClear}>
         {t('create.additionalInformation.description.clear')}
       </Button>
-      {eventTypeId && (
-        <Alert>
-          <Box
-            forwardedAs="div"
-            dangerouslySetInnerHTML={{
-              __html: t(
-                `create*additionalInformation*description*tips*${eventTypeId}`,
-                {
-                  keySeparator: '*',
-                },
-              ),
-            }}
-            css={`
-              strong {
-                font-weight: bold;
-              }
-
-              ul {
-                list-style-type: disc;
-                margin-bottom: ${parseSpacing(4)};
-
-                li {
-                  margin-left: ${parseSpacing(5)};
-                }
-              }
-            `}
-          />
-        </Alert>
-      )}
     </Stack>
   );
 };
@@ -166,26 +138,63 @@ const DescriptionStep = ({
   };
 
   return (
-    <FormElement
-      id="create-description"
-      label={t('create.additionalInformation.description.title')}
-      Component={
-        <TextArea
-          rows={5}
-          value={description}
-          onInput={handleInput}
-          onBlur={handleBlur}
-        />
-      }
-      info={
-        <DescriptionInfo
-          description={description}
-          onClear={handleClear}
-          eventTypeId={eventTypeId}
-        />
-      }
-      {...getStackProps(props)}
-    />
+    <Inline>
+      <FormElement
+        width="50%"
+        marginRight={5}
+        id="create-description"
+        label={t('create.additionalInformation.description.title')}
+        Component={
+          <TextArea
+            rows={10}
+            value={description}
+            onInput={handleInput}
+            onBlur={handleBlur}
+          />
+        }
+        info={
+          <DescriptionInfo
+            description={description}
+            onClear={handleClear}
+            eventTypeId={eventTypeId}
+          />
+        }
+        {...getStackProps(props)}
+      />
+      {eventTypeId && (
+        <Alert
+          css={`
+            margin-top: 1.86rem;
+          `}
+        >
+          <Box
+            forwardedAs="div"
+            dangerouslySetInnerHTML={{
+              __html: t(
+                `create*additionalInformation*description*tips*${eventTypeId}`,
+                {
+                  keySeparator: '*',
+                },
+              ),
+            }}
+            css={`
+              strong {
+                font-weight: bold;
+              }
+
+              ul {
+                list-style-type: disc;
+                margin-bottom: ${parseSpacing(4)};
+
+                li {
+                  margin-left: ${parseSpacing(5)};
+                }
+              }
+            `}
+          />
+        </Alert>
+      )}
+    </Inline>
   );
 };
 


### PR DESCRIPTION
### Changed
- Improve layout of DescriptionStep

**Before:**
<img width="1191" alt="Schermafbeelding 2022-08-31 om 16 23 43" src="https://user-images.githubusercontent.com/9402377/190125077-44bd850b-7697-471e-b741-5f96749fbbbd.png">

**After:**
<img width="1204" alt="Screenshot 2022-09-14 at 12 03 25" src="https://user-images.githubusercontent.com/9402377/190125223-f1b3d75b-b04d-474a-9b3a-3c430855a7c8.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-4923
