### PR TITLE
III-5273 - Move maxWidth to inputField

### DIFF
--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -420,7 +420,6 @@ const LocationStep = ({
                 </Inline>
                 {scope === OfferTypes.EVENTS && (
                   <PlaceStep
-                    maxWidth="28rem"
                     municipality={municipality}
                     country={country}
                     chooseLabel={chooseLabel}

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -178,7 +178,7 @@ const PlaceStep = ({
                         );
                       }}
                       selected={valueToArray(selectedPlace as Place)}
-                      maxWidth="43rem"
+                      maxWidth="28rem"
                       onChange={(places) => {
                         const place = places[0];
 


### PR DESCRIPTION
### Changed
- `LocationStep`: move maxWidth to inputField

<img width="596" alt="Screenshot 2023-02-10 at 13 15 39" src="https://user-images.githubusercontent.com/9402377/218090439-a3478dd3-0a8b-40f7-a4a7-d6a7b8018af3.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5273
