### PR TITLE
III-5845 - Organizer form: change title of location tab to 'Adres'

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -452,7 +452,8 @@
         }
       },
       "location": {
-        "title": "Standort"
+        "title": "Standort",
+        "title_organizer": "Adresse"
       },
       "place": {
         "add_new_label": "Ort nicht gefunden? Neuen Standort hinzufügen"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -454,7 +454,8 @@
         }
       },
       "location": {
-        "title": "Lieu"
+        "title": "Lieu",
+        "title_organizer": "Adresse"
       },
       "place": {
         "add_new_label": "Lieu introuvable ? Ajouter un nouveau lieu"

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -454,7 +454,8 @@
         }
       },
       "location": {
-        "title": "Locatie"
+        "title": "Locatie",
+        "title_organizer": "Adres"
       },
       "place": {
         "add_new_label": "Locatie niet gevonden? Nieuwe locatie toevoegen"

--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -62,6 +62,7 @@ type TabContentProps = {
 
 type TabConfig = {
   field: Field;
+  titleKey?: string;
   TabContent: FC<TabContentProps & { [prop: string]: unknown }>;
   shouldShowOn?: Values<typeof AdditionalInformationStepVariant>[];
   shouldInvalidate: boolean;
@@ -117,6 +118,7 @@ const tabConfigurations: TabConfig[] = [
   {
     field: Fields.LOCATION,
     TabContent: PhysicalLocationStep,
+    titleKey: 'create.additionalInformation.location.title_organizer',
     shouldInvalidate: false,
     shouldShowOn: [AdditionalInformationStepVariant.ORGANIZER],
   },
@@ -143,6 +145,7 @@ const tabConfigurations: TabConfig[] = [
 type TabTitleProps = InlineProps & {
   scope: Scope;
   field: Field;
+  titleKey?: string;
   validationStatus: ValidationStatus;
 };
 
@@ -150,9 +153,14 @@ const TabTitle = ({
   scope,
   field,
   validationStatus,
+  titleKey,
   ...props
 }: TabTitleProps) => {
   const { t } = useTranslation();
+
+  const title = titleKey
+    ? t(titleKey)
+    : t(`create.additionalInformation.${field}.title`);
 
   return (
     <Inline spacing={3} {...getInlineProps(props)}>
@@ -168,7 +176,7 @@ const TabTitle = ({
       <Text>
         {scope === ScopeTypes.ORGANIZERS && field === Fields.MEDIA
           ? t('organizers.create.step2.pictures.title')
-          : t(`create.additionalInformation.${field}.title`)}
+          : title}
       </Text>
     </Inline>
   );
@@ -262,6 +270,7 @@ const AdditionalInformationStep = ({
           ({
             shouldShowOn,
             field,
+            titleKey,
             shouldInvalidate,
             TabContent,
             stepProps,
@@ -280,6 +289,7 @@ const AdditionalInformationStep = ({
                   <TabTitle
                     scope={scope}
                     field={field}
+                    titleKey={titleKey}
                     validationStatus={validatedFields[field]}
                   />
                 }

--- a/src/pages/steps/AdditionalInformationStep/PhysicalLocationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PhysicalLocationStep.tsx
@@ -6,7 +6,7 @@ import {
   TabContentProps,
   ValidationStatus,
 } from '@/pages/steps/AdditionalInformationStep/AdditionalInformationStep';
-import { isLocationSet, LocationStep } from '@/pages/steps/LocationStep';
+import { LocationStep } from '@/pages/steps/LocationStep';
 import { StepProps } from '@/pages/steps/Steps';
 import { StackProps } from '@/ui/Stack';
 

--- a/src/test/e2e/create-organizer.spec.ts
+++ b/src/test/e2e/create-organizer.spec.ts
@@ -56,7 +56,7 @@ test('create an organizer', async ({ baseURL, page }) => {
   await page.getByRole('button', { name: 'Uploaden' }).click();
   await page.getByText(`© ${dummyOrganizer.image.copyright}`).click();
 
-  await page.getByRole('tab', { name: 'Locatie' }).click();
+  await page.getByRole('tab', { name: 'Adres' }).click();
   await page.getByLabel('Gemeente').click();
   await page.getByLabel('Gemeente').fill(dummyOrganizer.location.municipality);
   await page.getByLabel(dummyOrganizer.location.municipality).click();


### PR DESCRIPTION
### Added
- [optional titleKey prop to additionalInformation to make title of tabs more configurable](https://github.com/cultuurnet/udb3-frontend/commit/be079f225241c5cd3a4bfbd02316f7081b16907f)

### Changed
- Organizer form: change title of location tab to 'Adres'

<img width="725" alt="Screenshot 2023-10-11 at 14 58 02" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/2a71d76a-8e4b-4c95-9cf0-3b4e38cda945">


---
Ticket: https://jira.uitdatabank.be/browse/III-5845
