### PR TITLE
Only validate price names when it isn't a UiTPAS price (whose name is…

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -95,9 +95,18 @@ const schema = yup
               en: yup.string(),
               de: yup.string(),
             })
-            .test(`name-is-required`, 'name is required', shouldHaveAName)
-            .test(`name-is-not-uitpas`, 'should not be uitpas', isNotUitpas)
-            .required(),
+            .when('category', {
+              is: (category) => category !== PriceCategories.UITPAS,
+              then: (schema) =>
+                schema
+                  .test(`name-is-required`, 'name is required', shouldHaveAName)
+                  .test(
+                    `name-is-not-uitpas`,
+                    'should not be uitpas',
+                    isNotUitpas,
+                  )
+                  .required(),
+            }),
           category: yup.string(),
           price: yup.string().matches(PRICE_REGEX).required(),
           priceCurrency: yup.string(),


### PR DESCRIPTION
### Fixed

- Only validate price names when it isn't a UiTPAS price (whose name is automatic)

---

@brampauwelyn I tried the `getLanguageObjectOrFallback` solution but because in my case both the UI's language and the event's `mainLanguage` were `fr` it would still fail. So I think this should be a more reliable solution
