### PR TITLE
III-4482 - Show CardSystems in Organizer step

### DIFF
--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -1,0 +1,46 @@
+import { UseQueryOptions } from 'react-query';
+
+import { fetchFromApi, isErrorObject } from '@/utils/fetchFromApi';
+
+import { useAuthenticatedQuery } from './authenticated-query';
+
+type CardSystem = {
+  id: number;
+  name: string;
+  distributionKeys?: any[];
+};
+
+type CardSystems = {
+  [key: string]: CardSystem;
+};
+
+const getCardSystemsForOrganizer = async ({ headers, id }: CardSystems) => {
+  const res = await fetchFromApi({
+    path: `/uitpas/organizers/${id.toString()}/cardSystems/`,
+    options: {
+      headers,
+    },
+  });
+  if (isErrorObject(res)) {
+    // eslint-disable-next-line no-console
+    return console.error(res);
+  }
+  return await res.json();
+};
+
+const useGetCardSystemsForOrganizerQuery = (
+  { req, queryClient, id },
+  configuration: UseQueryOptions = {},
+) =>
+  useAuthenticatedQuery({
+    req,
+    queryClient,
+    queryKey: ['uitpas'],
+    queryFn: getCardSystemsForOrganizer,
+    queryArguments: { id },
+    enabled: !!id,
+    ...configuration,
+  });
+
+export { useGetCardSystemsForOrganizerQuery };
+export type { CardSystem };

--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -17,9 +17,9 @@ type CardSystems = {
   [key: string]: CardSystem;
 };
 
