### PR TITLE
Small tweaks to "Existing organization" prompt alert

### DIFF
--- a/src/pages/OrganizerAddModal.tsx
+++ b/src/pages/OrganizerAddModal.tsx
@@ -26,6 +26,8 @@ import { getValueFromTheme } from '@/ui/theme';
 import { Title } from '@/ui/Title';
 
 import { City, CityPicker } from './CityPicker';
+import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback';
+import { SupportedLanguage } from '@/i18n/index';
 
 const getValue = getValueFromTheme('organizerAddModal');
 
@@ -210,7 +212,11 @@ const OrganizerAddModal = ({
                 <Trans
                   i18nKey={`organizer.add_modal.validation_messages.url_not_unique`}
                   values={{
-                    organizerName: existingOrganization?.name[i18n.language],
+                    organizerName: getLanguageObjectOrFallback(
+                      existingOrganization?.name,
+                      i18n.language as SupportedLanguage,
+                      existingOrganization.mainLanguage as SupportedLanguage,
+                    ),
                   }}
                   components={{
                     setOrganizerLink: (

--- a/src/pages/OrganizerAddModal.tsx
+++ b/src/pages/OrganizerAddModal.tsx
@@ -6,6 +6,7 @@ import * as yup from 'yup';
 
 import { useGetOrganizersByWebsiteQuery } from '@/hooks/api/organizers';
 import { useAutoFocus } from '@/hooks/useAutoFocus';
+import { SupportedLanguage } from '@/i18n/index';
 import { OrganizerData } from '@/pages/OrganizerAddModal';
 import {
   ContactInfo,
@@ -24,10 +25,9 @@ import { Stack } from '@/ui/Stack';
 import { Text, TextVariants } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
 import { Title } from '@/ui/Title';
+import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback';
 
 import { City, CityPicker } from './CityPicker';
-import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback';
-import { SupportedLanguage } from '@/i18n/index';
 
 const getValue = getValueFromTheme('organizerAddModal');
 

--- a/src/pages/OrganizerAddModal.tsx
+++ b/src/pages/OrganizerAddModal.tsx
@@ -124,6 +124,7 @@ const OrganizerAddModal = ({
     // @ts-expect-error
     getOrganizersByWebsiteQuery.data?.member?.[0];
   const isUrlUnique = !existingOrganization;
+  const isUrlAlreadyTaken = formState.errors.url?.type === 'not_unique';
 
   const countries = useMemo(
     () => [
@@ -207,7 +208,7 @@ const OrganizerAddModal = ({
           id="organizer-url"
           label={t('organizer.add_modal.labels.url')}
           info={
-            formState.errors.url?.type === 'not_unique' ? (
+            isUrlAlreadyTaken ? (
               <Alert variant={AlertVariants.WARNING}>
                 <Trans
                   i18nKey={`organizer.add_modal.validation_messages.url_not_unique`}
@@ -239,6 +240,7 @@ const OrganizerAddModal = ({
             )
           }
           error={
+            !isUrlAlreadyTaken &&
             formState.errors.url &&
             t(`organizer.add_modal.validation_messages.url`)
           }


### PR DESCRIPTION
### Changed

- Remove redundant "Invalid URL" error message when trying taken URL

### Fixed

- Fixed organization name not showing in alert prompt depending on language

---

Ticket: https://jira.uitdatabank.be/browse/III-5518
