### PR TITLE
III-5158 - Fix scroll create form followup

### DIFF
--- a/src/pages/create/OfferForm.tsx
+++ b/src/pages/create/OfferForm.tsx
@@ -113,6 +113,42 @@ const parseLocationAttributes = (
   };
 };
 
+const useRerenderStepsForm = () => {
+  const router = useRouter();
+
+  const [rerenderTrigger, setRerenderTrigger] = useState(
+    Math.random().toString(),
+  );
+
+  useEffect(() => {
+    const handleRouteChange = (
+      newPathname: string,
+      options: Record<string, unknown>,
+    ) => {
+      if (options.shallow === true) {
+        return;
+      }
+
+      // Only rerender StepsForm if you go from edit to create page
+      if (
+        !['/create', '/manage/movies/create'].some((prefix) =>
+          newPathname.startsWith(prefix),
+        )
+      ) {
+        return;
+      }
+
+      setRerenderTrigger(Math.random().toString());
+    };
+
+    router.events.on('beforeHistoryChange', handleRouteChange);
+
+    return () => router.events.off('beforeHistoryChange', handleRouteChange);
+  }, [router.asPath, router.events]);
+
+  return rerenderTrigger;
+};
+
 const OfferForm = () => {
   const { t, i18n } = useTranslation();
   const { query, asPath, ...router } = useRouter();
@@ -231,39 +267,11 @@ const OfferForm = () => {
     };
   };
 
