### PR TITLE
III-5591 - Only do mutation when payload is different

### DIFF
--- a/src/hooks/api/authenticated-query.test.js
+++ b/src/hooks/api/authenticated-query.test.js
@@ -183,7 +183,7 @@ describe('useAuthenticatedMutation', () => {
     page = setupPage();
   });
 
-  it("doesn't excecute the mutation when the mutationKey and variables are the same as previous", async () => {
+  it("doesn't execute the mutation when the mutationKey and variables are the same as previous", async () => {
     mockResponses({
       '/mutate': { status: 204 },
     });
@@ -214,7 +214,7 @@ describe('useAuthenticatedMutation', () => {
     expect(calledMutationsCount).toEqual(1);
   });
 
-  it('does excecute the mutation when the mutationKey is different than previous mutations', async () => {
+  it('does execute the mutation when the mutationKey is different than previous mutations', async () => {
     mockResponses({
       '/mutate': { status: 204 },
     });
@@ -252,7 +252,7 @@ describe('useAuthenticatedMutation', () => {
     expect(calledMutationsCount).toEqual(2);
   });
 
-  it('does excecute the mutation when the mutationKey is the same but variables are different than previous mutations', async () => {
+  it('does execute the mutation when the mutationKey is the same but variables are different than previous mutations', async () => {
     mockResponses({
       '/mutate': { status: 204 },
     });

--- a/src/hooks/api/authenticated-query.test.js
+++ b/src/hooks/api/authenticated-query.test.js
@@ -280,4 +280,37 @@ describe('useAuthenticatedMutation', () => {
 
     expect(calledMutationsCount).toEqual(2);
   });
+
+  it('compares the payload with the latest mutation', async () => {
+    mockResponses({
+      '/mutate': { status: 204 },
+    });
+
+    const { result, waitForNextUpdate } = renderHookWithWrapper(() =>
+      useAuthenticatedMutation({
+        mutationKey: 'mutate-something',
+        mutationFn: mutationFn,
+      }),
+    );
+
+    await waitForNextUpdate();
+
+    const mutation = result.current;
+
+    await mutation.mutateAsync({
+      test: 'test',
+    });
+
+    await mutation.mutateAsync({
+      different: 'different',
+    });
+
+    await mutation.mutateAsync({
+      test: 'test',
+    });
+
+    const calledMutationsCount = getCalledMutations().length;
+
+    expect(calledMutationsCount).toEqual(3);
+  });
 });

--- a/src/hooks/api/authenticated-query.test.js
+++ b/src/hooks/api/authenticated-query.test.js
@@ -1,3 +1,5 @@
+import { useQueryClient } from 'react-query';
+
 import { renderHookWithWrapper } from '@/test/utils/renderHookWithWrapper';
 import { mockResponses, setupPage } from '@/test/utils/setupPage';
 import { fetchFromApi } from '@/utils/fetchFromApi';
@@ -5,8 +7,17 @@ import { fetchFromApi } from '@/utils/fetchFromApi';
 import {
   getStatusFromResults,
   QueryStatus,
+  useAuthenticatedMutation,
   useAuthenticatedQuery,
 } from './authenticated-query';
+
+const getCalledMutations = (path) => {
+  return fetch.mock.calls.filter((call) => {
+    const url = call[0];
+
+    return url.includes(path || '/mutate');
+  });
+};
 
 const queryFn = async ({ headers, ...queryData }) => {
   const res = await fetchFromApi({
@@ -17,6 +28,16 @@ const queryFn = async ({ headers, ...queryData }) => {
   });
 
   return await res.json();
+};
+
+const mutationFn = async ({ headers }) => {
+  return fetchFromApi({
+    path: '/mutate',
+    options: {
+      method: 'PUT',
+      headers,
+    },
+  });
 };
 
 describe('getStatusFromResults', () => {
@@ -142,5 +163,121 @@ describe('useAuthenticatedQuery', () => {
 
     await waitForNextUpdate();
     expect(page.router.push).toBeCalledWith('/login');
+  });
+});
+
+describe('useAuthenticatedMutation', () => {
+  let page;
+
+  beforeEach(async () => {
+    const { result, waitForNextUpdate } = renderHookWithWrapper(() =>
+      useQueryClient(),
+    );
+
+    await waitForNextUpdate();
+
+    const queryClient = result.current;
+
+    queryClient.getMutationCache().clear();
+    fetch.resetMocks();
+    page = setupPage();
+  });
+
+  it("doesn't excecute the mutation when the mutationKey and variables are the same as previous", async () => {
+    mockResponses({
+      '/mutate': { status: 204 },
+    });
+
+    const { waitForNextUpdate, result } = renderHookWithWrapper(() =>
+      useAuthenticatedMutation({
+        mutationKey: 'mutate-something',
+        mutationFn: mutationFn,
+      }),
+    );
+
+    await waitForNextUpdate({
+      timeout: 3000,
+    });
+
+    const mutation = result.current;
+
+    await mutation.mutateAsync({
+      test: 'test',
+    });
+
+    await mutation.mutateAsync({
+      test: 'test',
+    });
+
+    const calledMutationsCount = getCalledMutations().length;
+
+    expect(calledMutationsCount).toEqual(1);
+  });
+
+  it('does excecute the mutation when the mutationKey is different than previous mutations', async () => {
+    mockResponses({
+      '/mutate': { status: 204 },
+    });
+
+    const mutation1Hook = renderHookWithWrapper(() =>
+      useAuthenticatedMutation({
+        mutationKey: 'mutate-something',
+        mutationFn: mutationFn,
+      }),
+    );
+
+    const mutation2Hook = renderHookWithWrapper(() =>
+      useAuthenticatedMutation({
+        mutationKey: 'mutate-something-else',
+        mutationFn: mutationFn,
+      }),
+    );
+
+    await mutation1Hook.waitForNextUpdate();
+    await mutation2Hook.waitForNextUpdate();
+
+    const mutation1 = mutation1Hook.result.current;
+    const mutation2 = mutation2Hook.result.current;
+
+    await mutation1.mutateAsync({
+      test: 'test',
+    });
+
+    await mutation2.mutateAsync({
+      test: 'test',
+    });
+
+    const calledMutationsCount = getCalledMutations().length;
+
+    expect(calledMutationsCount).toEqual(2);
+  });
+
+  it('does excecute the mutation when the mutationKey is the same but variables are different than previous mutations', async () => {
+    mockResponses({
+      '/mutate': { status: 204 },
+    });
+
+    const { result, waitForNextUpdate } = renderHookWithWrapper(() =>
+      useAuthenticatedMutation({
+        mutationKey: 'mutate-something',
+        mutationFn: mutationFn,
+      }),
+    );
+
+    await waitForNextUpdate();
+
+    const mutation = result.current;
+
+    await mutation.mutateAsync({
+      test: 'test',
+    });
+
+    await mutation.mutateAsync({
+      different: 'different',
+    });
+
+    const calledMutationsCount = getCalledMutations().length;
+
+    expect(calledMutationsCount).toEqual(2);
   });
 });

--- a/src/hooks/api/authenticated-query.ts
+++ b/src/hooks/api/authenticated-query.ts
@@ -159,11 +159,15 @@ const useAuthenticatedMutation = ({ mutationFn, ...configuration }) => {
   const innerMutationFn = useCallback(async (variables) => {
     const mutationCache = queryClient.getMutationCache().getAll();
 
-    // get previous item from cache?
-    const latestMutation = mutationCache.at(-2);
+    const cacheForMutationKey = mutationCache.filter((mutation) => {
+      return mutation.options.mutationKey === configuration.mutationKey;
+    });
 
-    // @ts-expect-error
+    // get previous item from cache?
+    const latestMutation = cacheForMutationKey.at(-2);
+
     if (
+      // @ts-expect-error
       latestMutation?.options?.variables &&
       isEqual(latestMutation.options.variables, variables)
     ) {
@@ -199,8 +203,6 @@ const useAuthenticatedMutations = ({
 }) => {
   const router = useRouter();
   const headers = useHeaders();
-
-  console.log('in authenticatedMutations');
 
   const { removeAuthenticationCookies } = useCookiesWithOptions();
 

--- a/src/hooks/api/events.ts
+++ b/src/hooks/api/events.ts
@@ -94,6 +94,7 @@ const addEvent = async ({
 const useAddEventMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addEvent,
+    mutationKey: 'events-add',
     ...configuration,
   });
 
@@ -188,6 +189,7 @@ const deleteEventById = async ({ headers, id }) =>
 const useDeleteEventByIdMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: deleteEventById,
+    mutationKey: 'events-delete-by-id',
     ...configuration,
   });
 
@@ -290,7 +292,11 @@ const changeLocation = async ({ headers, eventId, locationId }) => {
 };
 
 const useChangeLocationMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeLocation, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeLocation,
+    mutationKey: 'events-change-location',
+    ...configuration,
+  });
 
 const changeAvailableFrom = async ({ headers, id, availableFrom }) => {
   return fetchFromApi({
@@ -306,6 +312,7 @@ const changeAvailableFrom = async ({ headers, id, availableFrom }) => {
 const useChangeAvailableFromMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeAvailableFrom,
+    mutationKey: 'events-change-available-from',
     ...configuration,
   });
 
@@ -321,7 +328,11 @@ const changeName = async ({ headers, id, lang, name }) => {
 };
 
 const useChangeNameMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeName, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeName,
+    mutationKey: 'events-change-name',
+    ...configuration,
+  });
 
 const changeCalendar = async ({
   headers,
@@ -361,7 +372,11 @@ const changeCalendar = async ({
 };
 
 const useChangeCalendarMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeCalendar, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeCalendar,
+    mutationKey: 'events-change-calendar',
+    ...configuration,
+  });
 
 const changeStatus = async ({ headers, id, type, reason }) =>
   fetchFromApi({
@@ -374,7 +389,11 @@ const changeStatus = async ({ headers, id, type, reason }) =>
   });
 
 const useChangeStatusMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeStatus, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeStatus,
+    mutationKey: 'events-change-status',
+    ...configuration,
+  });
 
 const changeStatusSubEvents = async ({
   headers,
@@ -435,6 +454,7 @@ const createSubEventPatch = (
 const useChangeStatusSubEventsMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeStatusSubEvents,
+    mutationKey: 'events-change-status-sub-events',
     ...configuration,
   });
 
@@ -454,6 +474,7 @@ const publish = async ({ headers, id, publicationDate }) =>
 const usePublishEventMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: publish,
+    mutationKey: 'events-publish',
     ...configuration,
   });
 
@@ -472,6 +493,7 @@ const changeAudience = async ({ headers, eventId, audienceType }) =>
 const useChangeAudienceMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeAudience,
+    mutationKey: 'events-change-audience',
     ...configuration,
   });
 
@@ -493,6 +515,7 @@ const changeAttendanceMode = async ({
 const useChangeAttendanceModeMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeAttendanceMode,
+    mutationKey: 'events-change-attendance-mode',
     ...configuration,
   });
 
@@ -509,6 +532,7 @@ const changeOnlineUrl = async ({ headers, eventId, onlineUrl }) =>
 const useChangeOnlineUrlMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeOnlineUrl,
+    mutationKey: 'events-change-online-url',
     ...configuration,
   });
 
@@ -524,6 +548,7 @@ const deleteOnlineUrl = async ({ headers, eventId }) =>
 const useDeleteOnlineUrlMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: deleteOnlineUrl,
+    mutationKey: 'events-delete-online-url',
     ...configuration,
   });
 export {

--- a/src/hooks/api/images.ts
+++ b/src/hooks/api/images.ts
@@ -31,6 +31,10 @@ const addImage = async ({
 };
 
 const useAddImageMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: addImage, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: addImage,
+    mutationKey: 'images-add',
+    ...configuration,
+  });
 
 export { useAddImageMutation };

--- a/src/hooks/api/offers.ts
+++ b/src/hooks/api/offers.ts
@@ -102,7 +102,11 @@ const changeOfferName = async ({ headers, id, lang, name, scope }) => {
 };
 
 const useChangeOfferNameMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeOfferName, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeOfferName,
+    mutationKey: 'offers-change-name',
+    ...configuration,
+  });
 
 const changeOfferTypicalAgeRange = async ({
   headers,
@@ -122,6 +126,7 @@ const changeOfferTypicalAgeRange = async ({
 const useChangeOfferTypicalAgeRangeMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeOfferTypicalAgeRange,
+    mutationKey: 'offers-change-typical-age-range',
     ...configuration,
   });
 
@@ -166,6 +171,7 @@ const changeOfferCalendar = async ({
 const useChangeOfferCalendarMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeOfferCalendar,
+    mutationKey: 'offers-change-calendar',
     ...configuration,
   });
 
@@ -190,12 +196,14 @@ const removeOfferLabel = async ({ headers, id, label, scope }) =>
 const useAddOfferLabelMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addOfferLabel,
+    mutationKey: 'offers-add-label',
     ...configuration,
   });
 
 const useRemoveOfferLabelMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: removeOfferLabel,
+    mutationKey: 'offers-remove-label',
     ...configuration,
   });
 
