### PR TITLE
III-5073 - Fix failing user requests

### DIFF
--- a/src/hooks/api/authenticated-query.ts
+++ b/src/hooks/api/authenticated-query.ts
@@ -143,11 +143,7 @@ const prefetchAuthenticatedQuery = async <TData>({
     headers,
   });
 
-  try {
-    await queryClient.prefetchQuery(queryKey, queryFn);
-  } catch {}
-
-  return await queryClient.getQueryData(queryKey);
+  return await queryClient.fetchQuery(queryKey, queryFn);
 };
 
 /// /////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/fetchFromApi.ts
+++ b/src/utils/fetchFromApi.ts
@@ -59,7 +59,8 @@ const fetchFromApi = async ({
     response = await fetch(url.toString(), options);
   } catch (e) {
     if (!silentError) {
-      throw new FetchError(response?.status, e?.message ?? 'Unknown error');
+      const status = e?.message === 'Failed to fetch' ? 401 : response?.status;
+      throw new FetchError(status, e?.message ?? 'Unknown error');
     }
 
     return {


### PR DESCRIPTION
### Changed

- [Use status 401 on a 'Failed to fetch'](https://github.com/cultuurnet/udb3-frontend/commit/bcaf1025fd23e7774ed278efbf171f35cbc61453)
- [Use queryClient.fetchQuery to throw when it fails on the server](https://github.com/cultuurnet/udb3-frontend/commit/31867ffbbe3aa02db6112c69b1c7345b568d27be)
- [Redirect to login if server get of user fails](https://github.com/cultuurnet/udb3-frontend/commit/c02f66a394402c2922908f38eed01db15e2c1cac)

### Fixed

- failing user requests

---

Ticket: https://jira.uitdatabank.be/browse/III-5073