-  const [rerenderTrigger, setRerenderTrigger] = useState(
-    Math.random().toString(),
-  );
-
-  useEffect(() => {
-    const handleRouteChange = (
-      newPathname: string,
-      options: Record<string, unknown>,
-    ) => {
-      if (options.shallow === true) {
-        return;
-      }
-
-      // Only rerender StepsForm if you go from edit to create page
-      if (
-        !['/create', '/manage/movies/create'].some((prefix) =>
-          newPathname.startsWith(prefix),
-        )
-      ) {
-        return;
-      }
-
-      setRerenderTrigger(Math.random().toString());
-    };
-
-    router.events.on('beforeHistoryChange', handleRouteChange);
-
-    return () => router.events.off('beforeHistoryChange', handleRouteChange);
-  }, [asPath, router.events]);
+  const rerenderTrigger = useRerenderStepsForm();
 
   return (
     <StepsForm
-      key={rerenderTrigger} // needed to re-render the form between create and edit.
+      key={rerenderTrigger}
       title={t(`create.title`)}
       scope={scope}
       convertFormDataToOffer={convertFormDataWithCalendarToOffer}

--- a/src/pages/create/OfferForm.tsx
+++ b/src/pages/create/OfferForm.tsx
@@ -281,18 +281,9 @@ const OfferForm = () => {
         title: '',
       }}
       configurations={[
-        {
-          ...scopeStepConfiguration,
-          stepProps: {
-            scope,
-          },
-        },
-        {
-          ...typeAndThemeStepConfiguration,
-        },
-        {
-          ...calendarStepConfiguration,
-        },
+        scopeStepConfiguration,
+        typeAndThemeStepConfiguration,
+        calendarStepConfiguration,
         locationStepConfiguration,
         nameAndAgeRangeStepConfiguration,
         {

--- a/src/pages/create/OfferForm.tsx
+++ b/src/pages/create/OfferForm.tsx
@@ -115,23 +115,23 @@ const parseLocationAttributes = (
 
 const OfferForm = () => {
   const { t, i18n } = useTranslation();
-  const { query, pathname, ...router } = useRouter();
+  const { query, asPath, ...router } = useRouter();
 
   const scope = useMemo(() => {
     if (
-      pathname.startsWith('/events') ||
-      pathname.startsWith('/manage/movies') ||
+      asPath.startsWith('/events') ||
+      asPath.startsWith('/manage/movies') ||
       query.scope === OfferTypes.EVENTS
     ) {
       return OfferTypes.EVENTS;
     }
 
-    if (pathname.startsWith('/places') || query.scope === OfferTypes.PLACES) {
+    if (asPath.startsWith('/places') || query.scope === OfferTypes.PLACES) {
       return OfferTypes.PLACES;
     }
 
     return undefined;
-  }, [pathname, query.scope]);
+  }, [asPath, query.scope]);
 
   const convertOfferToFormData = (offer: Offer) => {
     return {
@@ -244,7 +244,7 @@ const OfferForm = () => {
         return;
       }
 
-      if (newPathname === pathname) {
+      if (newPathname === asPath) {
         return;
       }
 
@@ -255,10 +255,10 @@ const OfferForm = () => {
       setRerenderTrigger(Math.random().toString());
     };
 
-    router.events.on('routeChangeStart', handleRouteChange);
+    router.events.on('beforeHistoryChange', handleRouteChange);
 
-    return () => router.events.off('routeChangeStart', handleRouteChange);
-  }, [pathname, router.events]);
+    return () => router.events.off('beforeHistoryChange', handleRouteChange);
+  }, [asPath, router.events]);
 
   return (
     <StepsForm
@@ -283,7 +283,9 @@ const OfferForm = () => {
       configurations={[
         {
           ...scopeStepConfiguration,
-          defaultValue: scope,
+          stepProps: {
+            scope,
+          },
         },
         {
           ...typeAndThemeStepConfiguration,

--- a/src/pages/create/OfferForm.tsx
+++ b/src/pages/create/OfferForm.tsx
@@ -244,11 +244,12 @@ const OfferForm = () => {
         return;
       }
 
-      if (newPathname === asPath) {
-        return;
-      }
-
-      if (!newPathname.startsWith('/create')) {
+      // Only rerender StepsForm if you go from edit to create page
+      if (
+        !['/create', '/manage/movies/create'].some((prefix) =>
+          newPathname.startsWith(prefix),
+        )
+      ) {
         return;
       }
 

--- a/src/pages/create/OfferForm.tsx
+++ b/src/pages/create/OfferForm.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { OfferTypes } from '@/constants/OfferType';
@@ -18,7 +18,7 @@ import {
 } from '@/pages/steps/machines/calendarMachine';
 import { nameAndAgeRangeStepConfiguration } from '@/pages/steps/NameAndAgeRangeStep';
 import { scopeStepConfiguration } from '@/pages/steps/ScopeStep';
-import { StepsForm } from '@/pages/steps/StepsForm';
+import { StepsForm, useRerenderStepsForm } from '@/pages/steps/StepsForm';
 import { Address, AddressInternal } from '@/types/Address';
 import { Country } from '@/types/Country';
 import { AttendanceMode, isEvent } from '@/types/Event';
@@ -111,42 +111,6 @@ const parseLocationAttributes = (
       ...(isPlace(offer) && { streetAndNumber: streetAddress }),
     },
   };
-};
-
-const useRerenderStepsForm = () => {
-  const router = useRouter();
-
-  const [rerenderTrigger, setRerenderTrigger] = useState(
-    Math.random().toString(),
-  );
-
-  useEffect(() => {
-    const handleRouteChange = (
-      newPathname: string,
-      options: Record<string, unknown>,
-    ) => {
-      if (options.shallow === true) {
-        return;
-      }
-
-      // Only rerender StepsForm if you go from edit to create page
-      if (
-        !['/create', '/manage/movies/create'].some((prefix) =>
-          newPathname.startsWith(prefix),
-        )
-      ) {
-        return;
-      }
-
-      setRerenderTrigger(Math.random().toString());
-    };
-
-    router.events.on('beforeHistoryChange', handleRouteChange);
-
-    return () => router.events.off('beforeHistoryChange', handleRouteChange);
-  }, [router.asPath, router.events]);
-
-  return rerenderTrigger;
 };
 
 const OfferForm = () => {

--- a/src/pages/create/OfferForm.tsx
+++ b/src/pages/create/OfferForm.tsx
@@ -18,7 +18,10 @@ import {
 } from '@/pages/steps/machines/calendarMachine';
 import { nameAndAgeRangeStepConfiguration } from '@/pages/steps/NameAndAgeRangeStep';
 import { scopeStepConfiguration } from '@/pages/steps/ScopeStep';
-import { StepsForm, useRerenderStepsForm } from '@/pages/steps/StepsForm';
+import {
+  StepsForm,
+  useRerenderTriggerStepsForm,
+} from '@/pages/steps/StepsForm';
 import { Address, AddressInternal } from '@/types/Address';
 import { Country } from '@/types/Country';
 import { AttendanceMode, isEvent } from '@/types/Event';
@@ -231,7 +234,7 @@ const OfferForm = () => {
     };
   };
 
-  const rerenderTrigger = useRerenderStepsForm();
+  const rerenderTrigger = useRerenderTriggerStepsForm();
 
   return (
     <StepsForm

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -14,7 +14,7 @@ import {
 import { typeAndThemeStepConfiguration } from '@/pages/steps/EventTypeAndThemeStep';
 import { placeStepConfiguration } from '@/pages/steps/PlaceStep';
 import { productionStepConfiguration } from '@/pages/steps/ProductionStep';
-import { StepsForm } from '@/pages/steps/StepsForm';
+import { StepsForm, useRerenderStepsForm } from '@/pages/steps/StepsForm';
 import {
   convertTimeTableToSubEvents,
   timeTableStepConfiguration,
@@ -114,10 +114,12 @@ const MovieForm = (props) => {
     };
   };
 
+  const rerenderTrigger = useRerenderStepsForm();
+
   return (
     <StepsForm
       {...props}
-      key={parts[parts.length - 1]} // needed to re-render the form between create and edit.
+      key={rerenderTrigger}
       scope={OfferTypes.EVENTS}
       label="udb-filminvoer"
       convertFormDataToOffer={convertFormDataToOffer}

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -14,7 +14,10 @@ import {
 import { typeAndThemeStepConfiguration } from '@/pages/steps/EventTypeAndThemeStep';
 import { placeStepConfiguration } from '@/pages/steps/PlaceStep';
 import { productionStepConfiguration } from '@/pages/steps/ProductionStep';
-import { StepsForm, useRerenderStepsForm } from '@/pages/steps/StepsForm';
+import {
+  StepsForm,
+  useRerenderTriggerStepsForm,
+} from '@/pages/steps/StepsForm';
 import {
   convertTimeTableToSubEvents,
   timeTableStepConfiguration,
@@ -114,7 +117,7 @@ const MovieForm = (props) => {
     };
   };
 
-  const rerenderTrigger = useRerenderStepsForm();
+  const rerenderTrigger = useRerenderTriggerStepsForm();
 
   return (
     <StepsForm

--- a/src/pages/manage/movies/MovieForm.tsx
+++ b/src/pages/manage/movies/MovieForm.tsx
@@ -19,6 +19,7 @@ import {
   convertTimeTableToSubEvents,
   timeTableStepConfiguration,
 } from '@/pages/steps/TimeTableStep';
+import { Countries } from '@/types/Country';
 import type { Event } from '@/types/Event';
 import type { SubEvent } from '@/types/Offer';
 import type { Place } from '@/types/Place';
@@ -148,6 +149,7 @@ const MovieForm = (props) => {
         {
           ...placeStepConfiguration,
           stepProps: {
+            country: Countries.BE,
             terms: [EventTypes.Bioscoop],
             chooseLabel: () => t('movies.create.actions.choose_cinema'),
             placeholderLabel: (t) => t('movies.create.cinema.placeholder'),

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -89,11 +89,12 @@ const PlaceStep = ({
     ],
   );
 
-  const place = useWatch({ control, name: 'location.place' });
+  const locationPlace = useWatch({ control, name: 'location.place' });
+  const place = useWatch({ control, name: 'place' });
 
   const selectedPlace = parentFieldValue
     ? parentFieldValue.place ?? undefined
-    : place;
+    : locationPlace ?? place;
 
   const getPlaceName = (
     name: Place['name'],
@@ -189,6 +190,7 @@ const PlaceStep = ({
                           parentOnChange(place);
                           return;
                         }
+
                         field.onChange(place);
                         onChange(place);
                       }}

--- a/src/pages/steps/ScopeStep.tsx
+++ b/src/pages/steps/ScopeStep.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { Controller, ControllerRenderProps, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -8,6 +9,7 @@ import { parseSpacing } from '@/ui/Box';
 import { getInlineProps, Inline, InlineProps } from '@/ui/Inline';
 import { ToggleBox } from '@/ui/ToggleBox';
 
+import { Scope } from '../create/OfferForm';
 import { FormDataUnion, StepProps, StepsConfiguration } from './Steps';
 
 const IconEvent = ({ width }: { width: string }) => {
@@ -101,7 +103,7 @@ const IconLocation = ({ width }: { width: string }) => {
   );
 };
 
-type Props = InlineProps & StepProps & { offerId?: string };
+type Props = InlineProps & StepProps & { offerId?: string; scope?: Scope };
 
 const ScopeStep = ({
   offerId,
@@ -109,10 +111,15 @@ const ScopeStep = ({
   name,
   setValue,
   resetField,
+  scope,
   ...props
 }: Props) => {
   const { t } = useTranslation();
   const { replace } = useRouter();
+
+  useEffect(() => {
+    setValue('scope', scope);
+  }, [scope, setValue]);
 
   const handleChangeScope = (
     field: ControllerRenderProps<FormDataUnion, string & Path<FormDataUnion>>,

--- a/src/pages/steps/StepsForm.tsx
+++ b/src/pages/steps/StepsForm.tsx
@@ -26,6 +26,42 @@ import { Steps, StepsConfiguration } from './Steps';
 
 const getValue = getValueFromTheme('createPage');
 
+const useRerenderStepsForm = () => {
+  const router = useRouter();
+
+  const [rerenderTrigger, setRerenderTrigger] = useState(
+    Math.random().toString(),
+  );
+
+  useEffect(() => {
+    const handleRouteChange = (
+      newPathname: string,
+      options: Record<string, unknown>,
+    ) => {
+      if (options.shallow === true) {
+        return;
+      }
+
+      // Only rerender StepsForm if you go from edit to create page
+      if (
+        !['/create', '/manage/movies/create'].some((prefix) =>
+          newPathname.startsWith(prefix),
+        )
+      ) {
+        return;
+      }
+
+      setRerenderTrigger(Math.random().toString());
+    };
+
+    router.events.on('beforeHistoryChange', handleRouteChange);
+
+    return () => router.events.off('beforeHistoryChange', handleRouteChange);
+  }, [router.asPath, router.events]);
+
+  return rerenderTrigger;
+};
+
 type StepsFormProps = {
   configurations: Array<StepsConfiguration>;
   convertFormDataToOffer: (data: any) => any;
@@ -197,4 +233,4 @@ const StepsForm = ({
   );
 };
 
-export { StepsForm };
+export { StepsForm, useRerenderStepsForm };

--- a/src/pages/steps/StepsForm.tsx
+++ b/src/pages/steps/StepsForm.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { OfferType, OfferTypes } from '@/constants/OfferType';
@@ -54,8 +54,9 @@ const StepsForm = ({
 
   // eventId is set after adding (saving) the event
   // or when entering the page from the edit route
-  const [offerId, setOfferId] = useState(
-    ((query.eventId as string) || (query.placeId as string)) ?? '',
+  const offerId = useMemo(
+    () => ((query.eventId as string) || (query.placeId as string)) ?? '',
+    [query.eventId, query.placeId],
   );
 
   const isMovieForm = pathname.startsWith('/manage/movies');
@@ -75,8 +76,7 @@ const StepsForm = ({
       const url = isMovieForm
         ? `/manage/movies/${offerId}/edit`
         : `/${scope}/${offerId}/edit`;
-      await push(url, undefined, { shallow: true });
-      setOfferId(offerId);
+      await push(url, undefined, { scroll: false });
     },
     convertFormDataToOffer,
     label,

--- a/src/pages/steps/StepsForm.tsx
+++ b/src/pages/steps/StepsForm.tsx
@@ -109,6 +109,14 @@ const StepsForm = ({
 
   const footerStatus = useFooterStatus({ offer, form });
 
+  // scroll effect
+  useEffect(() => {
+    if (([FooterStatus.HIDDEN] as typeof footerStatus[]).includes(footerStatus))
+      return;
+    const main = document.querySelector('main');
+    main.scroll({ left: 0, top: main.scrollHeight, behavior: 'smooth' });
+  }, [footerStatus]);
+
   return (
     <Page>
       <Page.Title spacing={3} alignItems="center">

--- a/src/pages/steps/StepsForm.tsx
+++ b/src/pages/steps/StepsForm.tsx
@@ -26,7 +26,7 @@ import { Steps, StepsConfiguration } from './Steps';
 
 const getValue = getValueFromTheme('createPage');
 
-const useRerenderStepsForm = () => {
+const useRerenderTriggerStepsForm = () => {
   const router = useRouter();
 
   const [rerenderTrigger, setRerenderTrigger] = useState(
@@ -233,4 +233,4 @@ const StepsForm = ({
   );
 };
 
-export { StepsForm, useRerenderStepsForm };
+export { StepsForm, useRerenderTriggerStepsForm };

--- a/src/pages/steps/hooks/useFooterStatus.ts
+++ b/src/pages/steps/hooks/useFooterStatus.ts
@@ -50,14 +50,6 @@ const useFooterStatus = ({ offer, form }) => {
     isPlaceDirty,
   ]);
 
-  // scroll effect
-  useEffect(() => {
-    if (footerStatus === FooterStatus.HIDDEN) return;
-
-    const main = document.querySelector('main');
-    main.scroll({ left: 0, top: main.scrollHeight, behavior: 'smooth' });
-  }, [footerStatus]);
-
   return footerStatus;
 };
 


### PR DESCRIPTION
### Changed

- [Move scroll effect to StepsForm to scroll after re-render](https://github.com/cultuurnet/udb3-frontend/commit/829baa89473450f3e27499be4242541bfa438ce1)
- [Always infer offerId from url](https://github.com/cultuurnet/udb3-frontend/commit/aafba01cca9e07a4b3e8939fba57493dae7a6f28)
- [Use custom rerenderTrigger instead of url to trigger re-render](https://github.com/cultuurnet/udb3-frontend/commit/dc6751a4a108bf92ce105e114e2a26a54146f43b)

### Fixed

- [Fix movie form place step](https://github.com/cultuurnet/udb3-frontend/commit/0ed4cb3091663e502fcf5133e1467683c8ad5ab4)
- [Fix scope value not resetting on click create link](https://github.com/cultuurnet/udb3-frontend/commit/2558f27c85cb3367859e8d518ef222f470bb79a5)

---

Ticket: https://jira.uitdatabank.be/browse/III-5158
