### PR TITLE
III-5304 - Use same imageIcon in PictureUploadModal as in PictureUploadBox

### DIFF
--- a/src/pages/PictureUploadBox.tsx
+++ b/src/pages/PictureUploadBox.tsx
@@ -195,6 +195,6 @@ const PictureUploadBox = ({
   );
 };
 
-export { PictureUploadBox };
+export { ImageIcon, PictureUploadBox };
 
 export type { ImageType };

--- a/src/pages/steps/modals/PictureUploadModal.tsx
+++ b/src/pages/steps/modals/PictureUploadModal.tsx
@@ -6,9 +6,9 @@ import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
 import { useAutoFocus } from '@/hooks/useAutoFocus';
+import { ImageIcon } from '@/pages/PictureUploadBox';
 import { Button } from '@/ui/Button';
 import { FormElement } from '@/ui/FormElement';
-import { Icon, Icons } from '@/ui/Icon';
 import { Image } from '@/ui/Image';
 import { Input } from '@/ui/Input';
 import { Link } from '@/ui/Link';
@@ -106,12 +106,7 @@ const PictureUploadBox = forwardRef<HTMLInputElement, Props>(
             <Text>{image.name}</Text>
           </Stack>
         ) : (
-          <Icon
-            name={Icons.IMAGE}
-            width="auto"
-            height="8rem"
-            color={getValue('imageIconColor')}
-          />
+          <ImageIcon width="80" />
         )}
         <Stack spacing={3} alignItems="center">
           <Text>Sleep een bestand hierheen of</Text>


### PR DESCRIPTION
### Changed
-Use same imageIcon in `PictureUploadModal` as in `PictureUploadBox`

<img width="1435" alt="Screenshot 2023-02-10 at 16 14 10" src="https://user-images.githubusercontent.com/9402377/218128051-0e4edfd6-2426-4f46-902b-bdcecfea3470.png">

---
Ticket: https://jira.uitdatabank.be/browse/III-5304
