### PR TITLE
Always show "Create new location" prompt even if one has the same name

### DIFF
--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -198,7 +198,7 @@ const PlaceStep = ({
                       newSelectionPrefix={t(
                         'create.additionalInformation.place.add_new_label',
                       )}
-                      allowNew={!isMovie}
+                      allowNew={() => !isMovie}
                     />
                   }
                 />


### PR DESCRIPTION
### Changed

- Always show "Create new location" prompt even if one has the same name

---

To be clear I don't know why the library behaves differently when passing true or returning true from a function, I found it in a Github issue, but seems to work 🤷‍♀️ 

![Screenshot 2023-02-16 at 14 53 56](https://user-images.githubusercontent.com/1321596/219383619-6886e5d0-0983-40e2-a62a-a6cc9ad6d320.png)


Ticket: https://jira.uitdatabank.be/browse/III-5319
