### PR TITLE
Add workaround to remove dummy organizers

### DIFF
--- a/src/hooks/api/organizers.ts
+++ b/src/hooks/api/organizers.ts
@@ -27,7 +27,12 @@ type GetOrganizersArgumentsByQuery = {
 };
 
 const useGetOrganizersByQueryQuery = (
-  { req, queryClient, name }: AuthenticatedQueryOptions<{ name?: string }> = {},
+  {
+    req,
+    queryClient,
+    name,
+    paginationOptions = { start: 0, limit: 10 },
+  }: AuthenticatedQueryOptions<{ name?: string } & PaginationOptions> = {},
   configuration: UseQueryOptions = {},
 ) =>
   useAuthenticatedQuery<{ member: Organizer[] }>({
@@ -38,8 +43,8 @@ const useGetOrganizersByQueryQuery = (
     queryArguments: {
       embed: true,
       name,
-      start: '0',
-      limit: '10',
+      start: paginationOptions.start,
+      limit: paginationOptions.limit,
     },
     enabled: !!name,
     ...configuration,

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -178,6 +178,12 @@ const OrganizerPicker = ({
   const [addButtonHasBeenPressed, setAddButtonHasBeenPressed] = useState(false);
   const [organizerSearchInput, setOrganizerSearchInput] = useState('');
 
+  // This is a random organizer with an ID to use as bridge when deleting dummy organizers
+  const getRandomOrganizerQuery = useGetOrganizersByQueryQuery({
+    name: 'a',
+    paginationOptions: { start: 0, limit: 1 },
+  });
+
   const getOrganizersByQueryQuery = useGetOrganizersByQueryQuery(
     { name: organizerSearchInput },
     { enabled: !!organizerSearchInput },
@@ -238,9 +244,17 @@ const OrganizerPicker = ({
                 <Button
                   spacing={3}
                   variant={ButtonVariants.LINK}
-                  onClick={() =>
-                    onDeleteOrganizer(parseOfferId(organizer['@id']))
-                  }
+                  onClick={async () => {
+                    let removed = organizer;
+
+                    // If we have a dummy organizer, first set a real one
+                    if (!organizer['@id']) {
+                      removed = getRandomOrganizerQuery.data?.member[0];
+                      await onChange(parseOfferId(removed?.['@id']));
+                    }
+
+                    onDeleteOrganizer(parseOfferId(removed['@id']));
+                  }}
                 >
                   {t('create.additionalInformation.organizer.change')}
                 </Button>

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -179,10 +179,15 @@ const OrganizerPicker = ({
   const [organizerSearchInput, setOrganizerSearchInput] = useState('');
 
   // This is a random organizer with an ID to use as bridge when deleting dummy organizers
-  const getRandomOrganizerQuery = useGetOrganizersByQueryQuery({
-    name: 'a',
-    paginationOptions: { start: 0, limit: 1 },
-  });
+  const getRandomOrganizerQuery = useGetOrganizersByQueryQuery(
+    {
+      name: 'a',
+      paginationOptions: { start: 0, limit: 1 },
+    },
+    {
+      enabled: organizer && !organizer['@id'],
+    },
+  );
 
   const getOrganizersByQueryQuery = useGetOrganizersByQueryQuery(
     { name: organizerSearchInput },

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -209,11 +209,8 @@ const OrganizerPicker = ({
     // @ts-expect-error
   }, [getOffersByCreatorQuery.data?.member]);
 
-  const organizers = useMemo(() => {
-    // @ts-expect-error
-    return getOrganizersByQueryQuery.data?.member ?? [];
-    // @ts-expect-error
-  }, [getOrganizersByQueryQuery.data?.member]);
+  // @ts-expect-error
+  const organizers = getOrganizersByQueryQuery.data?.member ?? [];
 
   const handleSelectRecentOrganizer = (organizerId: string) => {
     onChange(organizerId);

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -249,6 +249,7 @@ const OrganizerPicker = ({
 
                     // If we have a dummy organizer, first set a real one
                     if (!organizer['@id']) {
+                      // @ts-expect-error
                       removed = getRandomOrganizerQuery.data?.member[0];
                       await onChange(parseOfferId(removed?.['@id']));
                     }


### PR DESCRIPTION
### Fixed

- Add workaround to remove dummy organizers

---

This uses the workaround idea from @bertramakers which first sets a valid organizer then removes that one from the offer, so there is a slight "UI flash" but since this is for an edge case I think it's likely fine.


https://user-images.githubusercontent.com/1321596/232031362-134604f3-49c6-4135-a097-46ff951be7ef.mp4



Ticket: https://jira.uitdatabank.be/browse/III-5532
