### PR TITLE
III-5207 - Remove unnecessary loading state next to place TypeAhead

### DIFF
--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -101,7 +101,6 @@ const LocationStep = ({
   reset,
   control,
   name,
-  loading,
   onChange,
   chooseLabel,
   placeholderLabel,
@@ -351,7 +350,6 @@ const LocationStep = ({
                       reset,
                       control,
                       name,
-                      loading,
                       onChange,
                       watch,
                     }}

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -147,7 +147,6 @@ const PlaceStep = ({
                         )
                       : undefined
                   }
-                  loading={loading}
                   Component={
                     <Typeahead
                       options={places}


### PR DESCRIPTION
### Removed
- unnecessary loading state next to place TypeAhead

---
Ticket: https://jira.uitdatabank.be/browse/III-5207
