### PR TITLE
Fix ErrorBoundary (ironically) crashing when catching errors

### DIFF
--- a/src/layouts/ErrorFallback.js
+++ b/src/layouts/ErrorFallback.js
@@ -45,11 +45,6 @@ const ErrorFallback = ({ error }) => {
         color={getValue('iconColor')}
       />
       <Title size={1}>{t('error.title')}</Title>
-      {error && (
-        <Title size={2}>
-          {error.name}: {error.message}
-        </Title>
-      )}
       <Text maxWidth={550}>
         <Trans i18nKey="error.description">
           Er ging iets mis. Herlaad de pagina om opnieuw te proberen. Neem


### PR DESCRIPTION
### Fixed

- Fix ErrorBoundary (ironically) crashing when catching errors

---

Because `Title` (or a component down the chain) expects `children` to only be one child/component, it was currently crashing when `ErrorFallback` was trying to render the Error title and message as multiple ones.

While wrapping the error title/message in a `span` or similar fixes it, it was decided that since the component sends the full stack and details to Sentry, it's more confusing to show the error message to the end user than not, so I simply removed the section.

This does mean that currently the error boundary was not properly working and was instead showing a generic blank page. So I'm not sure all errors were making it to Sentry before, so this should help with future rounds of debugging.


![Screenshot 2023-06-16 at 14 45 07](https://github.com/cultuurnet/udb3-frontend/assets/1321596/5f927d0f-2c4b-4548-ae67-b25ef78d47ea)

---

Ticket: https://jira.uitdatabank.be/browse/III-5668