### PR TITLE
Refactor PriceInformation form to optimistic updates

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,10 +1,20 @@
 import type { CSSProp } from 'styled-components';
 
 import type { Theme } from '@/ui/theme';
+import { AnySchema } from 'yup/lib/schema';
+import Lazy from 'yup/lib/Lazy';
+import { AnyObject, Maybe } from 'yup/lib/types';
+import { TypeOf } from 'yup/lib/util/types';
 
 declare module 'react' {
   interface Attributes {
     css?: CSSProp<Theme>;
+  }
+}
+
+declare module 'yup' {
+  interface ArraySchema<T> {
+    uniqueName(): this;
   }
 }
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,10 +1,6 @@
 import type { CSSProp } from 'styled-components';
 
 import type { Theme } from '@/ui/theme';
-import { AnySchema } from 'yup/lib/schema';
-import Lazy from 'yup/lib/Lazy';
-import { AnyObject, Maybe } from 'yup/lib/types';
-import { TypeOf } from 'yup/lib/util/types';
 
 declare module 'react' {
   interface Attributes {

--- a/global.d.ts
+++ b/global.d.ts
@@ -8,12 +8,6 @@ declare module 'react' {
   }
 }
 
-declare module 'yup' {
-  interface ArraySchema<T> {
-    uniqueName(): this;
-  }
-}
-
 declare global {
   interface Window {
     clipboardData: DataTransfer;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-cookie": "^4.0.3",
     "react-datepicker": "^4.8.0",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^7.40.0",
+    "react-hook-form": "^7.43.0",
     "react-i18next": "^11.7.3",
     "react-query": "^3.2.0",
     "react-router": "^5.2.0",

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -155,6 +155,7 @@ const PriceInformation = ({
     trigger,
     control,
     setValue,
+    getValues,
     handleSubmit,
     formState: { errors },
     watch,
@@ -170,11 +171,10 @@ const PriceInformation = ({
     () => (errors?.rates ?? []).filter((error: any) => error !== undefined),
     [errors.rates],
   );
-  console.log(errorRates);
 
   const hasGlobalError = useMemo(() => errorRates.length > 0, [errorRates]);
   const duplicateNameError = useMemo(
-    () => errorRates.find((error) => error.type === 'unique')?.message,
+    () => errorRates.find((error) => error.type === 'uniqueName')?.message,
     [errorRates],
   );
   const hasUitpasError = useMemo(
@@ -234,7 +234,7 @@ const PriceInformation = ({
       addPriceInfoMutation.mutateAsync({
         id: offerId,
         scope,
-        priceInfo: rates.map((rate: Rate) => ({
+        priceInfo: getValues('rates').map((rate: Rate) => ({
           ...rate,
           price: parseFloat(rate.price.replace(',', '.')),
         })),
@@ -251,7 +251,6 @@ const PriceInformation = ({
   }, [updatePriceInfo, hasGlobalError]);
 
   const isPriceFree = (price: string) => ['0', '0,0', '0,00'].includes(price);
-
   const hasUitpasPrices = useMemo(
     () => rates.some((rate) => rate.category === PriceCategories.UITPAS),
     [rates],
@@ -352,6 +351,7 @@ const PriceInformation = ({
                   variant={ButtonVariants.DANGER}
                   onClick={async () => {
                     ratesField.remove(index);
+                    await trigger();
                     await onSubmit();
                   }}
                 >

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import { throttle } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -27,7 +28,6 @@ import { Input } from '@/ui/Input';
 import { getStackProps, Stack } from '@/ui/Stack';
 import { Text, TextVariants } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
-import { throttle } from 'lodash';
 
 const PRICE_CURRENCY: string = 'EUR';
 
@@ -206,13 +206,10 @@ const PriceInformation = ({
     1000,
   );
 
-  const onSubmit = useCallback(async () => {
-    if (hasGlobalError) {
-      return;
-    }
-
-    await updatePriceInfo();
-  }, [updatePriceInfo, hasGlobalError]);
+  const onSubmit = useCallback(
+    () => (hasGlobalError ? null : updatePriceInfo()),
+    [updatePriceInfo, hasGlobalError],
+  );
 
   const isPriceFree = (price: string) => ['0', '0,0', '0,00'].includes(price);
   const hasUitpasPrices = useMemo(

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -133,6 +133,20 @@ const PriceInformation = ({
   // @ts-expect-error
   const offer: Event | Place | undefined = getOfferByIdQuery.data;
 
+  const {
+    register,
+    control,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<FormData>({
+    mode: 'onBlur',
+    reValidateMode: 'onBlur',
+    resolver: yupResolver(schema),
+    shouldFocusError: false,
+    defaultValues: { rates: [] },
+  });
   useEffect(() => {
     let newPriceInfo = offer?.priceInfo ?? [];
     const hasUitpasLabel = offer?.organizer
@@ -164,21 +178,6 @@ const PriceInformation = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [offer?.priceInfo, offer?.mainLanguage, i18n.language]);
 
-  const {
-    register,
-    control,
-    setValue,
-    trigger,
-    formState: { errors, dirtyFields },
-    getValues,
-    handleSubmit,
-  } = useForm<FormData>({
-    mode: 'onBlur',
-    resolver: yupResolver(schema),
-    reValidateMode: 'onBlur',
-    shouldFocusError: false,
-    defaultValues: defaultPriceInfoValues,
-  });
 
   useEffect(() => {
     if (!priceInfo?.length) return;

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -83,26 +83,6 @@ const shouldHaveAName = (value: any): boolean => {
   return !!value[i18n.language];
 };
 
-yup.addMethod(yup.array, 'uniqueName', function () {
-  return this.test('uniqueName', function (prices) {
-    const priceNames = prices.map((item) => item.name[i18n.language]);
-    const errors = priceNames.map((priceName, index) => {
-      const indexOf = priceNames.indexOf(priceName);
-      if (indexOf !== -1 && indexOf !== index) {
-        return this.createError({
-          path: `${this.path}.${index}`,
-          message: i18n.t(
-            'create.additionalInformation.price_info.duplicate_name_error',
-            { priceName },
-          ),
-        });
-      }
-    });
-
-    return new ValidationError(errors.filter(Boolean));
-  });
-});
-
 const schema = yup
   .object()
   .shape({
@@ -125,7 +105,23 @@ const schema = yup
           priceCurrency: yup.string(),
         }),
       )
-      .uniqueName(),
+      .test('uniqueName', function (prices) {
+        const priceNames = prices.map((item) => item.name[i18n.language]);
+        const errors = priceNames.map((priceName, index) => {
+          const indexOf = priceNames.indexOf(priceName);
+          if (indexOf !== -1 && indexOf !== index) {
+            return this.createError({
+              path: `${this.path}.${index}`,
+              message: i18n.t(
+                'create.additionalInformation.price_info.duplicate_name_error',
+                { priceName },
+              ),
+            });
+          }
+        });
+
+        return new ValidationError(errors.filter(Boolean));
+      }),
   })
   .required();
 

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -147,6 +147,12 @@ const PriceInformation = ({
     shouldFocusError: false,
     defaultValues: { rates: [] },
   });
+  const ratesField = useFieldArray({ name: 'rates', control });
+  const rates = watch('rates');
+  const controlledRates = ratesField.fields.map((field, index) => ({
+    ...field,
+    ...rates[index],
+  }));
   useEffect(() => {
     let newPriceInfo = offer?.priceInfo ?? [];
     const hasUitpasLabel = offer?.organizer
@@ -183,8 +189,6 @@ const PriceInformation = ({
     if (!priceInfo?.length) return;
     setValue('rates', [...priceInfo]);
   }, [priceInfo, setValue]);
-
-  const rates = useWatch({ control, name: 'rates' });
 
   const addPriceInfoMutation = useAddOfferPriceInfoMutation({
     onSuccess: () => {
@@ -263,7 +267,7 @@ const PriceInformation = ({
     );
   };
 
-  const handleDuplicateNameError = (priceName: string): void => {
+  const handleDuplicateNameError = (priceName: string) =>
     setDuplicateNameError(
       t('create.additionalInformation.price_info.duplicate_name_error', {
         priceName,
@@ -334,9 +338,9 @@ const PriceInformation = ({
           {t('create.additionalInformation.price_info.uitpas_info')}
         </Alert>
       )}
-      {rates.map((rate, index) => (
+      {controlledRates.map((rate, index) => (
         <Inline
-          key={`rate_${index}`}
+          key={`rate_${rate.id}`}
           paddingTop={3}
           paddingBottom={3}
           css={`

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -213,43 +213,6 @@ const PriceInformation = ({
     });
   };
 
-  const handleClickAddRate = () => {
-    setValue('rates', [
-      ...rates,
-      {
-        name: {
-          [i18n.language]: '',
-        },
-        price: '',
-        category: PriceCategories.TARIFF,
-        priceCurrency: PRICE_CURRENCY,
-      },
-    ]);
-  };
-
-  const handleClickDeleteRate = async (id: number): Promise<void> => {
-    const ratesWithDeletedItem = [
-      ...rates.filter((_rate, index) => id !== index),
-    ];
-
-    setValue('rates', ratesWithDeletedItem);
-    await trigger();
-
-    const selectedRate = rates[id];
-
-    // if rate exists on priceInfo, also delete it from API
-
-    const existsInCurrentData = priceInfo.some(
-      (priceInfoItem) =>
-        selectedRate.name[i18n.language] ===
-          priceInfoItem.name[i18n.language] &&
-        selectedRate.price === priceInfoItem.price,
-    );
-
-    if (existsInCurrentData) {
-      await handlePriceInfoSubmitValid(ratesWithDeletedItem);
-    }
-  };
 
   const getDuplicateName = () => {
     const seenRates = [];
@@ -417,7 +380,10 @@ const PriceInformation = ({
                   iconName={Icons.TRASH}
                   spacing={3}
                   variant={ButtonVariants.DANGER}
-                  onClick={() => handleClickDeleteRate(index)}
+                  onClick={async () => {
+                    ratesField.remove(index);
+                    await onSubmit();
+                  }}
                 >
                   {t('create.additionalInformation.price_info.delete')}
                 </Button>
@@ -456,7 +422,17 @@ const PriceInformation = ({
         </Alert>
       )}
       <Inline marginTop={3}>
-        <Button onClick={handleClickAddRate} variant={ButtonVariants.SECONDARY}>
+        <Button
+          onClick={() =>
+            ratesField.append({
+              name: { [i18n.language]: '' },
+              price: '',
+              category: PriceCategories.TARIFF,
+              priceCurrency: PRICE_CURRENCY,
+            })
+          }
+          variant={ButtonVariants.SECONDARY}
+        >
           {t('create.additionalInformation.price_info.add')}
         </Button>
       </Inline>

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -189,6 +189,37 @@ const PriceInformation = ({
     ...rates[index],
   }));
 
+  const addPriceInfoMutation = useAddOfferPriceInfoMutation({
+    onSuccess: () => setTimeout(() => onSuccessfulChange(), 1000),
+  });
+
+  const updatePriceInfo = throttle(
+    () =>
+      addPriceInfoMutation.mutateAsync({
+        id: offerId,
+        scope,
+        priceInfo: getValues('rates').map((rate: Rate) => ({
+          ...rate,
+          price: parseFloat(rate.price.replace(',', '.')),
+        })),
+      }),
+    1000,
+  );
+
+  const onSubmit = useCallback(async () => {
+    if (hasGlobalError) {
+      return;
+    }
+
+    await updatePriceInfo();
+  }, [updatePriceInfo, hasGlobalError]);
+
+  const isPriceFree = (price: string) => ['0', '0,0', '0,00'].includes(price);
+  const hasUitpasPrices = useMemo(
+    () => rates.some((rate) => rate.category === PriceCategories.UITPAS),
+    [rates],
+  );
+
   useEffect(() => {
     let newPriceInfo = offer?.priceInfo ?? [];
     const hasUitpasLabel = offer?.organizer
@@ -224,37 +255,6 @@ const PriceInformation = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [offer?.priceInfo, offer?.mainLanguage, i18n.language]);
-
-  const addPriceInfoMutation = useAddOfferPriceInfoMutation({
-    onSuccess: () => setTimeout(() => onSuccessfulChange(), 1000),
-  });
-
-  const updatePriceInfo = throttle(
-    () =>
-      addPriceInfoMutation.mutateAsync({
-        id: offerId,
-        scope,
-        priceInfo: getValues('rates').map((rate: Rate) => ({
-          ...rate,
-          price: parseFloat(rate.price.replace(',', '.')),
-        })),
-      }),
-    1000,
-  );
-
-  const onSubmit = useCallback(async () => {
-    if (hasGlobalError) {
-      return;
-    }
-
-    await updatePriceInfo();
-  }, [updatePriceInfo, hasGlobalError]);
-
-  const isPriceFree = (price: string) => ['0', '0,0', '0,00'].includes(price);
-  const hasUitpasPrices = useMemo(
-    () => rates.some((rate) => rate.category === PriceCategories.UITPAS),
-    [rates],
-  );
 
   return (
     <Stack

--- a/yarn.lock
+++ b/yarn.lock
@@ -11157,10 +11157,10 @@ react-helmet-async@^1.0.7:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@^7.40.0:
-  version "7.40.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.40.0.tgz#62bc939dddca88522cd7f5135b6603192ccf7e17"
-  integrity sha512-0rokdxMPJs0k9bvFtY6dbcSydyNhnZNXCR49jgDr/aR03FDHFOK6gfh8ccqB3fl696Mk7lqh04xdm+agqWXKSw==
+react-hook-form@^7.43.0:
+  version "7.43.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.43.0.tgz#d0c19b5c4ec561fbf8d652869ccb513c11c772e7"
+  integrity sha512-/rVEz7T0gLdSFwPqutJ1kn2e0sQNyb9ci/hmwEYr2YG0KF/LSuRLvNrf9QWJM+gj88CjDpDW5Bh/1AD7B2+z9Q==
 
 react-i18next@^11.7.3:
   version "11.8.12"


### PR DESCRIPTION
### Changed

- Refactor PriceInformation form to optimistic updates

---

Ticket: https://jira.uitdatabank.be/browse/III-5256

It wasn't originally my intention to refactor the form entirely, but due to the multiple tickets revolving around issues with out of sync states and such, and the suggestion to move to optimistic updates in the ticket, I felt it was perhaps the way to go so I went all in.

The diff is a bit scary but the crux of the changes are the following:
1. I moved a bunch of things up and down to group related things more closely together. 
2. I moved the "unique name" validation to Yup to be able to use the same logic for all errors and validation.
3. I removed most local states in order to use the form's data as state directly (which was the crux of most out of sync issues)
4. I made the whole form submit on blur (with a throttle to avoid conflicting requests) which removed the need to manually watch for changes and submit. I still manually submit when removing/appending rows since for some reason that doesn't trigger `react-hook-form`'s `watch` but that could be a mistake on my part somewhere
5. I didn't put back the automatic price formatting as I wasn't sure this was intentional before? and it felt a bit weird UX wise to have the fields change under your hands but I can likely add it back if need be.

Here is a small video of the form acting (in theory) correctly:

https://user-images.githubusercontent.com/1321596/216367348-328488a0-78f8-484b-b8a4-32c694324fd6.mp4

Considering this is a refactor I'd be happy to have some more hands testing this to be sure there aren't edge cases not working


![1ea2bdef-35ee-4700-8454-dc3b1ed439b3_text](https://user-images.githubusercontent.com/1321596/216367747-3a06d5ac-d1db-4f08-98be-ff687569b649.gif)

