### PR TITLE
Check if price form is dirty before triggering invalidation

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -153,7 +153,8 @@ const PriceInformation = ({
     setValue,
     handleSubmit,
     watch,
-    formState: { errors },
+    reset,
+    formState: { errors, dirtyFields },
   } = useForm<FormData>({
     resolver: yupResolver(schema),
     defaultValues: defaultPriceInfoValues,
@@ -173,7 +174,8 @@ const PriceInformation = ({
 
   const addPriceInfoMutation = useAddOfferPriceInfoMutation({
     onSuccess: (data) => {
-      if (typeof data === 'undefined') return;
+      const isFormDirty = Object.keys(dirtyFields).length > 0;
+      if (typeof data === 'undefined' || !isFormDirty) return;
 
       return setTimeout(() => onSuccessfulChange(), 1000);
     },
@@ -215,6 +217,7 @@ const PriceInformation = ({
 
     if (!hasRates) {
       replace(priceInfo.length ? priceInfo : defaultPriceInfoValues.rates);
+      reset({}, { keepValues: true });
 
       return onValidationChange(
         hasUitpasLabel ? ValidationStatus.WARNING : ValidationStatus.NONE,
@@ -224,6 +227,7 @@ const PriceInformation = ({
     onValidationChange(ValidationStatus.SUCCESS);
 
     replace(reconcileRates(rates, priceInfo, offer));
+    reset({}, { keepValues: true });
     // onValidationChange is hard to wrap in useCallback in parent
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [


### PR DESCRIPTION
### Fixed

- Check if price form is dirty before triggering invalidation

---

This does not affect PUT requests since that'll be fixed separately through the mutation change. This only conditionally avoids triggering the `onSuccess` callback when no data has changed, which invalidates the step and refetches the offer.

Since we replace the form's values on load, it marks all fields as dirty. Using `reset({}, {keepValues: true})` does not touch any of the data but only resets form states (like dirty/touched) which allows us to rely on that to check if the form is dirty or not.

---

Ticket: https://jira.uitdatabank.be/browse/III-5626
