### PR TITLE
III-5213 -  missing border to VideoUploadBox

### DIFF
--- a/src/pages/PictureUploadBox.tsx
+++ b/src/pages/PictureUploadBox.tsx
@@ -87,12 +87,7 @@ const PictureUploadBox = ({
       {...getStackProps(props)}
     >
       <Inline>
-        <Title
-          size={3}
-          css={`
-            min-height: 26px;
-          `}
-        >
+        <Title size={3} minHeight="26px">
           {t('pictures.title')}
         </Title>
       </Inline>

--- a/src/pages/PictureUploadBox.tsx
+++ b/src/pages/PictureUploadBox.tsx
@@ -86,7 +86,16 @@ const PictureUploadBox = ({
       onDragOver={(e) => e.preventDefault()}
       {...getStackProps(props)}
     >
-      <Title size={3}>{t('pictures.title')}</Title>
+      <Inline>
+        <Title
+          size={3}
+          css={`
+            min-height: 26px;
+          `}
+        >
+          {t('pictures.title')}
+        </Title>
+      </Inline>
       <Stack
         flex={1}
         spacing={4}

--- a/src/pages/VideoUploadBox.tsx
+++ b/src/pages/VideoUploadBox.tsx
@@ -77,6 +77,9 @@ const VideoUploadBox = ({
         borderRadius={getGlobalBorderRadius}
         backgroundColor={getValue('backgroundColor')}
         justifyContent="center"
+        css={`
+          border: 1px solid ${getValue('borderColor')};
+        `}
       >
         <Stack
           spacing={4}


### PR DESCRIPTION
### Added
- missing border to `VideoUploadBox`
- min-height to PictureUploadBox so boxes are aligned vertically

**Before**:
![Screenshot 2023-01-12 at 12 09 26](https://user-images.githubusercontent.com/9402377/213137895-f6effc6d-301d-493c-82ca-b35285ceca41.png)

**After**:
<img width="1131" alt="Screenshot 2023-01-18 at 10 45 11" src="https://user-images.githubusercontent.com/9402377/213137991-1a7bea82-7f29-47a1-b61a-55a2e2ea07c4.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5213
