### PR TITLE
Allow . as decimal separators in prices

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -31,7 +31,7 @@ import { reconcileRates } from '@/utils/reconcileRates';
 
 const PRICE_CURRENCY: string = 'EUR';
 
-const PRICE_REGEX: RegExp = /^([1-9][0-9]*|[0-9]|0)(,[0-9]{1,2})?$/;
+const PRICE_REGEX: RegExp = /^([1-9][0-9]*|[0-9]|0)([.,][0-9]{1,2})?$/;
 
 const PriceCategory = {
   BASE: 'base',


### PR DESCRIPTION
### Changed

- Allow . as decimal separators in prices

---

Since we use `Intl.NumberFormat` both `.` and `,` get automatically converted to `,` correctly already


https://user-images.githubusercontent.com/1321596/229780898-56224942-0ddc-474a-a606-29e5e0e068bf.mp4



Ticket: https://jira.uitdatabank.be/browse/III-5519
