### PR TITLE
Ignore eslint and tsc during build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -38,6 +38,9 @@ const moduleExports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 const SentryWebpackPluginOptions = {

--- a/next.config.js
+++ b/next.config.js
@@ -35,6 +35,9 @@ const moduleExports = {
     shouldShowBetaVersion: process.env.NEXT_PUBLIC_SHOULD_SHOW_BETA_VERSION,
   },
   pageExtensions: ['page.tsx', 'page.js', 'api.ts'],
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
 
 const SentryWebpackPluginOptions = {


### PR DESCRIPTION
### Changed

- [Ignore eslint during build](https://github.com/cultuurnet/udb3-frontend/commit/4346e020148faaf4e1706807f9feff711c35d7aa)
- [Ignore typescript during build](https://github.com/cultuurnet/udb3-frontend/commit/069b67677b81ac797c70aaae80c20849028e217b)

This is a small improvement.
Since we always require typescript and eslint to succeed before merging a PR, those shouldn't be necessary anymore when the code is built on the server.

Improvement time build:
with eslint && typescript -> 57.97s
without eslint && typescript -> 45.43s
(Yes I removed the .next folder in between runs 😉)

No fan? No problem I can close the PR, the build time difference is not huge.
