### PR TITLE
III-5021 - Alert improvements

### DIFF
--- a/src/pages/OrganizerAddModal.tsx
+++ b/src/pages/OrganizerAddModal.tsx
@@ -191,7 +191,7 @@ const OrganizerAddModal = ({
           id="organizer-url"
           label={t('organizer.add_modal.labels.url')}
           info={
-            <Alert variant={AlertVariants.INFO}>
+            <Alert variant={AlertVariants.PRIMARY}>
               {t('organizer.add_modal.url_requirements')}
             </Alert>
           }

--- a/src/pages/dashboard/index.page.tsx
+++ b/src/pages/dashboard/index.page.tsx
@@ -69,7 +69,7 @@ const globalAlertVariant = Object.values(AlertVariants).some(
   (variant) => variant === publicRuntimeConfig.globalAlertVariant,
 )
   ? publicRuntimeConfig.globalAlertVariant
-  : AlertVariants.INFO;
+  : AlertVariants.PRIMARY;
 
 const getValue = getValueFromTheme('dashboardPage');
 

--- a/src/pages/steps/PriceInformation.tsx
+++ b/src/pages/steps/PriceInformation.tsx
@@ -391,7 +391,7 @@ const PriceInformation = ({
         </Inline>
       ))}
       {hasGlobalError && (
-        <Alert marginTop={3} variant={AlertVariants.INFO}>
+        <Alert marginTop={3} variant={AlertVariants.PRIMARY}>
           <Box
             forwardedAs="div"
             dangerouslySetInnerHTML={{

--- a/src/ui/Alert.stories.mdx
+++ b/src/ui/Alert.stories.mdx
@@ -25,6 +25,23 @@ export const commonArgs = {
   </Story>
 </Canvas>
 
+<ArgsTable story="Primary" />
+
+## Primary
+
+<Canvas>
+  <Story
+    name="Primary"
+    args={{
+      variant: AlertVariants.PRIMARY,
+      children: 'A Primary Alert',
+      ...commonArgs,
+    }}
+  >
+    {(args) => <Alert {...args} />}
+  </Story>
+</Canvas>
+
 <ArgsTable story="Info" />
 
 ## Success

--- a/src/ui/Alert.tsx
+++ b/src/ui/Alert.tsx
@@ -7,6 +7,7 @@ import { Box, getBoxProps } from './Box';
 import { getValueFromTheme } from './theme';
 
 const AlertVariants = {
+  PRIMARY: 'primary',
   INFO: 'info',
   SUCCESS: 'success',
   DANGER: 'danger',
@@ -47,7 +48,15 @@ const Alert = ({
         `}
         onClose={onDismiss}
       >
-        {children}
+        <Inline spacing={3} alignItems="flex-start">
+          <Icon
+            name={AlertVariantIconsMap[variant]}
+            css={`
+              height: 24px;
+            `}
+          />
+          <Text> {children}</Text>
+        </Inline>
       </BootstrapAlert>
     </Box>
   );
@@ -55,7 +64,7 @@ const Alert = ({
 
 Alert.defaultProps = {
   visible: true,
-  variant: AlertVariants.INFO,
+  variant: AlertVariants.PRIMARY,
   dismissible: false,
 };
 

--- a/src/ui/Alert.tsx
+++ b/src/ui/Alert.tsx
@@ -4,6 +4,9 @@ import type { Values } from '@/types/Values';
 
 import type { BoxProps } from './Box';
 import { Box, getBoxProps } from './Box';
+import { Icon, Icons } from './Icon';
+import { Inline } from './Inline';
+import { Text } from './Text';
 import { getValueFromTheme } from './theme';
 
 const AlertVariants = {
@@ -14,6 +17,13 @@ const AlertVariants = {
   WARNING: 'warning',
   DARK: 'dark',
 } as const;
+
+const AlertVariantIconsMap = {
+  [AlertVariants.PRIMARY]: [Icons.INFO],
+  [AlertVariants.SUCCESS]: [Icons.CHECK_CIRCLE],
+  [AlertVariants.WARNING]: [Icons.EXCLAMATION_CIRCLE],
+  [AlertVariants.DANGER]: [Icons.EXCLAMATION_TRIANGLE],
+};
 
 const getValue = getValueFromTheme(`alert`);
 

--- a/src/ui/Icon.tsx
+++ b/src/ui/Icon.tsx
@@ -10,6 +10,7 @@ import {
   faChevronRight,
   faCircleNotch,
   faCopy,
+  faExclamationCircle,
   faExclamationTriangle,
   faEye,
   faEyeSlash,
@@ -17,6 +18,7 @@ import {
   faGift,
   faHome,
   faImage,
+  faInfoCircle,
   faLayerGroup,
   faPencilAlt,
   faPlus,
@@ -63,6 +65,7 @@ const Icons = {
   PLUS: 'plus',
   TRASH: 'trash',
   BINOCULARS: 'binoculars',
+  EXCLAMATION_CIRCLE: 'exclamationCircle',
   EXCLAMATION_TRIANGLE: 'exclamationTriangle',
   PENCIL: 'pencilAlt',
   VIDEO: 'video',
@@ -70,6 +73,7 @@ const Icons = {
   IMAGE: 'image',
   BUILDING: 'building',
   TICKET: 'ticket',
+  INFO: 'info',
 } as const;
 
 const IconsMap = {
@@ -104,6 +108,8 @@ const IconsMap = {
   [Icons.IMAGE]: faImage,
   [Icons.BUILDING]: faBuilding,
   [Icons.TICKET]: faTicketAlt,
+  [Icons.INFO]: faInfoCircle,
+  [Icons.EXCLAMATION_CIRCLE]: faExclamationCircle,
 };
 
 type Props = Omit<BoxProps, 'width' | 'height'> & {


### PR DESCRIPTION
### Added
- New `primary`  bootstrap AlertVariant 
- Icons on alerts

### Changed
- use `primary` AlertVariant instead of `info`


## Screenshots:
<img width="1187" alt="Screenshot 2022-10-21 at 11 19 50" src="https://user-images.githubusercontent.com/9402377/197162856-9bc26a0b-abc0-443e-a6ca-0a36df02f8cc.png">
<img width="1188" alt="Screenshot 2022-10-21 at 11 19 41" src="https://user-images.githubusercontent.com/9402377/197163179-94d68e3d-0680-47a3-b221-4d378829adf9.png">
<img width="1188" alt="Screenshot 2022-10-21 at 11 21 12" src="https://user-images.githubusercontent.com/9402377/197162887-afcb00f7-e701-4286-b9b4-2b48218a6b1c.png">
<img width="1190" alt="Screenshot 2022-10-21 at 11 27 27" src="https://user-images.githubusercontent.com/9402377/197163112-0f0e3b94-e0a7-457b-8f85-575f5b18f0fc.png">
<img width="877" alt="Screenshot 2022-10-21 at 11 24 33" src="https://user-images.githubusercontent.com/9402377/197163275-207f1710-c50c-4bb2-a0d3-28d83badc4a7.png">
<img width="1184" alt="Screenshot 2022-10-21 at 11 24 44" src="https://user-images.githubusercontent.com/9402377/197163285-d3df199d-da77-4308-a0df-cecbe56ef500.png">


---
Ticket: https://jira.uitdatabank.be/browse/III-5021