@@ -220,7 +228,11 @@ const changeOfferTheme = async ({ headers, id, themeId, scope }) => {
 };
 
 const useChangeOfferThemeMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeOfferTheme, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeOfferTheme,
+    mutationKey: 'offers-change-theme',
+    ...configuration,
+  });
 
 const changeOfferType = async ({ headers, id, typeId, scope }) =>
   fetchFromApi({
@@ -232,7 +244,11 @@ const changeOfferType = async ({ headers, id, typeId, scope }) =>
   });
 
 const useChangeOfferTypeMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeOfferType, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeOfferType,
+    mutationKey: 'offers-change-type',
+    ...configuration,
+  });
 
 const addOfferPriceInfo = async ({ headers, id, priceInfo, scope }) =>
   fetchFromApi({
@@ -247,6 +263,7 @@ const addOfferPriceInfo = async ({ headers, id, priceInfo, scope }) =>
 const useAddOfferPriceInfoMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addOfferPriceInfo,
+    mutationKey: 'offers-add-price-info',
     ...configuration,
   });
 
@@ -269,6 +286,7 @@ const changeOfferDescription = async ({
 const useChangeOfferDescriptionMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeOfferDescription,
+    mutationKey: 'offers-change-description',
     ...configuration,
   });
 
@@ -283,7 +301,11 @@ const addOfferImage = async ({ headers, eventId, imageId, scope }) =>
   });
 
 const useAddOfferImageMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: addOfferImage, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: addOfferImage,
