### PR TITLE
III-5243 - Fix missing youtube thubmnail

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
@@ -147,9 +147,9 @@ const MediaStep = ({
       const youtubeImagePath = 'https://i.ytimg.com/vi_webp/';
 
       if (videoUrl.includes('v=')) {
-        return `${youtubeImagePath}${
-          videoUrl.split('v=')[1]
-        }/maxresdefault.webp`;
+        const urlParams = new URL(videoUrl).searchParams;
+        const videoId = urlParams.get('v');
+        return `${youtubeImagePath}${videoId}/maxresdefault.webp`;
       }
 
       if (videoUrl.includes('youtu.be/')) {


### PR DESCRIPTION
### Fixed
- Fix youtube thubmnail when share url has multiple query params

<img width="1440" alt="Screenshot 2023-01-19 at 14 14 44" src="https://user-images.githubusercontent.com/9402377/213453387-b84c1171-24c0-4253-8bb1-be31c9386fdb.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5243
