### PR TITLE
III-5719 - Fix incorrect validation of dutch zip codes

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -797,7 +797,10 @@
         "cancel": "Absagen"
       },
       "info": {
-        "zip": "Beispiel 1104CA"
+        "zip": {
+          "nl": "Beispiel 1104CA",
+          "de": "Beispiel 10115"
+        }
       },
       "labels": {
         "address": {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -797,7 +797,7 @@
         "cancel": "Absagen"
       },
       "info": {
-        "zip": "Beispiel 10115"
+        "zip": "Beispiel 1104CA"
       },
       "labels": {
         "address": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -796,7 +796,10 @@
         "cancel": "Annuler"
       },
       "info": {
-        "zip": "par ex. 1104CA"
+        "zip": {
+          "nl": "par ex. 1104CA",
+          "de": "par ex. 10115"
+        }
       },
       "labels": {
         "address": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -796,7 +796,7 @@
         "cancel": "Annuler"
       },
       "info": {
-        "zip": "par ex. 10115"
+        "zip": "par ex. 1104CA"
       },
       "labels": {
         "address": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -796,7 +796,10 @@
         "cancel": "Annuleren"
       },
       "info": {
-        "zip": "bv. 1104CA"
+        "zip": {
+          "nl": "bv. 1104CA",
+          "de": "bv. 10115"
+        }
       },
       "labels": {
         "address": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -796,7 +796,7 @@
         "cancel": "Annuleren"
       },
       "info": {
-        "zip": "bv. 10115"
+        "zip": "bv. 1104CA"
       },
       "labels": {
         "address": {

--- a/src/pages/OrganizerAddModal.tsx
+++ b/src/pages/OrganizerAddModal.tsx
@@ -360,12 +360,15 @@ const OrganizerAddModal = ({
                   }}
                 />
               </Stack>
-              {(watchedCountry === 'NL' || watchedCountry === 'DE') && (
+              {(watchedCountry === Countries.NL ||
+                watchedCountry === Countries.DE) && (
                 <FormElement
                   Component={<Input {...register('address.city.zip')} />}
                   id="organizer-address-city-zip"
                   label={t('organizer.add_modal.labels.address.zip')}
-                  info={t('organizer.add_modal.info.zip')}
+                  info={t(
+                    `organizer.add_modal.info.zip.${watchedCountry.toLowerCase()}`,
+                  )}
                   error={
                     formState.errors.address?.city?.zip &&
                     t(

--- a/src/pages/OrganizerAddModal.tsx
+++ b/src/pages/OrganizerAddModal.tsx
@@ -32,6 +32,7 @@ import { City, CityPicker } from './CityPicker';
 const getValue = getValueFromTheme('organizerAddModal');
 
 const GERMAN_ZIP_REGEX: RegExp = /\b\d{5}\b/;
+const DUTCH_ZIP_REGEX: RegExp = /^\d{4}([A-Za-z0-9]{2})?$/;
 
 const schema = yup
   .object({
@@ -59,9 +60,7 @@ const schema = yup
           then: yup.object({
             label: yup.string(),
             name: yup.string(),
-            zip: yup.string().test('valid_dutch_zip', (zip: string) => {
-              return zip?.length === 5;
-            }),
+            zip: yup.string().matches(DUTCH_ZIP_REGEX),
           }),
         })
         .when('country', {


### PR DESCRIPTION
### Added
- Regex for dutch zip codes

```javascript
var regex = /^\d{4}([A-Za-z0-9]{2})?$/;

console.log(regex.test("1234"));       // true
console.log(regex.test("1234AB"));     // true
console.log(regex.test("123"));        // false, less than 4 digits
console.log(regex.test("12345"));      // false, more than 4 digits
console.log(regex.test("1234ABC"));    // false, more than 2 alphanumeric characters
console.log(regex.test("1234AB7"));    // false, more than 2 alphanumeric characters

```

### Changed
- Copy for example dutch zip code

---
Ticket: https://jira.uitdatabank.be/browse/III-5719
