### PR TITLE
Centralize logic checking if a location is set and fix Cuultuur event case

### DIFF
--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -13,10 +13,12 @@ import {
   useChangeLocationMutation,
   useChangeOnlineUrlMutation,
   useDeleteOnlineUrlMutation,
+  useGetEventByIdQuery,
 } from '@/hooks/api/events';
-import { useGetEventByIdQuery } from '@/hooks/api/events';
-import { useGetPlaceByIdQuery } from '@/hooks/api/places';
-import { useChangeAddressMutation } from '@/hooks/api/places';
+import {
+  useChangeAddressMutation,
+  useGetPlaceByIdQuery,
+} from '@/hooks/api/places';
 import { FormData as OfferFormData } from '@/pages/create/OfferForm';
 import { Address } from '@/types/Address';
 import { Countries, Country } from '@/types/Country';

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -176,7 +176,7 @@ const isLocationSet = (
     return true;
   }
 
-  const isCultuurKuur = !location?.country && scope == OfferTypes.EVENTS;
+  const isCultuurKuur = !location?.country && scope === OfferTypes.EVENTS;
 
   return (
     isCultuurKuur ||

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
 import { EventTypes } from '@/constants/EventTypes';
-import { OfferTypes } from '@/constants/OfferType';
+import { OfferType, OfferTypes } from '@/constants/OfferType';
 import {
   useChangeAttendanceModeMutation,
   useChangeAudienceMutation,
@@ -167,6 +167,24 @@ type PlaceStepProps = StackProps &
     placeholderLabel: (t: TFunction) => string;
   } & { offerId?: string };
 
+const isLocationSet = (
+  scope: OfferType,
+  location: FormDataUnion['location'],
+  formState,
+) => {
+  if (location.isOnline || location.place) {
+    return true;
+  }
+
+  const isCultuurKuur = !location?.country && scope == OfferTypes.EVENTS;
+
+  return (
+    isCultuurKuur ||
+    (location.municipality?.name &&
+      formState.touchedFields.location?.streetAndNumber)
+  );
+};
+
 const LocationStep = ({
   formState,
   getValues,
@@ -200,29 +218,13 @@ const LocationStep = ({
     });
 
   const shouldAddSpaceBelowTypeahead = useMemo(() => {
-    if (offerId || location?.isOnline) return false;
+    if (offerId) return false;
 
-    if (
-      scope === OfferTypes.PLACES &&
-      (!location?.municipality?.name ||
-        !formState.touchedFields.location?.streetAndNumber)
-    ) {
-      return true;
-    }
-
-    if (
-      scope === OfferTypes.EVENTS &&
-      (!location?.municipality?.name || !location?.place)
-    ) {
-      return true;
-    }
-
-    return false;
+    return !isLocationSet(scope, location, formState);
   }, [
+    isLocationSet,
     formState.touchedFields.location?.streetAndNumber,
-    location?.isOnline,
-    location?.municipality?.name,
-    location?.place,
+    location,
     offerId,
     scope,
   ]);
@@ -609,4 +611,4 @@ const locationStepConfiguration: StepsConfiguration<'location'> = {
 
 LocationStep.defaultProps = {};
 
-export { locationStepConfiguration, useEditLocation };
+export { isLocationSet, locationStepConfiguration, useEditLocation };

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -375,6 +375,7 @@ const LocationStep = ({
                     onClick={() => {
                       const updatedValue = {
                         ...field.value,
+                        place: undefined,
                         country: Countries.BE,
                         municipality: undefined,
                       };
@@ -456,6 +457,7 @@ const LocationStep = ({
                     onClick={() => {
                       const updatedValue = {
                         ...field.value,
+                        place: undefined,
                         municipality: undefined,
                         streetAndNumber: undefined,
                       };

--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -90,19 +90,16 @@ const nameAndAgeRangeStepConfiguration: StepsConfiguration<'nameAndAgeRange'> =
       }
 
       if (!location.place) {
+        const isCultuurKuur = !location?.country;
+
         return (
-          location.municipality?.name &&
-          formState.touchedFields.location?.streetAndNumber
+          isCultuurKuur ||
+          (location.municipality?.name &&
+            formState.touchedFields.location?.streetAndNumber)
         );
       }
 
-      if (!!location?.place) {
-        return true;
-      }
-
-      const isCultuurKuur = !location?.country;
-
-      return isCultuurKuur;
+      return true;
     },
   };
 

--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -17,6 +17,7 @@ import {
   StepProps,
   StepsConfiguration,
 } from './Steps';
+import { isLocationSet } from '@/pages/steps/LocationStep';
 
 const useEditNameAndAgeRange = ({
   scope,
@@ -84,18 +85,9 @@ const nameAndAgeRangeStepConfiguration: StepsConfiguration<'nameAndAgeRange'> =
     }),
     shouldShowStep: ({ watch, formState }) => {
       const location = watch('location');
+      const scope = watch('scope');
 
-      if (location.isOnline || location.place) {
-        return true;
-      }
-
-      const isCultuurKuur = !location?.country;
-
-      return (
-        isCultuurKuur ||
-        (location.municipality?.name &&
-          formState.touchedFields.location?.streetAndNumber)
-      );
+      return isLocationSet(scope, location, formState);
     },
   };
 

--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -5,6 +5,7 @@ import {
   useChangeOfferNameMutation,
   useChangeOfferTypicalAgeRangeMutation,
 } from '@/hooks/api/offers';
+import { isLocationSet } from '@/pages/steps/LocationStep';
 import { parseSpacing } from '@/ui/Box';
 import { Stack } from '@/ui/Stack';
 
@@ -17,7 +18,6 @@ import {
   StepProps,
   StepsConfiguration,
 } from './Steps';
-import { isLocationSet } from '@/pages/steps/LocationStep';
 
 const useEditNameAndAgeRange = ({
   scope,

--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -85,21 +85,17 @@ const nameAndAgeRangeStepConfiguration: StepsConfiguration<'nameAndAgeRange'> =
     shouldShowStep: ({ watch, formState }) => {
       const location = watch('location');
 
-      if (location?.isOnline) {
+      if (location.isOnline || location.place) {
         return true;
       }
 
-      if (!location.place) {
-        const isCultuurKuur = !location?.country;
+      const isCultuurKuur = !location?.country;
 
-        return (
-          isCultuurKuur ||
-          (location.municipality?.name &&
-            formState.touchedFields.location?.streetAndNumber)
-        );
-      }
-
-      return true;
+      return (
+        isCultuurKuur ||
+        (location.municipality?.name &&
+          formState.touchedFields.location?.streetAndNumber)
+      );
     },
   };
 

--- a/src/pages/steps/hooks/useFooterStatus.ts
+++ b/src/pages/steps/hooks/useFooterStatus.ts
@@ -1,7 +1,8 @@
 import { useRouter } from 'next/router';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useQueryClient } from 'react-query';
 
+import { isLocationSet } from '@/pages/steps/LocationStep';
 import { isEvent } from '@/types/Event';
 import { isPlace } from '@/types/Place';
 
@@ -24,11 +25,12 @@ const useFooterStatus = ({ offer, form }) => {
   const isMutating = queryClient.isMutating();
   const offerId = offer?.['@id'];
   const availableFrom = offer?.availableFrom;
-  const hasLocation =
-    formValues.location?.place ||
-    (formValues.location?.municipality &&
-      formValues.location?.streetAndNumber) ||
-    formValues.location?.isOnline;
+  const hasLocation = isLocationSet(
+    formValues.scope,
+    formValues.location,
+    form.formState,
+  );
+
   const isPlaceDirty =
     (dirtyFields.place || dirtyFields.location) && hasLocation;
   const isEventType = isEvent(offer);


### PR DESCRIPTION
### Fixed

- Centralize logic checking if a location is set and fix Cuultuur case
- Fixed `place` attribute not being cleared when clicking on Change municipality/address

---

The one part I'm not sure I understand is why in these places we checked whether `streetAndNumber` is dirty instead of checking if it's set? Since this allows writing something in the field then deleting it, making the empty field pass as valid, is that intended for a particular usecase?

---

Ticket: https://jira.uitdatabank.be/browse/III-5492
