### PR TITLE
III-5022 - Success icon improvements

### DIFF
--- a/src/layouts/joblogger/Job.tsx
+++ b/src/layouts/joblogger/Job.tsx
@@ -15,6 +15,7 @@ import { Stack } from '@/ui/Stack';
 import { getValueFromTheme } from '@/ui/theme';
 
 const getValue = getValueFromTheme('jobStatusIcon');
+const getGlobalValue = getValueFromTheme('global');
 
 const dateFnsLocales = { nl: nlBE, fr };
 
@@ -33,12 +34,7 @@ const JobStates = {
 
 const StatusIcon = memo(({ state }: { state: Values<typeof JobStates> }) => {
   if (state === JobStates.FINISHED) {
-    return (
-      <Icon
-        name={Icons.CHECK_CIRCLE}
-        color={getValue('complete.circleFillColor')}
-      />
-    );
+    return <Icon name={Icons.CHECK_CIRCLE} color={getGlobalValue('success')} />;
   }
   return (
     <Icon

--- a/src/layouts/joblogger/JobLoggerStateIndicator.tsx
+++ b/src/layouts/joblogger/JobLoggerStateIndicator.tsx
@@ -9,6 +9,7 @@ import { getValueFromTheme } from '@/ui/theme';
 import { JobLoggerStates } from './JobLogger';
 
 const getValue = getValueFromTheme('jobStatusIcon');
+const getGlobalValue = getValueFromTheme('global');
 
 type SvgProps = BoxProps;
 
@@ -97,7 +98,7 @@ const CompleteIcon = ({ className }: { className?: string }) => (
       />
       <circle
         css={`
-          fill: ${getValue('complete.circleFillColor')};
+          fill: ${getGlobalValue('successIcon')};
         `}
         cx="20"
         cy="40"
@@ -156,7 +157,7 @@ const WarningIcon = ({ className }: { className?: string }) => (
       />
       <circle
         css={`
-          fill: ${getValue('warning.circleFillColor')};
+          fill: ${getGlobalValue('successIcon')};
         `}
         cx="20"
         cy="40"

--- a/src/pages/steps/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep.tsx
@@ -9,6 +9,7 @@ import { getInlineProps, Inline, InlineProps } from '@/ui/Inline';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
 import { Tabs } from '@/ui/Tabs';
 import { Text } from '@/ui/Text';
+import { getValueFromTheme } from '@/ui/theme';
 
 import { Audience } from './Audience';
 import { BookingInfoStep } from './BookingInfoStep';
@@ -19,6 +20,8 @@ import { MediaStep } from './MediaStep';
 import { OrganizerStep } from './OrganizerStep';
 import { PriceInformation } from './PriceInformation';
 import { FormDataUnion, StepsConfiguration } from './Steps';
+
+const getGlobalValue = getValueFromTheme('global');
 
 const AdditionalInformationStepVariant = {
   MINIMAL: 'minimal',
@@ -112,7 +115,9 @@ const TabTitle = ({ field, isCompleted, ...props }: TabTitleProps) => {
 
   return (
     <Inline spacing={3} {...getInlineProps(props)}>
-      {isCompleted && <Icon name={Icons.CHECK_CIRCLE} color="#48874a" />}
+      {isCompleted && (
+        <Icon name={Icons.CHECK_CIRCLE} color={getGlobalValue('successIcon')} />
+      )}
       <Text>{t(`create.additionalInformation.${field}.title`)}</Text>
     </Inline>
   );

--- a/src/pages/steps/EventTypeAndThemeStep.tsx
+++ b/src/pages/steps/EventTypeAndThemeStep.tsx
@@ -19,6 +19,7 @@ import { getValueFromTheme } from '@/ui/theme';
 import { FormDataUnion, StepProps, StepsConfiguration } from './Steps';
 
 const getValue = getValueFromTheme('createPage');
+const getGlobalValue = getValueFromTheme('global');
 
 const useEditTypeAndTheme = <TFormData extends FormDataUnion>({
   eventId,
@@ -126,7 +127,7 @@ const EventTypeAndThemeStep = <TFormData extends FormDataUnion>({
                   >
                     <Icon
                       name={Icons.CHECK_CIRCLE}
-                      color={getValue('check.circleFillColor')}
+                      color={getGlobalValue('successIcon')}
                     />
                     <Text>{field.value?.type?.label}</Text>
                     <Button
@@ -192,7 +193,7 @@ const EventTypeAndThemeStep = <TFormData extends FormDataUnion>({
               >
                 <Icon
                   name={Icons.CHECK_CIRCLE}
-                  color={getValue('check.circleFillColor')}
+                  color={getGlobalValue('succcessIcon')}
                 />
                 <Text>{field.value?.theme?.label}</Text>
                 <Button

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -30,6 +30,7 @@ import { PlaceStep } from './PlaceStep';
 import { FormDataUnion, StepProps, StepsConfiguration } from './Steps';
 
 const getValue = getValueFromTheme('createPage');
+const getGlobalValue = getValueFromTheme('global');
 
 const useEditPlace = <TFormData extends FormDataUnion>({
   eventId,
@@ -112,7 +113,7 @@ const LocationStep = <TFormData extends FormDataUnion>({
                 <Inline alignItems="center" spacing={3}>
                   <Icon
                     name={Icons.CHECK_CIRCLE}
-                    color={getValue('check.circleFillColor')}
+                    color={getGlobalValue('successIcon')}
                   />
                   <Text>{t('create.location.country.location_school')}</Text>
                   <Button
@@ -226,7 +227,7 @@ const LocationStep = <TFormData extends FormDataUnion>({
                 <Inline alignItems="center" spacing={3}>
                   <Icon
                     name={Icons.CHECK_CIRCLE}
-                    color={getValue('check.circleFillColor')}
+                    color={getGlobalValue('successIcon')}
                   />
                   <Text>{municipality.name}</Text>
                   <Button

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -32,6 +32,7 @@ import { City } from '../CityPicker';
 import { PlaceAddModal } from '../PlaceAddModal';
 
 const getValue = getValueFromTheme('createPage');
+const getGlobalValue = getValueFromTheme('global');
 
 const useEditLocation = <TFormData extends FormDataUnion>({
   eventId,
@@ -180,7 +181,7 @@ const PlaceStep = <TFormData extends FormDataUnion>({
             <Inline alignItems="center" spacing={3}>
               <Icon
                 name={Icons.CHECK_CIRCLE}
-                color={getValue('check.circleFillColor')}
+                color={getGlobalValue('successIcon')}
               />
               <Text>
                 {selectedPlace.name[i18n.language] ??

--- a/src/pages/steps/ProductionStep.tsx
+++ b/src/pages/steps/ProductionStep.tsx
@@ -35,6 +35,7 @@ type ProductionStepProps<TFormData extends FormDataUnion> = StackProps &
   StepProps<TFormData>;
 
 const getValue = getValueFromTheme('createPage');
+const getGlobalValue = getValueFromTheme('global');
 
 const useEditNameAndProduction = <TFormData extends FormDataUnion>({
   onSuccess,
@@ -157,7 +158,7 @@ const ProductionStep = <TFormData extends FormDataUnion>({
           <Inline alignItems="center" spacing={3} {...getInlineProps(props)}>
             <Icon
               name={Icons.CHECK_CIRCLE}
-              color={getValue('check.circleFillColor')}
+              color={getGlobalValue('successIcon')}
             />
             <Text>{selectedProduction.name}</Text>
             <Button

--- a/src/ui/Icon.tsx
+++ b/src/ui/Icon.tsx
@@ -132,8 +132,8 @@ const Icon = ({ name, width, height, className, ...props }: Props) => {
 };
 
 Icon.defaultProps = {
-  width: 15,
-  height: 15,
+  width: 18,
+  height: 18,
 };
 
 export { Icon, Icons };

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -15,7 +15,7 @@ const colors = {
   grey6: '#999999',
   green1: '#5cb85c',
   green2: '#449d44',
-  green3: '#48874a',
+  green3: '#28a745',
   green4: '#dcf2d7',
   green5: '#c7e6c7',
   pink1: '#fcd1cf',

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -249,7 +249,6 @@ const theme = {
         backgroundColor: colors.white,
       },
       complete: {
-        circleFillColor: colors.green3,
         checkFillColor: colors.green4,
       },
     },
@@ -303,10 +302,6 @@ const theme = {
       stepNumber: {
         backgroundColor: colors.grey5,
       },
-      check: {
-        circleFillColor: colors.green3,
-      },
-
       footer: {
         color: colors.textColor,
       },


### PR DESCRIPTION
### Changed
- hex value of color green3
- use global value for successIcon instead of too specific theming
- increase default size of icons `15px` -> `18px`

## Screenshots
<img width="919" alt="Screenshot 2022-10-21 at 11 50 50" src="https://user-images.githubusercontent.com/9402377/197168294-b1bed418-372e-4799-a4f6-682a9b87a447.png">

<img width="1131" alt="Screenshot 2022-10-21 at 11 50 45" src="https://user-images.githubusercontent.com/9402377/197168214-06b12d9d-c651-4ae9-b0af-a46f8f4b5fba.png">
8727-a874-4541-82a0-703a197e599f.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5022
