### PR TITLE
Add missing Theater location translation

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -585,7 +585,7 @@
     "0.53.0.0.0": "Freizeitbereich oder -zentrum",
     "0.54.0.0.0": "Tanzvorführung",
     "0.55.0.0.0": "Theatervorstellung",
-    "8.70.0.0.0": "Theatervorstellung",
+    "8.70.0.0.0": "Theater",
     "0.57.0.0.0": "Camp oder Ferienlager",
     "0.59.0.0.0": "Sportaktivität",
     "0.6.0.0.0": "Messe",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -585,6 +585,7 @@
     "0.53.0.0.0": "Freizeitbereich oder -zentrum",
     "0.54.0.0.0": "Tanzvorführung",
     "0.55.0.0.0": "Theatervorstellung",
+    "8.70.0.0.0": "Theatervorstellung",
     "0.57.0.0.0": "Camp oder Ferienlager",
     "0.59.0.0.0": "Sportaktivität",
     "0.6.0.0.0": "Messe",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -584,6 +584,7 @@
     "0.53.0.0.0": "Centre de loisirs ou centre de récréation",
     "0.54.0.0.0": "Spectacle de danse",
     "0.55.0.0.0": "Théâtre",
+    "8.70.0.0.0": "Théâtre",
     "0.57.0.0.0": "Camp de vacances",
     "0.59.0.0.0": "Activité sportive",
     "0.6.0.0.0": "Foire",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -584,7 +584,7 @@
     "0.53.0.0.0": "Recreatiedomein of centrum",
     "0.54.0.0.0": "Dansvoorstelling",
     "0.55.0.0.0": "Theatervoorstelling",
-    "8.70.0.0.0": "Theatervoorstelling",
+    "8.70.0.0.0": "Theater",
     "0.57.0.0.0": "Kamp of vakantie",
     "0.59.0.0.0": "Sportactiviteit",
     "0.6.0.0.0": "Beurs",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -584,6 +584,7 @@
     "0.53.0.0.0": "Recreatiedomein of centrum",
     "0.54.0.0.0": "Dansvoorstelling",
     "0.55.0.0.0": "Theatervoorstelling",
+    "8.70.0.0.0": "Theatervoorstelling",
     "0.57.0.0.0": "Kamp of vakantie",
     "0.59.0.0.0": "Sportactiviteit",
     "0.6.0.0.0": "Beurs",


### PR DESCRIPTION
### Fixed

- Add missing Theater location translation

---

We have the translation for Theater as an event but not as a type of location from what I understand, so added it with the other ID.

Ticket: https://jira.uitdatabank.be/browse/III-5494
