### PR TITLE
Only submit steps if they have changed

### DIFF
--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -22,6 +22,7 @@ const useEditNameAndAgeRange = ({
   scope,
   onSuccess,
   offerId,
+  mainLanguage,
 }: UseEditArguments) => {
   const changeNameMutation = useChangeOfferNameMutation({
     onSuccess: () => onSuccess('basic_info'),
@@ -44,8 +45,8 @@ const useEditNameAndAgeRange = ({
 
     await changeNameMutation.mutateAsync({
       id: offerId,
-      lang: 'nl',
-      name: name.nl,
+      lang: mainLanguage,
+      name: name[mainLanguage],
       scope,
     });
   };

--- a/src/pages/steps/NameStep.tsx
+++ b/src/pages/steps/NameStep.tsx
@@ -16,6 +16,7 @@ const NameStep = ({
   formState: { errors },
   control,
   onChange,
+  mainLanguage,
   ...props
 }: NameStepProps) => {
   const { t, i18n } = useTranslation();
@@ -36,12 +37,12 @@ const NameStep = ({
                 id="event-name"
                 Component={
                   <Input
-                    value={field.value?.name?.nl}
+                    value={field.value?.name?.[mainLanguage]}
                     onChange={(event) => {
                       field.onChange({
                         ...field.value,
                         name: {
-                          [i18n.language]: (event.target as HTMLInputElement)
+                          [mainLanguage]: (event.target as HTMLInputElement)
                             .value,
                         },
                       });
@@ -50,14 +51,14 @@ const NameStep = ({
                       field.onChange({
                         ...field.value,
                         name: {
-                          [i18n.language]: (event.target as HTMLInputElement)
+                          [mainLanguage]: (event.target as HTMLInputElement)
                             .value,
                         },
                       });
                       onChange({
                         ...field.value,
                         name: {
-                          [i18n.language]: (event.target as HTMLInputElement)
+                          [mainLanguage]: (event.target as HTMLInputElement)
                             .value,
                         },
                       });
@@ -80,7 +81,7 @@ const NameStep = ({
                     font-weight: bold;
                   }
                 `}
-              ></Text>
+              />
             </Stack>
           );
         }}

--- a/src/pages/steps/Steps.tsx
+++ b/src/pages/steps/Steps.tsx
@@ -215,7 +215,13 @@ const Steps = ({
             >
               <Step
                 key={index}
-                onChange={() => onChange(name)}
+                onChange={() => {
+                  if (!form.formState.dirtyFields[name]) {
+                    return;
+                  }
+
+                  onChange(name);
+                }}
                 loading={!!(name && fieldLoading === name)}
                 name={name}
                 offerId={offerId}

--- a/src/pages/steps/Steps.tsx
+++ b/src/pages/steps/Steps.tsx
@@ -21,6 +21,7 @@ import { Title } from '@/ui/Title';
 
 import type { FormData as OfferFormData } from '../create/OfferForm';
 import type { FormData as MovieFormData } from '../manage/movies/MovieForm';
+import { SupportedLanguage } from '@/i18n/index';
 
 type FormDataUnion = MovieFormData & OfferFormData;
 
@@ -117,11 +118,13 @@ type StepProps = UseFormReturn<FormDataUnion> & {
   loading: boolean;
   name: Path<FormDataUnion>;
   onChange: (value: any) => void;
+  mainLanguage: SupportedLanguage;
 };
 
 type StepsProps = {
   scope?: OfferType;
   offerId?: string;
+  mainLanguage: SupportedLanguage;
   form: UseFormReturn<FormDataUnion>;
   fieldLoading?: string;
   onChange?: (editedField: string) => void;
@@ -145,6 +148,7 @@ const stepPropKeys: (keyof StepProps)[] = [
   'onChange',
   'register',
   'reset',
+  'mainLanguage',
   'resetField',
   'setError',
   'setFocus',
@@ -162,6 +166,7 @@ const Steps = ({
   fieldLoading,
   form,
   offerId,
+  mainLanguage,
   scope,
   ...props
 }: StepsProps) => {
@@ -225,6 +230,7 @@ const Steps = ({
                 loading={!!(name && fieldLoading === name)}
                 name={name}
                 offerId={offerId}
+                mainLanguage={mainLanguage}
                 scope={scope}
                 variant={variant}
                 {...form}

--- a/src/pages/steps/Steps.tsx
+++ b/src/pages/steps/Steps.tsx
@@ -10,6 +10,7 @@ import type {
 import { useTranslation } from 'react-i18next';
 
 import { OfferType, OfferTypes } from '@/constants/OfferType';
+import { SupportedLanguage } from '@/i18n/index';
 import { Values } from '@/types/Values';
 import type { BoxProps } from '@/ui/Box';
 import { Box } from '@/ui/Box';
@@ -21,7 +22,6 @@ import { Title } from '@/ui/Title';
 
 import type { FormData as OfferFormData } from '../create/OfferForm';
 import type { FormData as MovieFormData } from '../manage/movies/MovieForm';
-import { SupportedLanguage } from '@/i18n/index';
 
 type FormDataUnion = MovieFormData & OfferFormData;
 

--- a/src/pages/steps/StepsForm.tsx
+++ b/src/pages/steps/StepsForm.tsx
@@ -174,6 +174,7 @@ const StepsForm = ({
           fieldLoading={fieldLoading}
           onChangeSuccess={handleChangeSuccess}
           offerId={offerId}
+          mainLanguage={offer?.mainLanguage}
           scope={scope}
           form={form}
         />

--- a/src/pages/steps/hooks/useEditField.ts
+++ b/src/pages/steps/hooks/useEditField.ts
@@ -9,6 +9,7 @@ import { useEditNameAndProduction } from '@/pages/steps/ProductionStep';
 import { FormDataUnion } from '@/pages/steps/Steps';
 
 import { useEditCalendar } from '../CalendarStep/CalendarStep';
+import { Offer } from '@/types/Offer';
 
 type HandleSuccessOptions = {
   shouldInvalidateEvent?: boolean;
@@ -23,6 +24,7 @@ type UseEditArguments = {
 const useEditField = ({ scope, onSuccess, offerId, handleSubmit }) => {
   const queryClient = useQueryClient();
   const [fieldLoading, setFieldLoading] = useState<string>();
+  const offer = queryClient.getQueryData<Offer>([scope, { id: offerId }]);
 
   const handleSuccess = (
     editedField: string,
@@ -34,7 +36,12 @@ const useEditField = ({ scope, onSuccess, offerId, handleSubmit }) => {
     queryClient.invalidateQueries([scope, { id: offerId }]);
   };
 
-  const editArguments = { scope, offerId, onSuccess: handleSuccess };
+  const editArguments = {
+    scope,
+    offerId,
+    onSuccess: handleSuccess,
+    mainLanguage: offer?.mainLanguage,
+  };
 
   const editTypeAndTheme = useEditTypeAndTheme(editArguments);
   const editNameAndAgeRange = useEditNameAndAgeRange(editArguments);

--- a/src/pages/steps/hooks/useEditField.ts
+++ b/src/pages/steps/hooks/useEditField.ts
@@ -2,14 +2,15 @@ import { useState } from 'react';
 import { useQueryClient } from 'react-query';
 
 import { OfferType } from '@/constants/OfferType';
+import { SupportedLanguage } from '@/i18n/index';
 import { useEditTypeAndTheme } from '@/pages/steps/EventTypeAndThemeStep';
 import { useEditLocation } from '@/pages/steps/LocationStep';
 import { useEditNameAndAgeRange } from '@/pages/steps/NameAndAgeRangeStep';
 import { useEditNameAndProduction } from '@/pages/steps/ProductionStep';
 import { FormDataUnion } from '@/pages/steps/Steps';
+import { Offer } from '@/types/Offer';
 
 import { useEditCalendar } from '../CalendarStep/CalendarStep';
-import { Offer } from '@/types/Offer';
 
 type HandleSuccessOptions = {
   shouldInvalidateEvent?: boolean;
@@ -19,6 +20,7 @@ type UseEditArguments = {
   scope: OfferType;
   offerId: string;
   onSuccess: (editedField: string, options?: HandleSuccessOptions) => void;
+  mainLanguage: SupportedLanguage;
 };
 
 const useEditField = ({ scope, onSuccess, offerId, handleSubmit }) => {


### PR DESCRIPTION
### Changed

- Only trigger Steps onChange if they are dirty
- Make `Name` field always use the offer's main language instead of NL or the UI's

---

The reason for the Name change is because, since my offers have `fr` as main language, the code would always backfill `nl`, causing the field to be dirty when it wasn't. I also figured this was the correct way the code should behave but since the localization of the app has some edge cases I'm not sure this is correct or not.
I was also unsure of the best way to retrieve the offer's main language all the way down to the field since we only keep the ID for most of the components chain, so if there's a terser way that doesn't require passing so many props I'm up for it. I used the query cache in the mutation part but it's not always the safest option I think so not sure if we could/should use it in the Name field component as well

Ticket: https://jira.uitdatabank.be/browse/III-5251
