### PR TITLE
Hide beta toggle for now

### DIFF
--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -580,6 +580,7 @@ const Sidebar = () => {
           )}
           <Stack>
             <Inline
+              display="none"
               flex={1}
               paddingLeft={2}
               alignItems="center"


### PR DESCRIPTION
### Fixed
- Hide beta toggle for now

<img width="223" alt="Screenshot 2023-02-22 at 16 03 49" src="https://user-images.githubusercontent.com/9402377/220662224-98514f1e-b78b-46ac-ac91-481cfb5bb4b9.png">
