### PR TITLE
III-5210 - Improve query to fetch organizers in TypeAhead

### DIFF
--- a/src/hooks/api/organizers.ts
+++ b/src/hooks/api/organizers.ts
@@ -27,7 +27,7 @@ type GetOrganizersArgumentsByQuery = {
 };
 
 const useGetOrganizersByQueryQuery = (
-  { req, queryClient, q }: AuthenticatedQueryOptions<{ q?: string }> = {},
+  { req, queryClient, name }: AuthenticatedQueryOptions<{ name?: string }> = {},
   configuration: UseQueryOptions = {},
 ) =>
   useAuthenticatedQuery<{ member: Organizer[] }>({
@@ -37,9 +37,11 @@ const useGetOrganizersByQueryQuery = (
     queryFn: getOrganizers,
     queryArguments: {
       embed: true,
-      q,
+      name,
+      start: '0',
+      limit: '10',
     },
-    enabled: !!q,
+    enabled: !!name,
     ...configuration,
   });
 
@@ -47,21 +49,27 @@ type GetOrganizersArguments = {
   headers: Headers;
   embed?: string;
   website?: string;
-  q?: string;
+  name?: string;
+  limit?: string;
+  start?: string;
 };
 
 const getOrganizers = async ({
   headers,
   website,
-  q,
+  name,
   embed,
+  limit,
+  start,
 }: GetOrganizersArguments) => {
   const res = await fetchFromApi({
     path: '/organizers',
     searchParams: {
       embed: `${embed}`,
       ...(website && { website }),
-      ...(q && { q }),
+      ...(name && { name }),
+      ...(limit && { limit }),
+      ...(start && { start }),
     },
     options: {
       headers,

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -178,7 +178,7 @@ const OrganizerPicker = ({
   const [organizerSearchInput, setOrganizerSearchInput] = useState('');
 
   const getOrganizersByQueryQuery = useGetOrganizersByQueryQuery(
-    { q: organizerSearchInput },
+    { name: organizerSearchInput },
     { enabled: !!organizerSearchInput },
   );
 


### PR DESCRIPTION
### Changed
- Improve query to fetch organizers in TypeAhead
<img width="418" alt="Screenshot 2023-01-12 at 14 01 50" src="https://user-images.githubusercontent.com/9402377/212075284-cb9b3196-9b5d-4fdd-91e7-91da0fc909d0.png">


---
Ticket: https://jira.uitdatabank.be/browse/III-5210
