### PR TITLE
III-5618 - DescriptionStep: don't do a mutation when last change type is null

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/DescriptionStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/DescriptionStep.tsx
@@ -144,6 +144,10 @@ const DescriptionStep = ({
       isCompleted ? ValidationStatus.SUCCESS : ValidationStatus.NONE,
     );
 
+    if (!editorState.getLastChangeType()) {
+      return;
+    }
+
     changeDescriptionMutation.mutate({
       description:
         plainTextDescription.length > 0


### PR DESCRIPTION
### Added
- `DescriptionStep` added early return before mutation when `lastChangeType` is null

---
Ticket: https://jira.uitdatabank.be/browse/III-5618
