### PR TITLE
Prevent images from being stretched in the Announcements

### DIFF
--- a/src/layouts/Announcements.js
+++ b/src/layouts/Announcements.js
@@ -92,9 +92,11 @@ const AnnouncementContent = ({
       alt={callToActionLabel ?? ''}
       width="100%"
       maxHeight="30vh"
+      objectFit="contain"
       opacity={{ hover: 0.85 }}
     />
   );
+
   return (
     <Stack as="article" padding={4} spacing={3} width="70%">
       <Title>{title}</Title>


### PR DESCRIPTION
### Fixed

- Prevent images from being stretched in the Announcements

---

I opted for an `object-fit` instead of removing the `max-height` altogether so that the text of the announcement isn't pushed out of view either

![Screenshot 2023-08-10 at 13 30 42](https://github.com/cultuurnet/udb3-frontend/assets/1321596/b39c1c0d-7c73-4d3b-aaa0-939fda1bea44)


Ticket: https://jira.uitdatabank.be/browse/III-5747