### PR TITLE
Remove duplicate padding at top of RTE

### DIFF
--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -167,6 +167,7 @@ const GlobalStyle = createGlobalStyle`
   
   .rdw-editor-main {
     padding: 10px;
+    padding-top: 0;
   }
 
   .rdw-option-wrapper {


### PR DESCRIPTION
### Fixed

- Remove duplicate padding at top of RTE

---

When we changed the newline behavior to only paragraphs it meant every block in Draft is a `<p>` by default which comes with some vertical padding. This was duplicating with the editor's own padding.

Ticket: https://jira.publiq.be/browse/III-5866
