### PR TITLE
III-5415 - Fix typeahead organiser

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -276,7 +276,7 @@ const OrganizerPicker = ({
                   <Typeahead<Organizer>
                     id={'organizer-picker'}
                     options={organizers}
-                    labelKey={'name'}
+                    labelKey={(org) => getOrganizerName(org, i18n.language)}
                     renderMenuItemChildren={(org: Organizer, { text }) => {
                       const name = getOrganizerName(org, i18n.language);
                       return (


### PR DESCRIPTION
### Fixed

- [Get organizer name from object as labelKey](https://github.com/cultuurnet/udb3-frontend/commit/b7d5818af571aba7bb541e1e5f24238a33733dfe)

---

Ticket: https://jira.uitdatabank.be/browse/III-5415

<img width="355" alt="Screenshot 2023-03-07 at 16 39 15" src="https://user-images.githubusercontent.com/66943525/223471635-5d0d426e-7df9-4650-a1af-b7cf853d8258.png">

