### PR TITLE
III-5642 - Fix too many calls to /userInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "i18next": "^19.8.3",
     "i18next-browser-languagedetector": "^6.0.1",
     "immutable": "^4.2.4",
+    "jwt-decode": "^3.1.2",
     "lodash": "^4.17.20",
     "next": "^12.3.0",
     "next-absolute-url": "^1.2.2",

--- a/src/hooks/useCookiesWithOptions.ts
+++ b/src/hooks/useCookiesWithOptions.ts
@@ -9,6 +9,7 @@ const defaultCookieOptions = {
 type Cookies = {
   'udb-language'?: string;
   token?: string;
+  idToken?: string;
 };
 
 type SetCookie = (name: string, value: any, options?: CookieSetOptions) => void;
@@ -24,7 +25,7 @@ const useCookiesWithOptions = (
   const setCookieWithOptions = (name: string, value: any) =>
     setCookie(name, value, options);
   const removeAuthenticationCookies = () =>
-    ['token'].forEach((cookie) => removeCookie(cookie));
+    ['token', 'idToken'].forEach((cookie) => removeCookie(cookie));
 
   return {
     cookies,
@@ -35,3 +36,4 @@ const useCookiesWithOptions = (
 };
 
 export { defaultCookieOptions, useCookiesWithOptions };
+export type { Cookies };

--- a/src/middleware.api.ts
+++ b/src/middleware.api.ts
@@ -14,8 +14,9 @@ export const middleware = async (request: NextRequest) => {
 
     try {
       const response = NextResponse.redirect(referer);
-      const { accessToken } = await getSession(request, response);
+      const { accessToken, idToken } = await getSession(request, response);
       response.cookies.set('token', accessToken, defaultCookieOptions);
+      response.cookies.set('idToken', idToken, defaultCookieOptions);
       response.cookies.set('auth0.redirect_uri', '', { maxAge: 0 });
       return response;
     } catch (err) {

--- a/src/pages/dashboard/index.page.tsx
+++ b/src/pages/dashboard/index.page.tsx
@@ -22,7 +22,11 @@ import {
   useDeletePlaceByIdMutation,
   useGetPlacesByCreatorQuery,
 } from '@/hooks/api/places';
-import { useGetUserQuery, User } from '@/hooks/api/user';
+import {
+  useGetUserQuery,
+  useGetUserQueryServerSide,
+  User,
+} from '@/hooks/api/user';
 import { FeatureFlags, useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { Footer } from '@/pages/Footer';
 import type { Event } from '@/types/Event';
@@ -713,7 +717,10 @@ const Dashboard = (): any => {
 
 const getServerSideProps = getApplicationServerSideProps(
   async ({ req, query, cookies: rawCookies, queryClient }) => {
-    const user = (await useGetUserQuery({ req, queryClient })) as User;
+    const user = (await useGetUserQueryServerSide({
+      req,
+      queryClient,
+    })) as User;
 
     await Promise.all(
       Object.entries(UseGetItemsByCreatorMap).map(([key, hook]) => {

--- a/src/pages/events/[eventId]/availability.multiple.test.js
+++ b/src/pages/events/[eventId]/availability.multiple.test.js
@@ -72,7 +72,7 @@ test('I can save a status', async () => {
 
   await waitForFetch(`/events/${page.router.query.eventId}/subEvents`);
 
-  expect(fetch.mock.calls[4][1].body).toEqual(
+  expect(fetch.mock.calls[3][1].body).toEqual(
     JSON.stringify([
       {
         id: 0,

--- a/src/pages/events/[eventId]/availability.single.test.js
+++ b/src/pages/events/[eventId]/availability.single.test.js
@@ -52,7 +52,7 @@ test('I can save a status', async () => {
 
   await waitForFetch(`/events/${page.router.query.eventId}/subEvents`);
 
-  expect(fetch.mock.calls[4][1].body).toEqual(
+  expect(fetch.mock.calls[3][1].body).toEqual(
     JSON.stringify([
       {
         id: 0,

--- a/src/pages/places/[placeId]/availability.test.js
+++ b/src/pages/places/[placeId]/availability.test.js
@@ -49,7 +49,7 @@ test('I can save a status', async () => {
 
   await waitForFetch(`/places/${page.router.query.placeId}/status`);
 
-  expect(fetch.mock.calls[4][1].body).toEqual(
+  expect(fetch.mock.calls[3][1].body).toEqual(
     JSON.stringify({
       type: OfferStatus.AVAILABLE,
     }),

--- a/src/utils/fetchFromApi.ts
+++ b/src/utils/fetchFromApi.ts
@@ -29,7 +29,6 @@ type FetchFromApiArguments = {
   searchParams?: { [key: string]: string };
   options?: RequestInit;
   silentError?: boolean;
-  apiUrl?: string;
 };
 
 const { publicRuntimeConfig } = getConfig();
@@ -39,13 +38,12 @@ const fetchFromApi = async ({
   searchParams = {},
   options = {},
   silentError = false,
-  apiUrl = publicRuntimeConfig.apiUrl,
 }: FetchFromApiArguments): Promise<ErrorObject | Response> => {
   let response: Response;
   let url: URL;
 
   try {
-    url = new URL(`${apiUrl}${path}`);
+    url = new URL(`${publicRuntimeConfig.apiUrl}${path}`);
     searchParams = omit(searchParams, 'queryKey');
     if (typeof searchParams?.q !== 'undefined' && !searchParams?.q) {
       searchParams = omit(searchParams, 'q');

--- a/src/utils/getApplicationServerSideProps.js
+++ b/src/utils/getApplicationServerSideProps.js
@@ -5,7 +5,7 @@ import { QueryClient } from 'react-query';
 import { generatePath, matchPath } from 'react-router';
 import UniversalCookies from 'universal-cookie';
 
-import { useGetUserQuery } from '@/hooks/api/user';
+import { useGetUserQuery, useGetUserQueryServerSide } from '@/hooks/api/user';
 import { defaultCookieOptions } from '@/hooks/useCookiesWithOptions';
 import { isFeatureFlagEnabledInCookies } from '@/hooks/useFeatureFlag';
 
@@ -121,7 +121,7 @@ const getApplicationServerSideProps =
     const queryClient = new QueryClient();
 
     try {
-      await useGetUserQuery({ req, queryClient });
+      await useGetUserQueryServerSide({ req, queryClient });
     } catch (error) {
       if (error instanceof FetchError) {
         return redirectToLogin(cookies, req, resolvedUrl);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9115,6 +9115,11 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
### Added
- [jwt-decode package](https://github.com/cultuurnet/udb3-frontend/pull/749/commits/0e18f197082ff9ce6087004cc38217fb05018df5)

### Changed
- [Get userInfo based on decoded idToken instead of api call](https://github.com/cultuurnet/udb3-frontend/pull/749/commits/fa119ffe0085e53859ce9a92b53110b5fe00131a)

### Removed
- [unnecessary apiUrl argument in fetchFromApi](https://github.com/cultuurnet/udb3-frontend/pull/749/commits/d88f96da7fba07a7df4e84d4deef1f0e245b2ba6)

### Fixed
- too many calls to auth0 /userInfo endpoint

---

Ticket: https://jira.uitdatabank.be/browse/III-5642 
