### PR TITLE
III-5619 - Early return when no dirtyFields

### DIFF
--- a/src/pages/steps/modals/PictureUploadModal.tsx
+++ b/src/pages/steps/modals/PictureUploadModal.tsx
@@ -204,7 +204,7 @@ const PictureUploadModal = ({
     control,
     reset,
     register,
-    formState: { errors },
+    formState: { errors, dirtyFields },
     handleSubmit,
     setValue,
   } = useForm<FormData>({
@@ -257,6 +257,10 @@ const PictureUploadModal = ({
       cancelTitle={t('pictures.upload_modal.actions.cancel')}
       size={ModalSizes.MD}
       onConfirm={() => {
+        if (!dirtyFields.description) {
+          onClose();
+        }
+
         formComponent.current.dispatchEvent(
           new Event('submit', { cancelable: true, bubbles: true }),
         );


### PR DESCRIPTION
### Added
- `PictureUploadBox`: early return when no dirtyFields

---
Ticket: https://jira.uitdatabank.be/browse/III-5619
