### PR TITLE
III-5178 - Fix CalendarStep posting wrong data

### DIFF
--- a/src/pages/steps/CalendarStep/CalendarStep.tsx
+++ b/src/pages/steps/CalendarStep/CalendarStep.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -104,8 +103,6 @@ type CalendarStepProps = StepProps & { offerId?: string };
 
 const CalendarStep = ({ offerId, control, ...props }: CalendarStepProps) => {
   const { t } = useTranslation();
-  const { pathname } = useRouter();
-  const postfix = pathname.split('/').at(-1);
 
   const scope = useWatch({ control, name: 'scope' });
 

--- a/src/pages/steps/CalendarStep/CalendarStep.tsx
+++ b/src/pages/steps/CalendarStep/CalendarStep.tsx
@@ -148,11 +148,12 @@ const CalendarStep = ({ offerId, control, ...props }: CalendarStepProps) => {
   const handleChooseFixedDays = useCallback(chooseFixedDays, []);
 
   useEffect(() => {
-    if (postfix !== 'create') return;
-
-    calendarService.stop();
     calendarService.start();
-  }, [calendarService, postfix]);
+
+    return () => {
+      calendarService.stop();
+    };
+  }, [calendarService]);
 
   useEffect(() => {
     if (offerId) return;

--- a/src/pages/steps/CalendarStep/CalendarStep.tsx
+++ b/src/pages/steps/CalendarStep/CalendarStep.tsx
@@ -5,10 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { CalendarType } from '@/constants/CalendarType';
 import { OfferStatus } from '@/constants/OfferStatus';
 import { OfferTypes } from '@/constants/OfferType';
-import {
-  useChangeCalendarMutation,
-  useGetEventByIdQuery,
-} from '@/hooks/api/events';
+import { useGetEventByIdQuery } from '@/hooks/api/events';
 import { useChangeOfferCalendarMutation } from '@/hooks/api/offers';
 import { useGetPlaceByIdQuery } from '@/hooks/api/places';
 import { useToast } from '@/pages/manage/movies/useToast';
@@ -202,7 +199,7 @@ const CalendarStep = ({ offerId, control, ...props }: CalendarStepProps) => {
     title: '',
   });
 
-  const changeCalendarMutation = useChangeCalendarMutation({
+  const changeCalendarMutation = useChangeOfferCalendarMutation({
     onSuccess: () => {
       // only trigger toast in edit mode
       if (!offerId) return;
@@ -223,9 +220,10 @@ const CalendarStep = ({ offerId, control, ...props }: CalendarStepProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [context, calendarType]);
 
-  const submitCalendarMutation = async (formData: any) => {
+  const submitCalendarMutation = async (formData: any, offerId: string) => {
     await changeCalendarMutation.mutateAsync({
       id: offerId,
+      scope,
       ...formData,
     });
   };
@@ -237,7 +235,7 @@ const CalendarStep = ({ offerId, control, ...props }: CalendarStepProps) => {
     if (!offerId) return;
     if (!convertedStateToFormData) return;
 
-    handleSubmitCalendarMutation(convertedStateToFormData);
+    handleSubmitCalendarMutation(convertedStateToFormData, offerId);
   }, [convertedStateToFormData, handleSubmitCalendarMutation, offerId]);
 
   useEffect(() => {


### PR DESCRIPTION
### Changed

- [Correctly start and stop calendarMachine on mount and unmount of CalendarStep](https://github.com/cultuurnet/udb3-frontend/pull/505/commits/23de6225e2d1f1a49d5f94a8825de2580e259445)

### Removed

- [Remove unused variables](https://github.com/cultuurnet/udb3-frontend/pull/505/commits/a4df7b5463d43e1eb3c79a612aa32699e415fbcd)

### Fixed

- [Fix calendar mutation to wrong scope and with undefined offerId](https://github.com/cultuurnet/udb3-frontend/pull/505/commits/a1b0e0fd424ac84acfe2693cbdf260b2c9adddda)

---

Ticket: https://jira.uitdatabank.be/browse/III-5178
