### PR TITLE
Fix images in PictureUploadModal being wider than modal

### DIFF
--- a/src/pages/steps/modals/PictureUploadModal.tsx
+++ b/src/pages/steps/modals/PictureUploadModal.tsx
@@ -102,7 +102,7 @@ const PictureUploadBox = forwardRef<HTMLInputElement, Props>(
               alt="preview"
               width="auto"
               maxHeight="8rem"
-              maxWidth={'100%'}
+              maxWidth="100%"
               objectFit="cover"
             />
             <Text>{image.name}</Text>

--- a/src/pages/steps/modals/PictureUploadModal.tsx
+++ b/src/pages/steps/modals/PictureUploadModal.tsx
@@ -102,6 +102,7 @@ const PictureUploadBox = forwardRef<HTMLInputElement, Props>(
               alt="preview"
               width="auto"
               maxHeight="8rem"
+              maxWidth={'100%'}
               objectFit="cover"
             />
             <Text>{image.name}</Text>


### PR DESCRIPTION
### Fixed

- Fix images in PictureUploadModal being wider than modal

---

Ticket: https://jira.uitdatabank.be/browse/III-5343