### PR TITLE
Don't show flash message when nothing changed in ContactInfostep

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
@@ -154,6 +154,10 @@ const ContactInfoStep = ({
       );
     },
     onSuccess: (data) => {
+      if (typeof data === 'undefined') {
+        return;
+      }
+
       onValidationChange(ValidationStatus.SUCCESS);
       onSuccessfulChange(data);
     },


### PR DESCRIPTION
### Fixed

- Don't show flash message when nothing changed in ContactInfostep

---

The extra requests were already fixed by #714 this just prevent the success flash messages from still firing

Ticket: https://jira.uitdatabank.be/browse/III-5617
