### PR TITLE
III-5134 - PlaceStep adjust query to get relevant places

### DIFF
--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -147,6 +147,7 @@ const getPlacesByQuery = async ({
       disableDefaultFilters: 'true',
       isDuplicate: 'false',
       workflowStatus: 'DRAFT,READY_FOR_VALIDATION,APPROVED',
+      ['sort[created]']: 'desc',
     },
     options: {
       headers: headers as unknown as Record<string, string>,

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -146,6 +146,7 @@ const getPlacesByQuery = async ({
       embed: 'true',
       disableDefaultFilters: 'true',
       isDuplicate: 'false',
+      workflowStatus: 'DRAFT,READY_FOR_VALIDATION,APPROVED',
     },
     options: {
       headers: headers as unknown as Record<string, string>,

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -145,6 +145,7 @@ const getPlacesByQuery = async ({
       addressCountry,
       embed: 'true',
       disableDefaultFilters: 'true',
+      isDuplicate: 'false',
     },
     options: {
       headers: headers as unknown as Record<string, string>,

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -127,13 +127,12 @@ const getPlacesByQuery = async ({
   zip,
   addressCountry,
 }: Headers & GetPlacesByQueryArguments) => {
-  const nameString = name ? `name.\\*:*${name}*` : '';
   const termsString = terms.reduce(
     (acc, currentTerm) => `${acc}terms.id:${currentTerm}`,
     '',
   );
   const postalCodeString = zip ? `address.\\*postalCode:${zip}` : '';
-  const queryArguments = [nameString, termsString, postalCodeString].filter(
+  const queryArguments = [termsString, postalCodeString].filter(
     (argument) => !!argument,
   );
 
@@ -142,6 +141,7 @@ const getPlacesByQuery = async ({
     searchParams: {
       // eslint-disable-next-line no-useless-escape
       q: queryArguments.join(' AND '),
+      text: `*${name}*`,
       addressCountry,
       embed: 'true',
     },

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -5,6 +5,7 @@ import type { EventTypes } from '@/constants/EventTypes';
 import type { OfferStatus } from '@/constants/OfferStatus';
 import type { SupportedLanguages } from '@/i18n/index';
 import type { Address } from '@/types/Address';
+import { Country } from '@/types/Country';
 import { OpeningHours, Term } from '@/types/Offer';
 import type { Place } from '@/types/Place';
 import type { User } from '@/types/User';
@@ -116,6 +117,7 @@ type GetPlacesByQueryArguments = {
   name: string;
   terms: Array<Values<typeof EventTypes>>;
   zip?: string;
+  addressCountry?: Country;
 };
 
 const getPlacesByQuery = async ({
@@ -123,6 +125,7 @@ const getPlacesByQuery = async ({
   name,
   terms,
   zip,
+  addressCountry,
 }: Headers & GetPlacesByQueryArguments) => {
   const nameString = name ? `name.\\*:*${name}*` : '';
   const termsString = terms.reduce(
@@ -139,6 +142,7 @@ const getPlacesByQuery = async ({
     searchParams: {
       // eslint-disable-next-line no-useless-escape
       q: queryArguments.join(' AND '),
+      addressCountry,
       embed: 'true',
     },
     options: {
@@ -154,7 +158,7 @@ const getPlacesByQuery = async ({
 };
 
 const useGetPlacesByQuery = (
-  { name, terms, zip }: GetPlacesByQueryArguments,
+  { name, terms, zip, addressCountry }: GetPlacesByQueryArguments,
   configuration = {},
 ) =>
   useAuthenticatedQuery<Place[]>({
@@ -164,6 +168,7 @@ const useGetPlacesByQuery = (
       name,
       terms,
       zip,
+      addressCountry,
     },
     enabled: !!name || terms.length,
     ...configuration,

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -144,6 +144,7 @@ const getPlacesByQuery = async ({
       text: `*${name}*`,
       addressCountry,
       embed: 'true',
+      disableDefaultFilters: 'true',
     },
     options: {
       headers: headers as unknown as Record<string, string>,

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -2,7 +2,7 @@ import type { UseMutationOptions, UseQueryOptions } from 'react-query';
 
 import { CalendarType } from '@/constants/CalendarType';
 import type { EventTypes } from '@/constants/EventTypes';
-import type { OfferStatus } from '@/constants/OfferStatus';
+import { OfferStatus } from '@/constants/OfferStatus';
 import type { SupportedLanguages } from '@/i18n/index';
 import type { Address } from '@/types/Address';
 import { Country } from '@/types/Country';
@@ -149,6 +149,7 @@ const getPlacesByQuery = async ({
       workflowStatus: 'DRAFT,READY_FOR_VALIDATION,APPROVED',
       ['sort[created]']: 'desc',
       limit: '1000',
+      status: OfferStatus.AVAILABLE,
     },
     options: {
       headers: headers as unknown as Record<string, string>,

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -148,6 +148,7 @@ const getPlacesByQuery = async ({
       isDuplicate: 'false',
       workflowStatus: 'DRAFT,READY_FOR_VALIDATION,APPROVED',
       ['sort[created]']: 'desc',
+      limit: '1000',
     },
     options: {
       headers: headers as unknown as Record<string, string>,

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -331,6 +331,7 @@ const LocationStep = ({
                     maxWidth="28rem"
                     name={'location.place'}
                     municipality={municipality}
+                    country={country}
                     chooseLabel={chooseLabel}
                     placeholderLabel={placeholderLabel}
                     parentFieldValue={field.value}

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -13,6 +13,7 @@ import type {
   StepProps,
   StepsConfiguration,
 } from '@/pages/steps/Steps';
+import { Country } from '@/types/Country';
 import type { Place } from '@/types/Place';
 import type { Values } from '@/types/Values';
 import { Button, ButtonVariants } from '@/ui/Button';
@@ -37,6 +38,7 @@ type PlaceStepProps = StackProps &
   StepProps & {
     terms: Array<Values<typeof EventTypes>>;
     municipality?: City;
+    country?: Country;
     chooseLabel: (t: TFunction) => string;
     placeholderLabel: (t: TFunction) => string;
     parentOnChange?: (val: Place | NewEntry | undefined) => void;
@@ -54,6 +56,7 @@ const PlaceStep = ({
   onChange,
   terms,
   municipality,
+  country,
   chooseLabel,
   placeholderLabel,
   parentOnChange,

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -77,6 +77,7 @@ const PlaceStep = ({
       name: searchInput,
       terms,
       zip: municipality?.zip,
+      addressCountry: country,
     },
     { enabled: !!searchInput },
   );


### PR DESCRIPTION
### Changed
**PlaceStep**
- Use text parameter instead of name (so that when you search for "handelsbeurs" the location with name "ha concerts" is also found)
- Disable the default filters
- Show places with workflowStatus DRAFT, READY_FOR_VALIDATION and APPROVED
- Filter out places that are duplicates from the query (isDuplicate=false)
- Filter out places that are not in Belgium (addressCountry=BE)
- Filter out places that are temporarily or permanently closed (status=Available)
- Limit the amount of results to 1000
- Sort on created (descending)

<img width="388" alt="Screenshot 2023-01-04 at 16 21 59" src="https://user-images.githubusercontent.com/9402377/210589884-bdd1c5a9-2c6f-403a-8caa-8b4786d88be3.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5134
