### PR TITLE
Tweak condition showing recent locations to not show for school offers

### DIFF
--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -823,7 +823,6 @@ const LocationStep = ({
           const { isOnline, municipality, country, place } =
             field?.value as OfferFormData['location'];
 
-          const hasLocation = place?.['@id'];
           const onFieldChange = (updatedValue) => {
             updatedValue = { ...field.value, ...updatedValue };
             field.onChange(updatedValue);
@@ -832,7 +831,7 @@ const LocationStep = ({
           };
 
           const showRecentLocations =
-            !isOnline && ((!municipality && country) || !hasLocation);
+            !isOnline && country && (!municipality || !place);
 
           const renderFieldWithRecentLocations = (children) => (
             <Stack spacing={5} maxWidth={'50%'}>


### PR DESCRIPTION
### Fixed

- Tweak condition showing recent locations to not show for school offers

---

I tried to test every variation as the previous condition worked for existing offers but not when filling new ones (since `place` is empty until first publication). This one should work for both new and existing offers

Ticket: https://jira.uitdatabank.be/browse/III-5571
