### PR TITLE
III-5643 - Set user query to enabled: false

### DIFF
--- a/src/hooks/api/user.ts
+++ b/src/hooks/api/user.ts
@@ -59,8 +59,8 @@ const useGetUserQuery = (
     queryClient,
     queryKey: ['user'],
     queryFn: getUser,
+    staleTime: Infinity,
     ...configuration,
-    enabled: false,
   });
 };
 

--- a/src/hooks/api/user.ts
+++ b/src/hooks/api/user.ts
@@ -60,6 +60,7 @@ const useGetUserQuery = (
     queryKey: ['user'],
     queryFn: getUser,
     ...configuration,
+    enabled: false,
   });
 };
 


### PR DESCRIPTION
### Added
- `staleTime: infinity` to useGetUserQuery

### Fixed
- userQuery executed too often resulting in a `429: Too many requests` error from auth0

https://tanstack.com/query/latest/docs/react/guides/disabling-queries?from=reactQueryV3&original=https%3A%2F%2Ftanstack.com%2Fquery%2Fv3%2Fdocs%2Fguides%2Fdisabling-queries



---
Ticket: https://jira.uitdatabank.be/browse/III-5643
