### PR TITLE
III-5191 - Make button heights consistent with formInput heights

### DIFF
--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -12,7 +12,7 @@ import { getInlineProps, Inline } from './Inline';
 import { Link } from './Link';
 import { Spinner, SpinnerSizes, SpinnerVariants } from './Spinner';
 import { Text } from './Text';
-import { getValueFromTheme } from './theme';
+import { getGlobalFormInputHeight, getValueFromTheme } from './theme';
 
 const BootStrapVariants = {
   PRIMARY: 'primary',
@@ -44,6 +44,7 @@ const customCSS = css`
     padding: ${getValue('paddingY')} ${getValue('paddingX')};
     flex-shrink: 0;
     align-items: center;
+    min-height: ${getGlobalFormInputHeight};
 
     border: none;
     box-shadow: ${getValue('boxShadow.small')};
@@ -139,9 +140,11 @@ const customCSS = css`
   &.btn-danger {
     color: ${getValue('danger.color')};
     background-color: ${getValue('danger.backgroundColor')};
+    border: 1px solid ${getValue('danger.backgroundColor')};
 
     &.dropdown-toggle.dropdown-toggle-split {
       box-shadow: 2px 2px 3px 0px rgb(210 210 210 / 70%);
+      border: none;
       border-left: 1px solid ${getValue('danger.color')};
     }
 

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -1,10 +1,11 @@
 import type { ChangeEvent } from 'react';
 import { forwardRef } from 'react';
 import { Form } from 'react-bootstrap';
+import { css } from 'styled-components';
 
 import type { BoxProps } from './Box';
 import { Box, getBoxProps } from './Box';
-import { getGlobalBorderRadius } from './theme';
+import { getGlobalBorderRadius, getGlobalFormInputHeight } from './theme';
 
 const BaseInput = forwardRef<HTMLInputElement, any>((props, ref) => (
   <Box as="input" {...props} ref={ref} />
@@ -79,6 +80,7 @@ const Input = forwardRef(
       placeholder={placeholder}
       className={className}
       maxWidth="43rem"
+      height={getGlobalFormInputHeight}
       borderRadius={getGlobalBorderRadius}
       onInput={onChange}
       onBlur={onBlur}

--- a/src/ui/Typeahead.tsx
+++ b/src/ui/Typeahead.tsx
@@ -6,7 +6,11 @@ import { useTranslation } from 'react-i18next';
 import type { BoxProps } from './Box';
 import { Box, getBoxProps } from './Box';
 import { InputType } from './Input';
-import { getGlobalBorderRadius, getValueFromTheme } from './theme';
+import {
+  getGlobalBorderRadius,
+  getGlobalFormInputHeight,
+  getValueFromTheme,
+} from './theme';
 
 const getValue = getValueFromTheme('typeahead');
 
@@ -110,6 +114,8 @@ const Typeahead: TypeaheadFunc = forwardRef(
 
           .form-control {
             border-radius: ${getGlobalBorderRadius};
+            height: ${getGlobalFormInputHeight};
+            padding: 0.375rem 0.9rem;
           }
 
           .dropdown-item.active,

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -67,6 +67,9 @@ type BreakpointValues = Values<typeof Breakpoints>;
 const getGlobalBorderRadius = (props: { theme: Theme }) =>
   props.theme.borderRadius;
 
+const getGlobalFormInputHeight = (props: { theme: Theme }) =>
+  props.theme.formInputHeight;
+
 const theme = {
   colors,
   breakpoints: {
@@ -76,6 +79,7 @@ const theme = {
     [Breakpoints.L]: 1200,
   },
   borderRadius: '8px',
+  formInputHeight: 'calc(1.5rem + 0.9rem + 2px)',
   components: {
     alert: {
       borderRadius: '8px',
@@ -406,5 +410,12 @@ const getValueFromTheme =
   (component: string) => (path: string) => (props: { theme: Theme }) =>
     get(props.theme, `components.${component}.${path}`);
 
-export { Breakpoints, colors, getGlobalBorderRadius, getValueFromTheme, theme };
+export {
+  Breakpoints,
+  colors,
+  getGlobalBorderRadius,
+  getGlobalFormInputHeight,
+  getValueFromTheme,
+  theme,
+};
 export type { BreakpointValues, Theme };


### PR DESCRIPTION
### Added
- globalFormInputHeight to theme

### Changed
- Make inputfields bigger
- Make buttons same height as inputfields

<img width="933" alt="Screenshot 2023-01-05 at 14 32 12" src="https://user-images.githubusercontent.com/9402377/210795201-cab0d43d-395a-4529-b02d-33306f101379.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5191
