### PR TITLE
Fix warning icon not appearing on Price tab when picking UiTPas organizer

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -247,7 +247,7 @@ const PriceInformation = ({
       ratesField.replace(newPriceInfo);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [offer?.priceInfo, offer?.mainLanguage, i18n.language]);
+  }, [offer?.organizer, offer?.priceInfo, offer?.mainLanguage, i18n.language]);
 
   return (
     <Stack


### PR DESCRIPTION
### Fixed

- Fix warning icon not appearing on Price tab when picking UiTPas organizer

---

Ticket: https://jira.uitdatabank.be/browse/III-5276
