### PR TITLE
III-5278 - Don't open modal when clicking on change link

### DIFF
--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -128,6 +128,7 @@ const PlaceStep = ({
                     field.onChange(updatedValue);
                     onChange(updatedValue);
                     field.onBlur();
+                    setIsPlaceAddModalVisible(false);
                   }}
                 />
                 <FormElement


### PR DESCRIPTION
### Changed
- Don't open modal when clicking on change link,  `setIsPlaceAddModalVisible` to `false` on confirm as well

### Fixed
- bug which would trigger the addPlaceModal when clicking on the edit location link

---
Ticket: https://jira.uitdatabank.be/browse/III-5279
