### PR TITLE
III-5314 - Added missing translations

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -115,6 +115,10 @@
         "events": "Wann findet diese Veranstaltung oder Aktivität statt?",
         "places": "Wann ist dieser Ort oder Standort geöffnet?"
       },
+      "types": {
+        "one_or_more_days": "Ein oder mehrere Tage",
+        "fixed_days": "Feste Tage pro Woche"
+      },
       "one_or_more_days": {
         "button_add": "Tag hinzufügen"
       },

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -115,6 +115,10 @@
         "events": "Quand cet événement ou cette activité a-t-il lieu ?",
         "places": "Quand cet endroit ou cet emplacement est-il ouvert ?"
       },
+      "types": {
+        "one_or_more_days": "Jours récurrents ou variables",
+        "fixed_days": "Période continue"
+      },
       "one_or_more_days": {
         "button_add": "Ajouter un jour"
       },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -115,6 +115,10 @@
         "events": "Wanneer vindt dit evenement of deze activiteit plaats?",
         "places": "Wanneer is deze plaats of locatie open?"
       },
+      "types": {
+        "one_or_more_days": "Een of meerdere dagen",
+        "fixed_days": "Vaste dagen per week"
+      },
       "one_or_more_days": {
         "button_add": "Dag toevoegen"
       },

--- a/src/pages/steps/CalendarStep/CalendarOptionToggle.tsx
+++ b/src/pages/steps/CalendarStep/CalendarOptionToggle.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import { parseSpacing } from '@/ui/Box';
 import { getInlineProps, Inline, InlineProps } from '@/ui/Inline';
 import { ToggleBox } from '@/ui/ToggleBox';
@@ -21,6 +23,7 @@ export const CalendarOptionToggle = ({
   disableChooseFixedDays,
   ...props
 }: CalendarOptionToggleProps) => {
+  const { t } = useTranslation();
   const isOneOrMoreDays = useIsOneOrMoreDays();
   const isFixedDays = useIsFixedDays();
 
@@ -30,7 +33,7 @@ export const CalendarOptionToggle = ({
         onClick={onChooseOneOrMoreDays}
         active={isOneOrMoreDays}
         icon={<IconOneOrMoreDays />}
-        text="Een of meerdere dagen"
+        text={t('create.calendar.types.one_or_more_days')}
         minHeight={parseSpacing(7)}
         flex={1}
       />
@@ -38,7 +41,7 @@ export const CalendarOptionToggle = ({
         onClick={onChooseFixedDays}
         active={isFixedDays}
         icon={<IconFixedDays />}
-        text="Vaste dagen per week"
+        text={t('create.calendar.types.one_or_more_days')}
         minHeight={parseSpacing(7)}
         flex={1}
         disabled={disableChooseFixedDays}

--- a/src/ui/DatePicker.tsx
+++ b/src/ui/DatePicker.tsx
@@ -1,5 +1,6 @@
 import 'react-datepicker/dist/react-datepicker.css';
 
+import de from 'date-fns/locale/de';
 import fr from 'date-fns/locale/fr';
 import nl from 'date-fns/locale/nl';
 import { useRef } from 'react';
@@ -7,6 +8,7 @@ import ReactDatePicker, {
   registerLocale,
   setDefaultLocale,
 } from 'react-datepicker';
+import { useTranslation } from 'react-i18next';
 
 import type { BoxProps } from './Box';
 import { Box } from './Box';
@@ -19,6 +21,7 @@ import { getValueFromTheme } from './theme';
 setDefaultLocale('nl');
 registerLocale('nl', nl);
 registerLocale('fr', fr);
+registerLocale('de', de);
 
 const getValue = getValueFromTheme('datePicker');
 
@@ -40,6 +43,7 @@ const DatePicker = ({
   disabled,
   ...props
 }: Props) => {
+  const { i18n } = useTranslation();
   const datePickerRef = useRef(null);
 
   return (
@@ -174,6 +178,7 @@ const DatePicker = ({
         maxDate={maxDate}
         customInput={<Input id={id} />}
         disabled={disabled}
+        locale={i18n.language}
         css={`
           &.form-control {
             border-top-right-radius: 0;


### PR DESCRIPTION
### Added
- missing translations
- [Use i18n.language for react-datepicker](https://github.com/cultuurnet/udb3-frontend/commit/7c39f757ed6fa1c4693f11bac32f48e501960428)

<img width="321" alt="Screenshot 2023-02-22 at 15 51 20" src="https://user-images.githubusercontent.com/9402377/220659425-18eca49e-9f94-4374-b767-3c84b9b9be9d.png">


---
Ticket: https://jira.uitdatabank.be/browse/III-5314