+    mutationKey: 'offers-add-image',
+    ...configuration,
+  });
 
 const addOfferMainImage = async ({ headers, eventId, imageId, scope }) =>
   fetchFromApi({
@@ -298,6 +320,7 @@ const addOfferMainImage = async ({ headers, eventId, imageId, scope }) =>
 const useAddOfferMainImageMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addOfferMainImage,
+    mutationKey: 'offers-add-main-image',
     ...configuration,
   });
 
@@ -317,6 +340,7 @@ const addOfferVideo = async ({ headers, eventId, url, language, scope }) =>
 const useAddOfferVideoMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addOfferVideo,
+    mutationKey: 'offers-add-video',
     ...configuration,
   });
 
@@ -332,6 +356,7 @@ const deleteOfferVideo = async ({ headers, eventId, videoId, scope }) =>
 const useDeleteOfferVideoMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: deleteOfferVideo,
+    mutationKey: 'offers-delete-video',
     ...configuration,
   });
 
@@ -355,6 +380,7 @@ const updateOfferImage = async ({
 const useUpdateOfferImageMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: updateOfferImage,
+    mutationKey: 'offers-update-image',
     ...configuration,
   });
 
@@ -370,6 +396,7 @@ const deleteOfferImage = async ({ headers, eventId, imageId, scope }) =>
 const useDeleteOfferImageMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: deleteOfferImage,
