### PR TITLE
III-5069 - Online toggle layout improvements

### DIFF
--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -16,7 +16,7 @@ import { FormElement } from '@/ui/FormElement';
 import { Icon, Icons } from '@/ui/Icon';
 import { Inline } from '@/ui/Inline';
 import { Input } from '@/ui/Input';
-import { LabelPositions } from '@/ui/Label';
+import { LabelPositions, LabelVariants } from '@/ui/Label';
 import { RadioButtonTypes } from '@/ui/RadioButton';
 import { RadioButtonWithLabel } from '@/ui/RadioButtonWithLabel';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
@@ -128,7 +128,7 @@ const LocationStep = <TFormData extends FormDataUnion>({
               id="online-toggle"
               label={t('create.location.is_online.label')}
               labelPosition={LabelPositions.LEFT}
-              labelIsBold={false}
+              labelVariant={LabelVariants.NORMAL}
             />
           );
 

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -99,6 +99,30 @@ const LocationStep = <TFormData extends FormDataUnion>({
                     field.onChange(updatedValue);
                     onChange(updatedValue);
                   }}
+                  css={`
+                    .custom-switch .custom-control-label {
+                      padding-left: 2rem;
+                      padding-bottom: 1.5rem;
+                    }
+
+                    .custom-switch .custom-control-label::before {
+                      height: 1.5rem;
+                      width: calc(2rem + 0.75rem);
+                      border-radius: 3rem;
+                    }
+
+                    .custom-switch .custom-control-label::after {
+                      width: calc(1.5rem - 4px);
+                      height: calc(1.5rem - 4px);
+                      border-radius: calc(2rem - (1.5rem / 2));
+                    }
+
+                    .custom-switch
+                      .custom-control-input:checked
+                      ~ .custom-control-label::after {
+                      transform: translateX(calc(1.5rem - 0.25rem));
+                    }
+                  `}
                 />
               }
               id="online-toggle"

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -128,6 +128,7 @@ const LocationStep = <TFormData extends FormDataUnion>({
               id="online-toggle"
               label={t('create.location.is_online.label')}
               labelPosition={LabelPositions.LEFT}
+              labelIsBold={false}
             />
           );
 

--- a/src/ui/FormElement.tsx
+++ b/src/ui/FormElement.tsx
@@ -15,7 +15,7 @@ type Props = {
   ref?: Ref<HTMLElement>;
   label?: string;
   labelPosition?: Values<typeof LabelPositions>;
-  labelIsBold: boolean;
+  labelVariant?: Values<typeof LabelVariants>;
   error?: string;
   info?: ReactNode;
   loading?: boolean;
@@ -27,7 +27,7 @@ const FormElement = ({
   ref,
   label,
   labelPosition,
-  labelIsBold,
+  labelVariant,
   error,
   info,
   loading,
@@ -58,7 +58,7 @@ const FormElement = ({
     >
       {label && (
         <Label
-          variant={labelIsBold ? LabelVariants.BOLD : LabelVariants.NORMAL}
+          variant={labelVariant}
           htmlFor={id}
           {...(labelPosition === LabelPositions.LEFT
             ? { height: '36px', alignItems: 'center' }
@@ -91,7 +91,7 @@ const FormElement = ({
 
 FormElement.defaultProps = {
   labelPosition: LabelPositions.TOP,
-  labelIsBold: true,
+  labelVariant: LabelVariants.BOLD,
   loading: false,
 };
 

--- a/src/ui/FormElement.tsx
+++ b/src/ui/FormElement.tsx
@@ -58,7 +58,7 @@ const FormElement = ({
     >
       {label && (
         <Label
-          variant={labelIsBold && LabelVariants.BOLD}
+          variant={labelIsBold ? LabelVariants.BOLD : LabelVariants.NORMAL}
           htmlFor={id}
           {...(labelPosition === LabelPositions.LEFT
             ? { height: '36px', alignItems: 'center' }

--- a/src/ui/FormElement.tsx
+++ b/src/ui/FormElement.tsx
@@ -15,6 +15,7 @@ type Props = {
   ref?: Ref<HTMLElement>;
   label?: string;
   labelPosition?: Values<typeof LabelPositions>;
+  labelIsBold: boolean;
   error?: string;
   info?: ReactNode;
   loading?: boolean;
@@ -26,6 +27,7 @@ const FormElement = ({
   ref,
   label,
   labelPosition,
+  labelIsBold,
   error,
   info,
   loading,
@@ -56,7 +58,7 @@ const FormElement = ({
     >
       {label && (
         <Label
-          variant={LabelVariants.BOLD}
+          variant={labelIsBold && LabelVariants.BOLD}
           htmlFor={id}
           {...(labelPosition === LabelPositions.LEFT
             ? { height: '36px', alignItems: 'center' }
@@ -89,6 +91,7 @@ const FormElement = ({
 
 FormElement.defaultProps = {
   labelPosition: LabelPositions.TOP,
+  labelIsBold: true,
   loading: false,
 };
 


### PR DESCRIPTION
### Added
- `labelIsBold` prop in `FormElement`

### Changed
- Don't make the "online" label bold
- Make toggle bigger in LocationStep
https://codepen.io/nisharg/pen/mdJmywW

@simon-debruijn  maybe we should a seperate ui component for the toggle component in which we can integrate this custom css? I guess we always want the same size for the toggle...

Before:
<img width="425" alt="Schermafbeelding 2022-10-24 om 10 41 27" src="https://user-images.githubusercontent.com/9402377/201094793-aae2f4d2-1128-4568-9577-3090e0ff8357.png">

After:
<img width="567" alt="Screenshot 2022-11-10 at 13 38 18" src="https://user-images.githubusercontent.com/9402377/201095637-b126c7c0-b15d-4397-a0c5-8bd506503504.png">


---
Ticket: https://jira.uitdatabank.be/browse/III-5069 
