### PR TITLE
Fix some Additional Steps jumping around

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/LabelsStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/LabelsStep.tsx
@@ -71,7 +71,7 @@ function LabelsStep({
         spacing={2}
       >
         <FormElement
-          id={'labels'}
+          id={'labels-picker'}
           label={t('create.additionalInformation.labels.label')}
           loading={isWriting}
           error={

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -828,7 +828,10 @@ const LocationStep = ({
   return (
     <Stack
       {...getStackProps(props)}
-      minHeight={shouldAddSpaceBelowTypeahead ? '26.5rem' : 'inherit'}
+      minHeight={
+        props.minHeight ??
+        (shouldAddSpaceBelowTypeahead ? '26.5rem' : 'inherit')
+      }
     >
       <Controller
         control={control}


### PR DESCRIPTION
### Fixed

- Fix some Additional Steps jumping around

---

The issue was:
- The LocationStep not respecting `minHeight` and thus having a different height than the other tabs (causing jumping)
- The main labels input having an ID of `labels` making the browser scroll to it on opening the tab (because of the #hash feature)

Ticket: https://jira.publiq.be/browse/III-5844
