### PR TITLE
Fix getLanguageObjectOrFallback trying to use NL default when object is not localized

### DIFF
--- a/src/utils/getLanguageObjectOrFallback.ts
+++ b/src/utils/getLanguageObjectOrFallback.ts
@@ -14,7 +14,7 @@ const getLanguageObjectOrFallback = <TReturned>(
   }
 
   // use nl as fallback language
-  if (typeof obj !== 'string') {
+  if (typeof obj !== 'string' && obj[SupportedLanguages.NL]) {
     return obj[SupportedLanguages.NL] as TReturned;
   }
 


### PR DESCRIPTION
### Fixed

- Fix getLanguageObjectOrFallback trying to use NL default when object is not localized

---

Ticket: https://jira.uitdatabank.be/browse/III-5595
