### PR TITLE
III-5095 - Image upload increase file size to 20MB

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -665,7 +665,7 @@
           "text": "Sie sind dabei, Bilder hinzuzufügen und öffentlich zu verteilen. Sie müssen alle anwendbaren Urheber- und Porträtrechte sowie alle anderen anwendbaren Gesetze respektieren. Sie können dafür gemäß <0></0> haftbar gemacht werden. Weitere Informationen zu <1></1>"
         }
       },
-      "file_requirements": "Die maximale Größe Ihres Bildes beträgt 5 MB und hat den Typ .jpeg, .gif oder .png",
+      "file_requirements": "Die maximale Größe Ihres Bildes beträgt {{maxFileSize}} MB und hat den Typ .jpeg, .gif oder .png",
       "title": "Bild hinzufügen",
       "validation_messages": {
         "copyrightHolder": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -665,7 +665,7 @@
           "text": "Vous êtes sur le point d'ajouter des images et de les diffuser publiquement. Vous devez respecter tous les droits d'auteur et de portrait applicables, ainsi que toutes les autres lois applicables. Vous pouvez en être tenu responsable, comme indiqué dans le <0></0>. Plus d'informations sur <1></1>"
         }
       },
-      "file_requirements": "La taille maximale de votre image est de 5 Mo et est de type .jpeg, .gif ou .png",
+      "file_requirements": "La taille maximale de votre image est de {{maxFileSize}} Mo et est de type .jpeg, .gif ou .png",
       "title": "Ajouter image",
       "validation_messages": {
         "copyrightHolder": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -670,7 +670,7 @@
           "text": "Je staat op het punt (een) afbeelding(en) toe te voegen en openbaar te verspreiden. Je dient daartoe alle geldende auteurs- en portretrechten te respecteren, alsook alle andere toepasselijke wetgeving. Je kan daarvoor aansprakelijk worden gehouden, zoals vastgelegd in de <0></0>. Meer informatie over <1></1>"
         }
       },
-      "file_requirements": "De maximale grootte van je afbeelding is 5MB en heeft als type .jpeg, .gif of .png",
+      "file_requirements": "De maximale grootte van je afbeelding is {{maxFileSize}}MB en heeft als type .jpeg, .gif of .png",
       "title": "Afbeelding toevoegen",
       "validation_messages": {
         "copyrightHolder": {

--- a/src/pages/steps/modals/PictureUploadModal.tsx
+++ b/src/pages/steps/modals/PictureUploadModal.tsx
@@ -31,7 +31,7 @@ type PictureUploadModalProps = {
   onSubmitValid: (data: FormData) => Promise<void>;
 };
 
-const MAX_FILE_SIZE = 5_000_000;
+const MAX_FILE_SIZE = 20_000_000;
 const ALLOWED_FILE_TYPES = ['png', 'jpg', 'jpeg', 'gif'];
 
 const getValue = getValueFromTheme('pictureUploadBox');

--- a/src/pages/steps/modals/PictureUploadModal.tsx
+++ b/src/pages/steps/modals/PictureUploadModal.tsx
@@ -128,7 +128,9 @@ const PictureUploadBox = forwardRef<HTMLInputElement, Props>(
           <Text variant={TextVariants.ERROR}>{error}</Text>
         </Stack>
         <Text variant={TextVariants.MUTED} textAlign="center">
-          {t('pictures.upload_modal.file_requirements')}
+          {t('pictures.upload_modal.file_requirements', {
+            maxFileSize: MAX_FILE_SIZE / 1_000_000,
+          })}
         </Text>
       </Stack>
     );


### PR DESCRIPTION
### Changed
- Image upload increase file size to 20MB

<img width="491" alt="Screenshot 2022-11-23 at 16 57 52" src="https://user-images.githubusercontent.com/9402377/203592108-fde3b848-210f-4245-8e6a-cef19f661e97.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5095
