### PR TITLE
III-5032 - Organizer picker refinements

### DIFF
--- a/src/pages/steps/OrganizerPicker.tsx
+++ b/src/pages/steps/OrganizerPicker.tsx
@@ -74,15 +74,12 @@ const RecentUsedOrganizers = ({
             <Button
               key={index}
               onClick={() => onChange(parseOfferId(organizer['@id']))}
-              paddingTop={4}
-              paddingBottom={4}
-              paddingLeft={5}
-              paddingRight={5}
+              padding={4}
               borderRadius="0.5rem"
               variant={ButtonVariants.UNSTYLED}
               customChildren
               marginBottom={4}
-              width="25rem"
+              width="20rem"
               title={name}
               css={`
                 flex-direction: column;
@@ -99,7 +96,7 @@ const RecentUsedOrganizers = ({
                 fontWeight="bold"
                 display="flex"
                 justifyContent="space-between"
-                width="20rem"
+                width="18rem"
                 textAlign="left"
               >
                 <Text

--- a/src/pages/steps/OrganizerPicker.tsx
+++ b/src/pages/steps/OrganizerPicker.tsx
@@ -17,7 +17,7 @@ import { Inline } from '@/ui/Inline';
 import { Paragraph } from '@/ui/Paragraph';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
 import { Text } from '@/ui/Text';
-import { getValueFromTheme } from '@/ui/theme';
+import { getGlobalBorderRadius, getValueFromTheme } from '@/ui/theme';
 import { isNewEntry, NewEntry, Typeahead } from '@/ui/Typeahead';
 import { parseOfferId } from '@/utils/parseOfferId';
 import { valueToArray } from '@/utils/valueToArray';
@@ -75,7 +75,7 @@ const RecentUsedOrganizers = ({
               key={index}
               onClick={() => onChange(parseOfferId(organizer['@id']))}
               padding={4}
-              borderRadius="0.5rem"
+              borderRadius={getGlobalBorderRadius}
               variant={ButtonVariants.UNSTYLED}
               customChildren
               marginBottom={4}

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
-import { getValueFromTheme } from '@/ui/theme';
+import { colors as globalColors, getValueFromTheme } from '@/ui/theme';
 
 const getValueForModal = getValueFromTheme('modal');
 
@@ -146,6 +146,10 @@ const GlobalStyle = createGlobalStyle`
 
   .modal-backdrop {
     z-index: ${getValueForModal('zIndexBackdrop')};
+  }
+
+  .badge-secondary{
+    background-color: ${globalColors.grey5};
   }
 `;
 

--- a/src/ui/Badge.tsx
+++ b/src/ui/Badge.tsx
@@ -1,4 +1,5 @@
 import { Badge as BootstrapBadge } from 'react-bootstrap';
+import { css } from 'styled-components';
 
 import type { Values } from '@/types/Values';
 

--- a/src/ui/Badge.tsx
+++ b/src/ui/Badge.tsx
@@ -1,5 +1,4 @@
 import { Badge as BootstrapBadge } from 'react-bootstrap';
-import { css } from 'styled-components';
 
 import type { Values } from '@/types/Values';
 

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -387,5 +387,5 @@ const getValueFromTheme = (component: string) => (path: string) => (props: {
   theme: Theme;
 }) => get(props.theme, `components.${component}.${path}`);
 
-export { Breakpoints, getGlobalBorderRadius, getValueFromTheme, theme };
+export { Breakpoints, colors, getGlobalBorderRadius, getValueFromTheme, theme };
 export type { BreakpointValues, Theme };


### PR DESCRIPTION
### Changed
- Make organizer buttons less large
- Use global border radius
- Badge secondary: use same grey as for step numbers


<img width="807" alt="Screenshot 2022-10-21 at 13 41 29" src="https://user-images.githubusercontent.com/9402377/197189107-0c75ac1a-155e-486f-bdf3-ced7f5fbc3c5.png">


---
Ticket: https://jira.uitdatabank.be/browse/III-5032 
