### PR TITLE
III-5157 - Add days label to openinHoursModal

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -147,6 +147,7 @@
         "end_time": "Bis um",
         "start_time": "Aus",
         "title": "Öffnungszeiten",
+        "days": "Tage",
         "validation_messages": {
           "day_of_week": {
             "min": "Sie müssen mindestens 1 Wochentag angeben."

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -148,6 +148,7 @@
         "end_time": "Jusqu'à",
         "start_time": "De",
         "title": "Heures d 'ouverture",
+        "days": "Jours",
         "validation_messages": {
           "day_of_week": {
             "min": "Vous devez indiquer au moins 1 jour de la semaine."

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -148,6 +148,7 @@
         "end_time": "Tot",
         "start_time": "Van",
         "title": "Openingsuren",
+        "days": "Dagen",
         "validation_messages": {
           "day_of_week": {
             "min": "Je moet minstens 1 dag van de week aanduiden."

--- a/src/pages/steps/CalendarStep/CalendarOpeninghoursModal.tsx
+++ b/src/pages/steps/CalendarStep/CalendarOpeninghoursModal.tsx
@@ -175,27 +175,37 @@ const CalendarOpeninghoursModal = ({
         onClose();
       })}
     >
-      <Stack spacing={4} padding={4} alignItems="flex-start">
+      <Stack
+        spacing={4}
+        padding={4}
+        alignItems="flex-start"
+        justifyContent="center"
+      >
         {openingHours.map((openingHour, index) => (
           <Stack key={openingHour.id} flex={1}>
-            <Inline alignItems="center" spacing={5}>
-              <Inline spacing={4}>
-                {Object.values(DaysOfWeek).map((dayOfWeek) => (
-                  <CheckboxWithLabel
-                    key={`${openingHour.id}-${dayOfWeek}`}
-                    className="day-of-week-radio"
-                    id={`day-of-week-radio-${openingHour.id}-${dayOfWeek}`}
-                    name={dayOfWeek}
-                    checked={openingHour.dayOfWeek.includes(dayOfWeek)}
-                    disabled={false}
-                    onToggle={(e) =>
-                      handleToggleDaysOfWeek(e, dayOfWeek, openingHour.id)
-                    }
-                  >
-                    {t(`create.calendar.days.short.${dayOfWeek}`)}
-                  </CheckboxWithLabel>
-                ))}
-              </Inline>
+            <Inline alignItems="flex-end" spacing={5}>
+              <Stack spacing={3}>
+                <Text fontWeight="bold">
+                  {t('create.calendar.opening_hours_modal.days')}
+                </Text>
+                <Inline spacing={4}>
+                  {Object.values(DaysOfWeek).map((dayOfWeek) => (
+                    <CheckboxWithLabel
+                      key={`${openingHour.id}-${dayOfWeek}`}
+                      className="day-of-week-radio"
+                      id={`day-of-week-radio-${openingHour.id}-${dayOfWeek}`}
+                      name={dayOfWeek}
+                      checked={openingHour.dayOfWeek.includes(dayOfWeek)}
+                      disabled={false}
+                      onToggle={(e) =>
+                        handleToggleDaysOfWeek(e, dayOfWeek, openingHour.id)
+                      }
+                    >
+                      {t(`create.calendar.days.short.${dayOfWeek}`)}
+                    </CheckboxWithLabel>
+                  ))}
+                </Inline>
+              </Stack>
               <TimeSpanPicker
                 spacing={3}
                 id={`openinghours-row-timespan-${openingHour.id}`}


### PR DESCRIPTION
### Added
- days label to openinHoursModal
<img width="1013" alt="Screenshot 2023-01-04 at 13 54 42" src="https://user-images.githubusercontent.com/9402377/210559719-9245b6fb-53dd-4f86-94f7-ab39e1a86b8e.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5157
