### PR TITLE
Ensure empty descriptions can still be sent with RTE

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/DescriptionStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/DescriptionStep.tsx
@@ -138,7 +138,7 @@ const DescriptionStep = ({
     );
 
     changeDescriptionMutation.mutate({
-      description: plainTextDescription.length
+      description: plainTextDescription.length > 0
         ? draftToHtml(convertToRaw(editorState.getCurrentContent()))
         : '',
       language: i18n.language,

--- a/src/pages/steps/AdditionalInformationStep/DescriptionStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/DescriptionStep.tsx
@@ -138,9 +138,10 @@ const DescriptionStep = ({
     );
 
     changeDescriptionMutation.mutate({
-      description: plainTextDescription.length > 0
-        ? draftToHtml(convertToRaw(editorState.getCurrentContent()))
-        : '',
+      description:
+        plainTextDescription.length > 0
+          ? draftToHtml(convertToRaw(editorState.getCurrentContent()))
+          : '',
       language: i18n.language,
       eventId,
       scope,

--- a/src/pages/steps/AdditionalInformationStep/DescriptionStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/DescriptionStep.tsx
@@ -138,7 +138,9 @@ const DescriptionStep = ({
     );
 
     changeDescriptionMutation.mutate({
-      description: draftToHtml(convertToRaw(editorState.getCurrentContent())),
+      description: plainTextDescription.length
+        ? draftToHtml(convertToRaw(editorState.getCurrentContent()))
+        : '',
       language: i18n.language,
       eventId,
       scope,


### PR DESCRIPTION
### Fixed

- Ensure empty descriptions can still be sent with RTE

---

Ticket: https://jira.uitdatabank.be/browse/III-5421