-const getCardSystemForEvent = async ({ headers, id }) => {
+const getCardSystemForEvent = async ({ headers, eventId }) => {
   const res = await fetchFromApi({
-    path: `/uitpas/events/${id.toString()}/cardSystems/`,
+    path: `/uitpas/events/${eventId.toString()}/cardSystems/`,
     options: {
       headers,
     },

--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -32,7 +32,7 @@ const getCardSystemForEvent = async ({ headers, eventId }) => {
 };
 
 const useGetCardSystemForEventQuery = (
-  { req, queryClient, id },
+  { req, queryClient, eventId },
   configuration: UseQueryOptions = {},
 ) =>
   useAuthenticatedQuery({
@@ -40,14 +40,14 @@ const useGetCardSystemForEventQuery = (
     queryClient,
     queryKey: ['uitpas_events'],
     queryFn: getCardSystemForEvent,
-    queryArguments: { id },
-    enabled: !!id,
+    queryArguments: { eventId },
+    enabled: !!eventId,
     ...configuration,
   });
 
 const getCardSystemsForOrganizer = async ({ headers, organizerId }) => {
   const res = await fetchFromApi({
-    path: `/uitpas/organizers/${id.toString()}/cardSystems/`,
+    path: `/uitpas/organizers/${organizerId.toString()}/cardSystems/`,
     options: {
       headers,
     },
@@ -60,7 +60,7 @@ const getCardSystemsForOrganizer = async ({ headers, organizerId }) => {
 };
 
 const useGetCardSystemsForOrganizerQuery = (
-  { req, queryClient, id },
+  { req, queryClient, organizerId },
   configuration: UseQueryOptions = {},
 ) =>
   useAuthenticatedQuery({
@@ -68,14 +68,14 @@ const useGetCardSystemsForOrganizerQuery = (
     queryClient,
     queryKey: ['uitpas_organizers'],
     queryFn: getCardSystemsForOrganizer,
-    queryArguments: { id },
-    enabled: !!id,
+    queryArguments: { organizerId },
+    enabled: !!organizerId,
     ...configuration,
   });
 
-const addCardSystemToEvent = async ({ headers, id, cardSystemId }) =>
+const addCardSystemToEvent = async ({ headers, eventId, cardSystemId }) =>
   await fetchFromApi({
-    path: `/uitpas/events/${id.toString()}/cardSystems/${cardSystemId}`,
+    path: `/uitpas/events/${eventId.toString()}/cardSystems/${cardSystemId}`,
     options: {
       headers,
       method: 'PUT',
@@ -88,9 +88,9 @@ const useAddCardSystemToEventMutation = (configuration = {}) =>
     ...configuration,
   });
 
-const deleteCardSystemFromEvent = async ({ headers, id, cardSystemId }) =>
+const deleteCardSystemFromEvent = async ({ headers, eventId, cardSystemId }) =>
   await fetchFromApi({
-    path: `/uitpas/events/${id.toString()}/cardSystems/${cardSystemId}`,
+    path: `/uitpas/events/${eventId.toString()}/cardSystems/${cardSystemId}`,
     options: {
       headers,
       method: 'DELETE',
@@ -105,12 +105,12 @@ const useDeleteCardSystemFromEventMutation = (configuration = {}) =>
 
 const changeDistributionKey = async ({
   headers,
-  id,
+  eventId,
   cardSystemId,
   distributionKeyId,
 }) =>
   await fetchFromApi({
-    path: `/uitpas/events/${id.toString()}/cardSystems/${cardSystemId}/distributionKey/${distributionKeyId}`,
+    path: `/uitpas/events/${eventId.toString()}/cardSystems/${cardSystemId}/distributionKey/${distributionKeyId}`,
     options: {
       headers,
       method: 'PUT',

--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -103,8 +103,30 @@ const useDeleteCardSystemFromEventMutation = (configuration = {}) =>
     ...configuration,
   });
 
+const changeDistributionKey = async ({
+  headers,
+  id,
+  cardSystemId,
+  distributionKeyId,
+}) =>
+  await fetchFromApi({
+    path: `/uitpas/events/${id.toString()}/cardSystems/${cardSystemId}/distributionKey/${distributionKeyId}`,
+    options: {
+      headers,
+      method: 'PUT',
+    },
+  });
+
+const useChangeDistributionKeyMutation = (configuration = {}) =>
+  useAuthenticatedMutation({
+    mutationFn: changeDistributionKey,
+    ...configuration,
+  });
+
 export {
+  changeDistributionKey,
   useAddCardSystemToEventMutation,
+  useChangeDistributionKeyMutation,
   useDeleteCardSystemFromEventMutation,
   useGetCardSystemForEventQuery,
   useGetCardSystemsForOrganizerQuery,

--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -2,7 +2,10 @@ import { UseQueryOptions } from 'react-query';
 
 import { fetchFromApi, isErrorObject } from '@/utils/fetchFromApi';
 
-import { useAuthenticatedQuery } from './authenticated-query';
+import {
+  useAuthenticatedMutation,
+  useAuthenticatedQuery,
+} from './authenticated-query';
 
 type CardSystem = {
   id: number;
@@ -14,7 +17,7 @@ type CardSystems = {
   [key: string]: CardSystem;
 };
 
-const getCardSystemForEvent = async ({ headers, id }: CardSystems) => {
+const getCardSystemForEvent = async ({ headers, id }) => {
   const res = await fetchFromApi({
     path: `/uitpas/events/${id.toString()}/cardSystems/`,
     options: {
@@ -42,7 +45,7 @@ const useGetCardSystemForEventQuery = (
     ...configuration,
   });
 
-const getCardSystemsForOrganizer = async ({ headers, id }: CardSystems) => {
+const getCardSystemsForOrganizer = async ({ headers, id }) => {
   const res = await fetchFromApi({
     path: `/uitpas/organizers/${id.toString()}/cardSystems/`,
     options: {
@@ -70,5 +73,40 @@ const useGetCardSystemsForOrganizerQuery = (
     ...configuration,
   });
 
-export { useGetCardSystemForEventQuery, useGetCardSystemsForOrganizerQuery };
+const addCardSystemToEvent = async ({ headers, id, cardSystemId }) =>
+  await fetchFromApi({
+    path: `/uitpas/events/${id.toString()}/cardSystems/${cardSystemId}`,
+    options: {
+      headers,
+      method: 'PUT',
+    },
+  });
+
+const useAddCardSystemToEventMutation = (configuration = {}) =>
+  useAuthenticatedMutation({
+    mutationFn: addCardSystemToEvent,
+    ...configuration,
+  });
+
+const deleteCardSystemFromEvent = async ({ headers, id, cardSystemId }) =>
+  await fetchFromApi({
+    path: `/uitpas/events/${id.toString()}/cardSystems/${cardSystemId}`,
+    options: {
+      headers,
+      method: 'DELETE',
+    },
+  });
+
+const useDeleteCardSystemFromEventMutation = (configuration = {}) =>
+  useAuthenticatedMutation({
+    mutationFn: deleteCardSystemFromEvent,
+    ...configuration,
+  });
+
+export {
+  useAddCardSystemToEventMutation,
+  useDeleteCardSystemFromEventMutation,
+  useGetCardSystemForEventQuery,
+  useGetCardSystemsForOrganizerQuery,
+};
 export type { CardSystem };

--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -45,7 +45,7 @@ const useGetCardSystemForEventQuery = (
     ...configuration,
   });
 
-const getCardSystemsForOrganizer = async ({ headers, id }) => {
+const getCardSystemsForOrganizer = async ({ headers, organizerId }) => {
   const res = await fetchFromApi({
     path: `/uitpas/organizers/${id.toString()}/cardSystems/`,
     options: {

--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -14,6 +14,34 @@ type CardSystems = {
   [key: string]: CardSystem;
 };
 
+const getCardSystemForEvent = async ({ headers, id }: CardSystems) => {
+  const res = await fetchFromApi({
+    path: `/uitpas/events/${id.toString()}/cardSystems/`,
+    options: {
+      headers,
+    },
+  });
+  if (isErrorObject(res)) {
+    // eslint-disable-next-line no-console
+    return console.error(res);
+  }
+  return await res.json();
+};
+
+const useGetCardSystemForEventQuery = (
+  { req, queryClient, id },
+  configuration: UseQueryOptions = {},
+) =>
+  useAuthenticatedQuery({
+    req,
+    queryClient,
+    queryKey: ['uitpas_events'],
+    queryFn: getCardSystemForEvent,
+    queryArguments: { id },
+    enabled: !!id,
+    ...configuration,
+  });
+
 const getCardSystemsForOrganizer = async ({ headers, id }: CardSystems) => {
   const res = await fetchFromApi({
     path: `/uitpas/organizers/${id.toString()}/cardSystems/`,
@@ -35,12 +63,12 @@ const useGetCardSystemsForOrganizerQuery = (
   useAuthenticatedQuery({
     req,
     queryClient,
-    queryKey: ['uitpas'],
+    queryKey: ['uitpas_organizers'],
     queryFn: getCardSystemsForOrganizer,
     queryArguments: { id },
     enabled: !!id,
     ...configuration,
   });
 
-export { useGetCardSystemsForOrganizerQuery };
+export { useGetCardSystemForEventQuery, useGetCardSystemsForOrganizerQuery };
 export type { CardSystem };

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -257,7 +257,7 @@
         "title": "Organisator",
         "or_select_recent_used_organizer": "Oder wählen Sie eine Ihrer zuletzt verwendeten Organisationen aus",
         "uitpas_cardsystems": "UiTPAS Kartensysteme",
-        "uitpas_info_alert": "Dies ist ein UiTPAS-Organisator. Wählen Sie einen Preis, um eine bestimmte UiTPAS-Information hinzuzufügen."
+        "uitpas_info_no_price_alert": "Dies ist ein UiTPAS-Organisator. Fügen Sie einen <link1>Preis</link1> hinzu, um Ihre Veranstaltung als UiTPAS-Aktivität zu veröffentlichen"
       },
       "media": {
         "title": "Medien"

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -256,7 +256,8 @@
         "change": "Ändern Organisator",
         "title": "Organisator",
         "or_select_recent_used_organizer": "Oder wählen Sie eine Ihrer zuletzt verwendeten Organisationen aus",
-        "uitpas_cardsystems": "UiTPAS Kartensysteme"
+        "uitpas_cardsystems": "UiTPAS Kartensysteme",
+        "uitpas_info_alert": "Dies ist ein UiTPAS-Organisator. Wählen Sie einen Preis, um eine bestimmte UiTPAS-Information hinzuzufügen."
       },
       "media": {
         "title": "Medien"

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -257,6 +257,7 @@
         "title": "Organisator",
         "or_select_recent_used_organizer": "Oder wählen Sie eine Ihrer zuletzt verwendeten Organisationen aus",
         "uitpas_cardsystems": "UiTPAS Kartensysteme",
+        "uitpas_info": "Ihre Aktivität ist jetzt als UitPAS-Aktivität registriert",
         "uitpas_info_no_price_alert": "Dies ist ein UiTPAS-Organisator. Fügen Sie einen <link1>Preis</link1> hinzu, um Ihre Veranstaltung als UiTPAS-Aktivität zu veröffentlichen"
       },
       "media": {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -255,7 +255,8 @@
         "add_new_label": "Neuen Organisator hinzufügen: ",
         "change": "Ändern Organisator",
         "title": "Organisator",
-        "or_select_recent_used_organizer": "Oder wählen Sie eine Ihrer zuletzt verwendeten Organisationen aus"
+        "or_select_recent_used_organizer": "Oder wählen Sie eine Ihrer zuletzt verwendeten Organisationen aus",
+        "uitpas_cardsystems": "UiTPAS Kartensysteme"
       },
       "media": {
         "title": "Medien"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -256,7 +256,8 @@
         "add_new_label": "Ajouter un nouveau organisateur: ",
         "change": "Modifier l'organisateur",
         "title": "Organisateur",
-        "or_select_recent_used_organizer": "Ou sélectionnez l'une de vos organisations les plus récemment utilisées"
+        "or_select_recent_used_organizer": "Ou sélectionnez l'une de vos organisations les plus récemment utilisées",
+        "uitpas_cardsystems": "UiTPAS systèmes de cartes"
       },
       "media": {
         "title": "Médias"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -258,7 +258,8 @@
         "title": "Organisateur",
         "or_select_recent_used_organizer": "Ou sélectionnez l'une de vos organisations les plus récemment utilisées",
         "uitpas_cardsystems": "UiTPAS systèmes de cartes",
-        "uitpas_info_alert": "Ceci est un organisateur UiTPAS. Sélectionnez le prix afin d'ajouter de l'information spécifique concernant UiTPAS."
+        "uitpas_info": "Votre activité est désormais enregistrée en tant qu'activité UitPAS",
+        "uitpas_info_no_price_alert": "Ceci est un organisateur UiTPAS. Ajoutez <link1>un prix</link1> pour publier votre événement en tant qu'activité UiTPAS."
       },
       "media": {
         "title": "Médias"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -257,7 +257,8 @@
         "change": "Modifier l'organisateur",
         "title": "Organisateur",
         "or_select_recent_used_organizer": "Ou sélectionnez l'une de vos organisations les plus récemment utilisées",
-        "uitpas_cardsystems": "UiTPAS systèmes de cartes"
+        "uitpas_cardsystems": "UiTPAS systèmes de cartes",
+        "uitpas_info_alert": "Ceci est un organisateur UiTPAS. Sélectionnez le prix afin d'ajouter de l'information spécifique concernant UiTPAS."
       },
       "media": {
         "title": "Médias"

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -262,7 +262,8 @@
         "title": "Organisatie",
         "or_select_recent_used_organizer": "Of selecteer een van je laatst gebruikte organisaties",
         "uitpas_cardsystems": "UiTPAS Kaartsystemen",
-        "uitpas_info_alert": "Dit is een UiTPAS organisator. Selecteer een prijs om specifieke UiTPAS-informatie toe te voegen."
+        "uitpas_info": "Ihre Aktivität ist jetzt als UitPAS-Aktivität registriert",
+        "uitpas_info_no_price_alert": "Dit is een UiTPAS organisator. Voeg een <link1>prijs</link1> toe om je evenement te publiceren als UiTPAS activiteit"
       },
       "media": {
         "title": "Media"

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -261,7 +261,8 @@
         "change": "Wijzig organisatie",
         "title": "Organisatie",
         "or_select_recent_used_organizer": "Of selecteer een van je laatst gebruikte organisaties",
-        "uitpas_cardsystems": "UiTPAS Kaartsystemen"
+        "uitpas_cardsystems": "UiTPAS Kaartsystemen",
+        "uitpas_info_alert": "Dit is een UiTPAS organisator. Selecteer een prijs om specifieke UiTPAS-informatie toe te voegen."
       },
       "media": {
         "title": "Media"

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -260,7 +260,8 @@
         "add_new_label": "Voeg nieuwe organisator toe: ",
         "change": "Wijzig organisatie",
         "title": "Organisatie",
-        "or_select_recent_used_organizer": "Of selecteer een van je laatst gebruikte organisaties"
+        "or_select_recent_used_organizer": "Of selecteer een van je laatst gebruikte organisaties",
+        "uitpas_cardsystems": "UiTPAS Kaartsystemen"
       },
       "media": {
         "title": "Media"

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -262,7 +262,7 @@
         "title": "Organisatie",
         "or_select_recent_used_organizer": "Of selecteer een van je laatst gebruikte organisaties",
         "uitpas_cardsystems": "UiTPAS Kaartsystemen",
-        "uitpas_info": "Ihre Aktivität ist jetzt als UitPAS-Aktivität registriert",
+        "uitpas_info": "Je activiteit is nu geregistreerd als UiTPAS activiteit.",
         "uitpas_info_no_price_alert": "Dit is een UiTPAS organisator. Voeg een <link1>prijs</link1> toe om je evenement te publiceren als UiTPAS activiteit"
       },
       "media": {

--- a/src/pages/steps/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
@@ -137,6 +138,8 @@ const AdditionalInformationStep = ({
 }: Props) => {
   const queryClient = useQueryClient();
 
+  const router = useRouter();
+
   const invalidateEventQuery = useCallback(
     async (field: Field, shouldInvalidate: boolean) => {
       if (shouldInvalidate) {
@@ -149,20 +152,27 @@ const AdditionalInformationStep = ({
 
   const [tab, setTab] = useState('description');
 
+  const hashHandlerCallback = useCallback(() => {
+    const { hash } = window.location;
+    const newTab = hash.replace('#', '');
+    if (newTab && Object.values(Fields).some((field) => newTab === field)) {
+      setTab(newTab);
+    }
+  }, [setTab]);
+
   useEffect(() => {
-    const hashChangeHandler = () => {
-      const { hash } = window.location;
-      const newTab = hash.replace('#', '');
-      if (newTab && Object.values(Fields).some((field) => newTab === field)) {
-        setTab(newTab);
-      }
-    };
-    hashChangeHandler();
-    window.addEventListener('hashchange', hashChangeHandler);
+    hashHandlerCallback();
+
+    window.addEventListener('hashchange', hashHandlerCallback);
+
     return () => {
-      window.removeEventListener('hashchange', hashChangeHandler);
+      window.removeEventListener('hashchange', hashHandlerCallback);
     };
-  }, [tab, setTab]);
+  }, [hashHandlerCallback]);
+
+  const handleSelectTab = (tab: string) => {
+    window.location.hash = tab;
+  };
 
   const [completedFields, setCompletedFields] = useState<
     Record<Field, boolean>
@@ -181,7 +191,7 @@ const AdditionalInformationStep = ({
     <Stack {...getStackProps(props)}>
       <Tabs
         activeKey={tab}
-        onSelect={setTab}
+        onSelect={handleSelectTab}
         css={`
           .tab-content {
             padding-top: ${parseSpacing(3)};

--- a/src/pages/steps/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep.tsx
@@ -1,3 +1,4 @@
+import Router, { useRouter } from 'next/router';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
@@ -135,6 +136,8 @@ const AdditionalInformationStep = ({
   variant,
   ...props
 }: Props) => {
+  const { asPath, ...router } = useRouter();
+
   const queryClient = useQueryClient();
 
   const invalidateEventQuery = useCallback(
@@ -149,26 +152,15 @@ const AdditionalInformationStep = ({
 
   const [tab, setTab] = useState('description');
 
-  const hashHandlerCallback = useCallback(() => {
-    const { hash } = window.location;
-    const newTab = hash.replace('#', '');
-    if (newTab && Object.values(Fields).some((field) => newTab === field)) {
-      setTab(newTab);
-    }
-  }, [setTab]);
+  const [_path, hash] = asPath.split('#');
 
   useEffect(() => {
-    hashHandlerCallback();
-
-    window.addEventListener('hashchange', hashHandlerCallback);
-
-    return () => {
-      window.removeEventListener('hashchange', hashHandlerCallback);
-    };
-  }, [hashHandlerCallback]);
+    if (!hash || !Object.values(Fields).some((field) => hash === field)) return;
+    setTab(hash);
+  }, [hash]);
 
   const handleSelectTab = (tab: string) => {
-    window.location.hash = tab;
+    router.push({ hash: tab });
   };
 
   const [completedFields, setCompletedFields] = useState<

--- a/src/pages/steps/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
@@ -137,8 +136,6 @@ const AdditionalInformationStep = ({
   ...props
 }: Props) => {
   const queryClient = useQueryClient();
-
-  const router = useRouter();
 
   const invalidateEventQuery = useCallback(
     async (field: Field, shouldInvalidate: boolean) => {

--- a/src/pages/steps/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 
@@ -148,6 +148,21 @@ const AdditionalInformationStep = ({
   );
 
   const [tab, setTab] = useState('description');
+
+  useEffect(() => {
+    const hashChangeHandler = () => {
+      const { hash } = window.location;
+      const newTab = hash.replace('#', '');
+      if (newTab && Object.values(Fields).some((field) => newTab === field)) {
+        setTab(newTab);
+      }
+    };
+    hashChangeHandler();
+    window.addEventListener('hashchange', hashChangeHandler);
+    return () => {
+      window.removeEventListener('hashchange', hashChangeHandler);
+    };
+  }, [tab, setTab]);
 
   const [completedFields, setCompletedFields] = useState<
     Record<Field, boolean>

--- a/src/pages/steps/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep.tsx
@@ -160,7 +160,7 @@ const AdditionalInformationStep = ({
   }, [hash]);
 
   const handleSelectTab = (tab: string) => {
-    router.push({ hash: tab });
+    router.push({ hash: tab }, undefined, { shallow: true });
   };
 
   const [completedFields, setCompletedFields] = useState<

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from 'react-query';
 
 import {
   useAddOrganizerToEventMutation,
@@ -35,6 +36,7 @@ const OrganizerStep = ({
   ...props
 }: Props) => {
   const { i18n } = useTranslation();
+  const queryClient = useQueryClient();
 
   const getEventByIdQuery = useGetEventByIdQuery({ id: eventId });
 
@@ -85,14 +87,14 @@ const OrganizerStep = ({
 
   const addCardSystemToEventMutation = useAddCardSystemToEventMutation({
     onSuccess: () => {
-      console.log('added success');
+      queryClient.invalidateQueries('uitpas_events');
     },
   });
 
   const deleteCardSystemFromEventMutation = useDeleteCardSystemFromEventMutation(
     {
       onSuccess: () => {
-        console.log('delete success');
+        queryClient.invalidateQueries('uitpas_events');
       },
     },
   );
@@ -120,6 +122,7 @@ const OrganizerStep = ({
   const changeDistributionKey = useChangeDistributionKeyMutation({
     onSuccess: () => {
       console.log('change distributionkey success');
+      queryClient.invalidateQueries('uitpas_events');
     },
   });
 
@@ -130,7 +133,6 @@ const OrganizerStep = ({
     distributionKeyId: number;
     cardSystemId: number;
   }) => {
-    console.log({ distributionKeyId });
     changeDistributionKey.mutate({
       id: eventId,
       cardSystemId,

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -7,7 +7,14 @@ import {
   useGetEventByIdQuery,
 } from '@/hooks/api/events';
 import { useCreateOrganizerMutation } from '@/hooks/api/organizers';
+import {
+  CardSystem,
+  useGetCardSystemsForOrganizerQuery,
+} from '@/hooks/api/uitpas';
+import { CheckboxWithLabel } from '@/ui/CheckboxWithLabel';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
+import { Text } from '@/ui/Text';
+import { parseOfferId } from '@/utils/parseOfferId';
 
 import { OrganizerAddModal, OrganizerData } from '../OrganizerAddModal';
 import { TabContentProps } from './AdditionalInformationStep';
@@ -27,6 +34,16 @@ const OrganizerStep = ({
 
   // @ts-expect-error
   const organizer = getEventByIdQuery.data?.organizer;
+
+  // @ts-ignore
+  const getCardSystemsForOrganizerQuery = useGetCardSystemsForOrganizerQuery({
+    id: parseOfferId(organizer['@id']) ?? '',
+  });
+
+  // @ts-expect-error
+  const cardSystems = getCardSystemsForOrganizerQuery.data ?? [];
+
+  console.log({ cardSystems });
 
   const [isOrganizerAddModalVisible, setIsOrganizerAddModalVisible] = useState(
     false,
@@ -108,6 +125,14 @@ const OrganizerStep = ({
         }
         organizer={organizer}
       />
+      <Stack>
+        <Text fontWeight="bold">UiTPAS Kaartsystemen</Text>
+        {Object.values(cardSystems).map((cardSystem: CardSystem) => (
+          <CheckboxWithLabel key={cardSystem.id} name={cardSystem.name}>
+            {cardSystem.name}
+          </CheckboxWithLabel>
+        ))}
+      </Stack>
     </Stack>
   );
 };

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -16,6 +16,7 @@ import {
   useGetCardSystemForEventQuery,
   useGetCardSystemsForOrganizerQuery,
 } from '@/hooks/api/uitpas';
+import { Alert, AlertVariants } from '@/ui/Alert';
 import { CheckboxWithLabel } from '@/ui/CheckboxWithLabel';
 import { Inline } from '@/ui/Inline';
 import { Select } from '@/ui/Select';
@@ -176,6 +177,8 @@ const OrganizerStep = ({
     setIsOrganizerAddModalVisible(false);
   };
 
+  const isUitpasOrganizer = Object.values(cardSystems).length > 0;
+
   return (
     <Stack {...getStackProps(props)}>
       <OrganizerAddModal
@@ -199,11 +202,14 @@ const OrganizerStep = ({
         }
         organizer={organizer}
       />
-      {Object.values(cardSystems).length !== 0 && (
+      {isUitpasOrganizer && (
         <Stack>
           <Text fontWeight="bold" marginBottom={3}>
             {t('create.additionalInformation.organizer.uitpas_cardsystems')}
           </Text>
+          <Alert marginBottom={3} variant={AlertVariants.PRIMARY}>
+            {t('create.additionalInformation.organizer.uitpas_info_alert')}
+          </Alert>
           {Object.values(cardSystems).map((cardSystem: CardSystem) => (
             <Inline key={cardSystem.id} spacing={5} marginBottom={3}>
               <CheckboxWithLabel

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -43,7 +43,7 @@ const OrganizerStep = ({
 
   const getEventByIdQuery = useGetEventByIdQuery({ id: eventId });
 
-  // @ts-ignore
+  // @ts-expect-error
   const getCardSystemForEventQuery = useGetCardSystemForEventQuery({
     eventId,
   });
@@ -54,7 +54,7 @@ const OrganizerStep = ({
   const organizer = event?.organizer;
   const hasPriceInfo = (event?.priceInfo ?? []).length > 0;
 
-  // @ts-ignore
+  // @ts-expect-error
   const getCardSystemsForOrganizerQuery = useGetCardSystemsForOrganizerQuery({
     organizerId: organizer?.['@id']
       ? parseOfferId(organizer['@id'])

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -205,15 +205,15 @@ const OrganizerStep = ({
         organizer={organizer}
       />
       {isUitpasOrganizer && (
-        <Stack>
-          <Text fontWeight="bold" marginBottom={3}>
+        <Stack spacing={3}>
+          <Text fontWeight="bold">
             {t('create.additionalInformation.organizer.uitpas_cardsystems')}
           </Text>
-          <Alert marginBottom={3} variant={AlertVariants.PRIMARY}>
+          <Alert variant={AlertVariants.PRIMARY}>
             {t('create.additionalInformation.organizer.uitpas_info_alert')}
           </Alert>
           {Object.values(cardSystems).map((cardSystem: CardSystem) => (
-            <Inline key={cardSystem.id} spacing={5} marginBottom={3}>
+            <Inline key={cardSystem.id} spacing={5}>
               <CheckboxWithLabel
                 className="cardsystem-checkbox"
                 id={cardSystem.id}

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -35,7 +35,7 @@ const OrganizerStep = ({
   onSuccessfulChange,
   ...props
 }: Props) => {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
 
   const getEventByIdQuery = useGetEventByIdQuery({ id: eventId });
@@ -202,7 +202,7 @@ const OrganizerStep = ({
       {Object.values(cardSystems).length !== 0 && (
         <Stack>
           <Text fontWeight="bold" marginBottom={3}>
-            UiTPAS Kaartsystemen
+            {t('create.additionalInformation.organizer.uitpas_cardsystems')}
           </Text>
           {Object.values(cardSystems).map((cardSystem: CardSystem) => (
             <Inline key={cardSystem.id} spacing={5} marginBottom={3}>

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -86,14 +86,16 @@ const OrganizerStep = ({
   });
 
   const addCardSystemToEventMutation = useAddCardSystemToEventMutation({
-    onSuccess: () => {
+    onSuccess: (data) => {
+      onSuccessfulChange(data);
       queryClient.invalidateQueries('uitpas_events');
     },
   });
 
   const deleteCardSystemFromEventMutation = useDeleteCardSystemFromEventMutation(
     {
-      onSuccess: () => {
+      onSuccess: (data) => {
+        onSuccessfulChange(data);
         queryClient.invalidateQueries('uitpas_events');
       },
     },
@@ -120,8 +122,8 @@ const OrganizerStep = ({
   };
 
   const changeDistributionKey = useChangeDistributionKeyMutation({
-    onSuccess: () => {
-      console.log('change distributionkey success');
+    onSuccess: (data) => {
+      onSuccessfulChange(data);
       queryClient.invalidateQueries('uitpas_events');
     },
   });

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -9,6 +9,7 @@ import {
 import { useCreateOrganizerMutation } from '@/hooks/api/organizers';
 import {
   CardSystem,
+  useGetCardSystemForEventQuery,
   useGetCardSystemsForOrganizerQuery,
 } from '@/hooks/api/uitpas';
 import { CheckboxWithLabel } from '@/ui/CheckboxWithLabel';
@@ -32,12 +33,22 @@ const OrganizerStep = ({
 
   const getEventByIdQuery = useGetEventByIdQuery({ id: eventId });
 
+  // @ts-ignore
+  const getCardSystemForEventQuery = useGetCardSystemForEventQuery({
+    id: eventId,
+  });
+
   // @ts-expect-error
   const organizer = getEventByIdQuery.data?.organizer;
 
+  // @ts-expect-error
+  const cardSystemForEvent = getCardSystemForEventQuery.data;
+
+  const selectedCardSystems: CardSystem[] = Object.values(cardSystemForEvent);
+
   // @ts-ignore
   const getCardSystemsForOrganizerQuery = useGetCardSystemsForOrganizerQuery({
-    id: parseOfferId(organizer['@id']) ?? '',
+    id: '8f4a3a2b-fa24-43e9-a874-3cf1354dfaff',
   });
 
   // @ts-expect-error
@@ -128,7 +139,11 @@ const OrganizerStep = ({
       <Stack>
         <Text fontWeight="bold">UiTPAS Kaartsystemen</Text>
         {Object.values(cardSystems).map((cardSystem: CardSystem) => (
-          <CheckboxWithLabel key={cardSystem.id} name={cardSystem.name}>
+          <CheckboxWithLabel
+            key={cardSystem.id}
+            name={cardSystem.name}
+            checked={selectedCardSystems.some(({ id }) => cardSystem.id === id)}
+          >
             {cardSystem.name}
           </CheckboxWithLabel>
         ))}

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -175,12 +175,14 @@ const OrganizerStep = ({
           <Text fontWeight="bold">UiTPAS Kaartsystemen</Text>
           {Object.values(cardSystems).map((cardSystem: CardSystem) => (
             <CheckboxWithLabel
+              className="cardsystem-checkbox"
               id={cardSystem.id}
               key={cardSystem.id}
               name={cardSystem.name}
               checked={selectedCardSystems.some(
                 ({ id }) => cardSystem.id === id,
               )}
+              disabled={false}
               onToggle={(e) => handleToggleCardSystem(e, cardSystem.id)}
             >
               {cardSystem.name}

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -20,7 +20,7 @@ import { Event } from '@/types/Event';
 import { Alert, AlertVariants } from '@/ui/Alert';
 import { CheckboxWithLabel } from '@/ui/CheckboxWithLabel';
 import { Inline } from '@/ui/Inline';
-import { Link, LinkVariants } from '@/ui/Link';
+import { Link } from '@/ui/Link';
 import { Select } from '@/ui/Select';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
 import { Text } from '@/ui/Text';

--- a/src/pages/steps/OrganizerStep.tsx
+++ b/src/pages/steps/OrganizerStep.tsx
@@ -43,7 +43,7 @@ const OrganizerStep = ({
 
   // @ts-ignore
   const getCardSystemForEventQuery = useGetCardSystemForEventQuery({
-    id: eventId,
+    eventId,
   });
 
   // @ts-expect-error
@@ -51,7 +51,9 @@ const OrganizerStep = ({
 
   // @ts-ignore
   const getCardSystemsForOrganizerQuery = useGetCardSystemsForOrganizerQuery({
-    id: organizer?.['@id'] ? parseOfferId(organizer['@id']) : undefined,
+    organizerId: organizer?.['@id']
+      ? parseOfferId(organizer['@id'])
+      : undefined,
   });
 
   // @ts-expect-error
@@ -103,11 +105,11 @@ const OrganizerStep = ({
   );
 
   const handleAddCardSystemToEvent = (cardSystemId: number) => {
-    addCardSystemToEventMutation.mutate({ cardSystemId, id: eventId });
+    addCardSystemToEventMutation.mutate({ cardSystemId, eventId });
   };
 
   const handleDeleteCardSystemFromEvent = (cardSystemId: number) => {
-    deleteCardSystemFromEventMutation.mutate({ cardSystemId, id: eventId });
+    deleteCardSystemFromEventMutation.mutate({ cardSystemId, eventId });
   };
 
   const handleToggleCardSystem = (
@@ -137,7 +139,7 @@ const OrganizerStep = ({
     cardSystemId: number;
   }) => {
     changeDistributionKey.mutate({
-      id: eventId,
+      eventId,
       cardSystemId,
       distributionKeyId,
     });


### PR DESCRIPTION
### Added
- new `uitpas` api hook file
- show uitpas cardsystems in `OrganizerStep` component
- `AdditionalInformationStep`, select active tab based on **hash**  in url

<img width="939" alt="Screenshot 2022-11-02 at 16 09 30" src="https://user-images.githubusercontent.com/9402377/199527026-07a46a57-61b8-4572-a73f-363b1d371139.png">

Can be tested with following event (from acc):
- 5330a84f-7496-46a1-b60d-fa7d62ec5fb8

---
Ticket: https://jira.uitdatabank.be/browse/III-4482
