### PR TITLE
III-4923 - Don't make alerts full-width

### DIFF
--- a/src/pages/steps/PriceInformation.tsx
+++ b/src/pages/steps/PriceInformation.tsx
@@ -391,7 +391,7 @@ const PriceInformation = ({
         </Inline>
       ))}
       {hasGlobalError && (
-        <Alert marginTop={3} variant={AlertVariants.INFO}>
+        <Alert display="flex" marginTop={3} variant={AlertVariants.INFO}>
           <Box
             forwardedAs="div"
             dangerouslySetInnerHTML={{
@@ -409,12 +409,12 @@ const PriceInformation = ({
         </Alert>
       )}
       {hasUitpasError && (
-        <Alert marginTop={3} variant={AlertVariants.WARNING}>
+        <Alert display="flex" marginTop={3} variant={AlertVariants.WARNING}>
           {t('create.additionalInformation.price_info.uitpas_error')}
         </Alert>
       )}
       {!!duplicateNameError && (
-        <Alert marginTop={3} variant={AlertVariants.DANGER}>
+        <Alert display="flex" marginTop={3} variant={AlertVariants.DANGER}>
           {duplicateNameError}
         </Alert>
       )}

--- a/src/ui/Alert.tsx
+++ b/src/ui/Alert.tsx
@@ -2,10 +2,9 @@ import { Alert as BootstrapAlert } from 'react-bootstrap';
 
 import type { Values } from '@/types/Values';
 
-import type { BoxProps } from './Box';
-import { Box, getBoxProps } from './Box';
 import { Icon, Icons } from './Icon';
-import { Inline } from './Inline';
+import type { InlineProps } from './Inline';
+import { getInlineProps, Inline } from './Inline';
 import { Text } from './Text';
 import { getValueFromTheme } from './theme';
 
@@ -27,7 +26,7 @@ const AlertVariantIconsMap = {
 
 const getValue = getValueFromTheme(`alert`);
 
-type Props = BoxProps & {
+type Props = InlineProps & {
   variant?: Values<typeof AlertVariants>;
   visible?: boolean;
   dismissible?: boolean;
@@ -44,7 +43,7 @@ const Alert = ({
   ...props
 }: Props) => {
   return (
-    <Box {...getBoxProps(props)}>
+    <Inline {...getInlineProps(props)} alignSelf="flex-start">
       <BootstrapAlert
         variant={variant}
         hidden={!visible}
@@ -68,7 +67,7 @@ const Alert = ({
           <Text> {children}</Text>
         </Inline>
       </BootstrapAlert>
-    </Box>
+    </Inline>
   );
 };
 

--- a/src/ui/Box.tsx
+++ b/src/ui/Box.tsx
@@ -195,6 +195,7 @@ type FlexWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
 type UIProps = {
   alignItems: UIProp<AlignItems>;
+  alignSelf: UIProp<AlignItems>;
   animation: UIProp<FlattenSimpleInterpolation>;
   backgroundColor: UIProp<string>;
   backgroundPosition: UIProp<string>;

--- a/src/ui/Inline.tsx
+++ b/src/ui/Inline.tsx
@@ -37,6 +37,7 @@ const inlineProps = css`
   flex-direction: row;
 
   ${parseProperty('alignItems')};
+  ${parseProperty('alignSelf')};
   ${parseProperty('justifyContent')};
   ${parseStackOnProperty()};
 `;
@@ -84,7 +85,13 @@ const Inline = forwardRef<HTMLElement, Props>(
 
 Inline.displayName = 'Inline';
 
-const inlinePropTypes = ['spacing', 'alignItems', 'justifyContent', 'stackOn'];
+const inlinePropTypes = [
+  'spacing',
+  'alignItems',
+  'alignSelf',
+  'justifyContent',
+  'stackOn',
+];
 
 const getInlineProps = (props: UnknownProps) =>
   pick(props, [...boxPropTypes, ...inlinePropTypes]);


### PR DESCRIPTION
### Changed
- Don't make alerts full-width

**Screenshots**
<img width="1198" alt="Screenshot 2022-10-26 at 10 24 30" src="https://user-images.githubusercontent.com/9402377/197975020-30fe913f-4e22-4d66-b638-9091c9d70957.png">

<img width="595" alt="Screenshot 2022-10-26 at 10 08 22" src="https://user-images.githubusercontent.com/9402377/197974956-44a6466d-13c0-460e-ba1a-515a9b25398a.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-4923
