### PR TITLE
III-5067 - Filter out unused eventtypes from terms

### DIFF
--- a/src/hooks/api/terms.ts
+++ b/src/hooks/api/terms.ts
@@ -22,10 +22,21 @@ type EventType = Term & {
 
 type TermsData = { terms: EventType[] };
 
+const DISABLED_TERMS = [
+  '0.51.0.0.0', // Type onbepaald
+  '0.100.0.0.0', // Kijken en luisteren
+  '0.100.1.0.0', // Doen
+  '0.100.2.0.0', // Bezoeken
+];
+
 const getTerms = async (): Promise<TermsData> => {
   const { publicRuntimeConfig } = getConfig();
   const res = await fetch(`${publicRuntimeConfig.taxonomyUrl}/terms`);
-  return await res.json();
+  const { terms } = await res.json();
+  const allowedTerms = terms.filter(
+    (term: EventType) => !DISABLED_TERMS.includes(term.id),
+  );
+  return { terms: allowedTerms };
 };
 
 const useGetTermsQuery = (configuration = {}) =>


### PR DESCRIPTION
### Changed
- Filter out unused eventtypes from terms

**Before:**
<img width="1056" alt="Screenshot 2022-11-21 at 08 44 42" src="https://user-images.githubusercontent.com/9402377/202993748-00da2514-2973-40c8-a8c5-1cc2c527dafd.png">

**After:**
<img width="1132" alt="Screenshot 2022-11-21 at 08 44 14" src="https://user-images.githubusercontent.com/9402377/202993798-9a4be38e-d64d-4cc7-9df8-9501fe7c3035.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5067
