### PR TITLE
III-5327 - Add isExternalCreator label on organizer dashboard

### DIFF
--- a/src/pages/dashboard/index.page.tsx
+++ b/src/pages/dashboard/index.page.tsx
@@ -121,8 +121,8 @@ const RowStatusToColor: Record<RowStatus, string> = {
 };
 
 type Status = {
-  color: string;
-  label: string;
+  color?: string;
+  label?: string;
   isExternalCreator?: boolean;
 };
 
@@ -143,14 +143,20 @@ const StatusIndicator = ({
         alignItems="center"
         {...getInlineProps(props)}
       >
-        <Box
-          width="0.60rem"
-          height="0.60rem"
-          backgroundColor={color}
-          borderRadius="50%"
-          flexShrink={0}
-        />
-        <Text variant={TextVariants.MUTED}>{label}</Text>
+        {color &&
+          label && [
+            <Box
+              key="status-indicator-box"
+              width="0.60rem"
+              height="0.60rem"
+              backgroundColor={color}
+              borderRadius="50%"
+              flexShrink={0}
+            />,
+            <Text key="status-indicator-label" variant={TextVariants.MUTED}>
+              {label}
+            </Text>,
+          ]}
       </Inline>
       {isExternalCreator && (
         <Text variant={TextVariants.MUTED}>
@@ -185,7 +191,7 @@ const Row = ({
       css={css`
         display: grid;
         gap: ${parseSpacing(4)};
-        grid-template-columns: ${status ? '6fr 2fr 2fr' : '8fr 2fr'};
+        grid-template-columns: ${status ? '5fr 3fr 1fr' : '8fr 2fr'};
       `}
       {...getInlineProps(props)}
     >
@@ -336,6 +342,11 @@ const OrganizerRow = ({
 }: OrganizerRowProps) => {
   const { t, i18n } = useTranslation();
 
+  const getUserQuery = useGetUserQuery();
+  // @ts-expect-error
+  const userId = getUserQuery.data?.uuid;
+  const isExternalCreator = userId !== organizer.creator;
+
   const address =
     organizer?.address?.[i18n.language] ??
     organizer?.address?.[organizer.mainLanguage];
@@ -355,6 +366,9 @@ const OrganizerRow = ({
           {t('dashboard.actions.edit')}
         </Link>,
       ]}
+      status={{
+        isExternalCreator,
+      }}
       {...getInlineProps(props)}
     />
   );

--- a/src/types/Organizer.ts
+++ b/src/types/Organizer.ts
@@ -7,6 +7,7 @@ type Organizer = {
   '@context': string;
   mainLanguage: string;
   name: string | { nl: string };
+  creator: string;
   address: Address;
   labels: string[];
   hiddenLabels: string[];


### PR DESCRIPTION
### Added
-  isExternalCreator label on organizer dashboard

<img width="1276" alt="Screenshot 2023-04-20 at 16 12 52" src="https://user-images.githubusercontent.com/9402377/233393714-65cacc98-1983-4d65-bba8-699c501c16af.png">


---
Ticket: https://jira.uitdatabank.be/browse/III-5327
