### PR TITLE
III-5238 - Show broken vimeo video thumbnails

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
@@ -18,6 +18,7 @@ import { Inline } from '@/ui/Inline';
 import { getStackProps, Stack } from '@/ui/Stack';
 import { Breakpoints } from '@/ui/theme';
 import { parseOfferId } from '@/utils/parseOfferId';
+import { isFulfilledResult } from '@/utils/promise';
 
 import type { ImageType } from '../../PictureUploadBox';
 import { PictureUploadBox } from '../../PictureUploadBox';
@@ -196,8 +197,8 @@ const MediaStep = ({
     const data = await Promise.allSettled(convertAllVideoUrlsPromises);
 
     const successVideos = data
-      .filter((res) => res.status === 'fulfilled')
-      .map((res: PromiseFulfilledResult<VideoEnriched>) => res.value);
+      .filter(isFulfilledResult)
+      .map((res) => res.value);
 
     setVideos(successVideos);
   };

--- a/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
@@ -193,9 +193,13 @@ const MediaStep = ({
       return enrichedVideo;
     });
 
-    const data = await Promise.all(convertAllVideoUrlsPromises);
+    const data = await Promise.allSettled(convertAllVideoUrlsPromises);
 
-    setVideos(data);
+    const successVideos = data
+      .filter((res) => res.status === 'fulfilled')
+      .map((res: PromiseFulfilledResult<VideoEnriched>) => res.value);
+
+    setVideos(successVideos);
   };
 
   useEffect(() => {

--- a/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
@@ -168,7 +168,7 @@ const MediaStep = ({
         : urlParts[urlParts.length - 1];
 
       const response = await fetch(
-        `http://vimeo.com/api/v2/video/${videoId}.json`,
+        `https://vimeo.com/api/v2/video/${videoId}.json`,
       );
 
       const data = await response.json();

--- a/src/utils/promise.ts
+++ b/src/utils/promise.ts
@@ -1,0 +1,7 @@
+const isFulfilledResult = <T>(
+  res: PromiseSettledResult<T>,
+): res is PromiseFulfilledResult<T> => {
+  return res.status === 'fulfilled';
+};
+
+export { isFulfilledResult };


### PR DESCRIPTION
### Changed
- Use https to get vimeo thumbnails 
- Show successful video thumbnails instead of 0 if an api calls fails

### Fixed
- `Blocked loading mixed active content "http://vimeo.com/api/v2/video/117686240.json"`

---
Ticket: https://jira.uitdatabank.be/browse/III-5238