+    mutationKey: 'offers-delete-image',
     ...configuration,
   });
 
@@ -391,6 +418,7 @@ const addOfferContactPoint = async ({
 const useAddOfferContactPointMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addOfferContactPoint,
+    mutationKey: 'offers-add-contact-point',
     ...configuration,
   });
 
@@ -413,6 +441,7 @@ const addOfferBookingInfo = async ({
 const useAddOfferBookingInfoMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addOfferBookingInfo,
+    mutationKey: 'offers-add-booking-info',
     ...configuration,
   });
 
@@ -428,6 +457,7 @@ const addOfferOrganizer = async ({ headers, id, organizerId, scope }) =>
 const useAddOfferOrganizerMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addOfferOrganizer,
+    mutationKey: 'offers-add-organizer',
     ...configuration,
   });
 
@@ -443,6 +473,7 @@ const deleteOfferOrganizer = async ({ headers, id, organizerId, scope }) =>
 const useDeleteOfferOrganizerMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: deleteOfferOrganizer,
+    mutationKey: 'offers-delete-organizer',
     ...configuration,
   });
 

--- a/src/hooks/api/organizers.ts
+++ b/src/hooks/api/organizers.ts
@@ -172,6 +172,7 @@ const deleteOrganizerById = async ({ headers, id }) =>
 const useDeleteOrganizerByIdMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: deleteOrganizerById,
+    mutationKey: 'organizers-delete-by-id',
     ...configuration,
   });
 
@@ -232,6 +233,7 @@ const createOrganizer = ({
 const useCreateOrganizerMutation = (configuration: UseMutationOptions = {}) =>
   useAuthenticatedMutation({
     mutationFn: createOrganizer,
+    mutationKey: 'organizers-create',
     ...configuration,
   });
 

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -203,7 +203,11 @@ const changeAddress = async ({ headers, id, address, language }) =>
   });
 
 const useChangeAddressMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeAddress, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeAddress,
