### PR TITLE
Add back missing error filtering throwing empty errors and silently failing validation

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -114,18 +114,20 @@ const schema = yup
       )
       .test('uniqueName', 'No unique name', (prices, context) => {
         const priceNames = prices.map((item) => item.name[i18n.language]);
-        const errors = priceNames.map((priceName, index) => {
-          const indexOf = priceNames.indexOf(priceName);
-          if (indexOf !== -1 && indexOf !== index) {
-            return context.createError({
-              path: `${context.path}.${index}`,
-              message: i18n.t(
-                'create.additionalInformation.price_info.duplicate_name_error',
-                { priceName },
-              ),
-            });
-          }
-        });
+        const errors = priceNames
+          .map((priceName, index) => {
+            const indexOf = priceNames.indexOf(priceName);
+            if (indexOf !== -1 && indexOf !== index) {
+              return context.createError({
+                path: `${context.path}.${index}`,
+                message: i18n.t(
+                  'create.additionalInformation.price_info.duplicate_name_error',
+                  { priceName },
+                ),
+              });
+            }
+          })
+          .filter(Boolean);
 
         return errors.length ? new ValidationError(errors) : true;
       }),


### PR DESCRIPTION
### Fixed

- Add back missing error filtering throwing empty errors and silently failing validation

---

Ticket: https://jira.uitdatabank.be/browse/III-5317

Seems one of the merges conflict resolution resulted in this incorrect code without the `errors` filtering, resulting in validation still failing silently
