### PR TITLE
III-5170 - Show Address in typeahead in PlaceStep

### DIFF
--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -7,14 +7,9 @@ import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
 import { EventTypes } from '@/constants/EventTypes';
-import { useChangeLocationMutation } from '@/hooks/api/events';
 import { useGetPlacesByQuery } from '@/hooks/api/places';
 import { SupportedLanguage } from '@/i18n/index';
-import type {
-  FormDataUnion,
-  StepProps,
-  StepsConfiguration,
-} from '@/pages/steps/Steps';
+import type { StepProps, StepsConfiguration } from '@/pages/steps/Steps';
 import { Address, AddressInternal } from '@/types/Address';
 import type { Place } from '@/types/Place';
 import type { Values } from '@/types/Values';
@@ -29,7 +24,6 @@ import { getValueFromTheme } from '@/ui/theme';
 import { isOneTimeSlotValid } from '@/ui/TimeTable';
 import { isNewEntry, NewEntry, Typeahead } from '@/ui/Typeahead';
 import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback';
-import { parseOfferId } from '@/utils/parseOfferId';
 import { valueToArray } from '@/utils/valueToArray';
 
 import { City } from '../CityPicker';

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -1,6 +1,7 @@
 import { TFunction } from 'i18next';
 import debounce from 'lodash/debounce';
 import { useMemo, useState } from 'react';
+import { Highlighter } from 'react-bootstrap-typeahead';
 import { Controller, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
@@ -131,6 +132,20 @@ const PlaceStep = ({
                         place.name[i18n.language] ??
                         place.name[place.mainLanguage]
                       }
+                      renderMenuItemChildren={(place: Place, { text }) => (
+                        <Stack>
+                          <Text>
+                            <Highlighter search={text}>
+                              {place.name[i18n.language] ??
+                                place.name[place.mainLanguage]}
+                            </Highlighter>
+                          </Text>
+                          <Text>
+                            {place.address[i18n.language]?.streetAddress ??
+                              place.address[place.mainLanguage]?.streetAddress}
+                          </Text>
+                        </Stack>
+                      )}
                       selected={valueToArray(selectedPlace as Place)}
                       maxWidth="43rem"
                       onChange={(places) => {

--- a/src/ui/Box.tsx
+++ b/src/ui/Box.tsx
@@ -125,6 +125,7 @@ type TypeaheadProps = {
         props: Record<string, unknown>,
       ) => boolean);
   newSelectionPrefix: string;
+  renderMenuItemChildren?: (option: unknown, { text }) => JSX.Element;
   inputProps: HTMLProps<HTMLInputElement>;
   defaultInputValue: string;
 };

--- a/src/ui/Typeahead.tsx
+++ b/src/ui/Typeahead.tsx
@@ -32,7 +32,7 @@ type TypeaheadProps<T> = {
   minLength?: number;
   inputType?: InputType;
   inputRequired?: boolean;
-  customFilter?: (option: unknown) => boolean;
+  customFilter?: (option: T) => boolean;
   onChange?: (value: (T | NewEntry)[]) => void;
   defaultInputValue?: string;
   allowNew?:

--- a/src/ui/Typeahead.tsx
+++ b/src/ui/Typeahead.tsx
@@ -25,13 +25,14 @@ type TypeaheadProps<T> = {
   name?: string;
   options: T[];
   labelKey: ((option: T) => string) | string;
+  renderMenuItemChildren?: (option: T, { text }) => JSX.Element;
   disabled?: boolean;
   placeholder?: string;
   emptyLabel?: string;
   minLength?: number;
   inputType?: InputType;
   inputRequired?: boolean;
-  customFilter?: (option: T) => boolean;
+  customFilter?: (option: unknown) => boolean;
   onChange?: (value: (T | NewEntry)[]) => void;
   defaultInputValue?: string;
   allowNew?:
@@ -64,6 +65,7 @@ const Typeahead: TypeaheadFunc = forwardRef(
       inputRequired,
       options,
       labelKey,
+      renderMenuItemChildren,
       disabled,
       placeholder,
       emptyLabel,
@@ -95,6 +97,7 @@ const Typeahead: TypeaheadFunc = forwardRef(
         newSelectionPrefix={newSelectionPrefix}
         options={options}
         labelKey={labelKey}
+        renderMenuItemChildren={renderMenuItemChildren}
         isLoading={false}
         disabled={disabled}
         className={className}


### PR DESCRIPTION
### Added
- renderMenuItemChildren as prop to `TypeAhead` and `Box`
- pass custom menuItemChildren to TypeAhead in PlaceStep

### Changed
- Show Address in typeahead in PlaceStep 

<img width="510" alt="Screenshot 2023-01-04 at 14 46 26" src="https://user-images.githubusercontent.com/9402377/210569562-e360df7e-29a6-428f-b009-9b478b2d4618.png">


---
Ticket: https://jira.uitdatabank.be/browse/III-5170