+    mutationKey: 'places-change-address',
+    ...configuration,
+  });
 
 const deletePlaceById = async ({ headers, id }) =>
   fetchFromApi({
@@ -214,6 +218,7 @@ const deletePlaceById = async ({ headers, id }) =>
 const useDeletePlaceByIdMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: deletePlaceById,
+    mutationKey: 'places-delete-by-id',
     ...configuration,
   });
 
@@ -240,7 +245,11 @@ const changeStatus = async ({
   });
 
 const useChangeStatusMutation = (configuration: UseMutationOptions = {}) =>
-  useAuthenticatedMutation({ mutationFn: changeStatus, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: changeStatus,
+    mutationKey: 'places-change-status',
+    ...configuration,
+  });
 
 type PlaceArguments = {
   address: Address;
@@ -293,6 +302,7 @@ const addPlace = async ({
 const useAddPlaceMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addPlace,
+    mutationKey: 'places-add',
     ...configuration,
   });
 
@@ -312,6 +322,7 @@ const publish = async ({ headers, id, publicationDate }) =>
 const usePublishPlaceMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: publish,
+    mutationKey: 'places-publish',
     ...configuration,
   });
 

--- a/src/hooks/api/productions.ts
+++ b/src/hooks/api/productions.ts
@@ -56,7 +56,11 @@ const deleteEventById = async ({
   });
 
 const useDeleteEventByIdMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: deleteEventById, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: deleteEventById,
+    mutationKey: 'productions-delete-event-by-id',
+    ...configuration,
+  });
 
 const deleteEventsByIds = async ({
   productionId = '',
@@ -91,7 +95,11 @@ const addEventById = async ({
   });
 
 const useAddEventByIdMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: addEventById, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: addEventById,
+    mutationKey: 'productions-add-event-by-id',
+    ...configuration,
+  });
 
 const addEventsByIds = async ({ productionId = '', eventIds = [], headers }) =>
   Promise.all(
@@ -140,6 +148,7 @@ const skipSuggestedEvents = async ({ headers, eventIds = [] }) =>
 const useSkipSuggestedEventsMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: skipSuggestedEvents,
+    mutationKey: 'productions-skip-suggested-events',
     ...configuration,
   });
 
@@ -157,7 +166,11 @@ const createWithEvents = async ({ headers, productionName, eventIds = [] }) =>
   });
 
 const useCreateWithEventsMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: createWithEvents, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: createWithEvents,
+    mutationKey: 'productions-create-with-events',
+    ...configuration,
+  });
 
 const mergeProductions = async ({
   headers,
@@ -170,7 +183,11 @@ const mergeProductions = async ({
   });
 
 const useMergeProductionsMutation = (configuration = {}) =>
-  useAuthenticatedMutation({ mutationFn: mergeProductions, ...configuration });
+  useAuthenticatedMutation({
+    mutationFn: mergeProductions,
+    mutationKey: 'productions-merge',
+    ...configuration,
+  });
 
 const changeProductionName = async ({
   productionId = '',
@@ -193,6 +210,7 @@ const changeProductionName = async ({
 const useChangeProductionNameMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeProductionName,
+    mutationKey: 'productions-change-name',
     ...configuration,
   });
 

--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -87,6 +87,7 @@ const addCardSystemToEvent = async ({ headers, eventId, cardSystemId }) =>
 const useAddCardSystemToEventMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: addCardSystemToEvent,
+    mutationKey: 'uitpas-add-cardsystem-to-event',
     ...configuration,
   });
 
@@ -102,6 +103,7 @@ const deleteCardSystemFromEvent = async ({ headers, eventId, cardSystemId }) =>
 const useDeleteCardSystemFromEventMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: deleteCardSystemFromEvent,
+    mutationKey: 'uitpas-delete-cardsystem-from-event',
     ...configuration,
   });
 
@@ -122,6 +124,7 @@ const changeDistributionKey = async ({
 const useChangeDistributionKeyMutation = (configuration = {}) =>
   useAuthenticatedMutation({
     mutationFn: changeDistributionKey,
+    mutationKey: 'uitpas-change-distribution-key',
     ...configuration,
   });
 


### PR DESCRIPTION
### Added
- `mutationKeys` to all mutations
- test for mutation cache mechanism

### Changed
- only execute mutation when the payload is different to the previous payload of the mutation with the same cacheKey

---
Ticket: https://jira.uitdatabank.be/browse/III-5591
