### PR TITLE
Fixed  Uitpas card systems checked state sometimes being incorrect

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/OrganizerStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerStep.tsx
@@ -70,11 +70,7 @@ const OrganizerStep = ({
       isUitpasOrganizer: hasUitpasLabel && hasPriceInfo,
     },
     {
-      onSuccess: (data) => {
-        // @ts-expect-error
-        if (!getCardSystemForEventQuery.dataUpdatedAt)
-          setSelectedCardSystems(Object.values(data));
-      },
+      onSuccess: (data) => setSelectedCardSystems(Object.values(data)),
     },
   );
 


### PR DESCRIPTION
### Fixed

- Fixed  Uitpas card systems checked state sometimes being incorrect

---

When I converted the card system stuff to optimistic I didn't account for an edge case which resulted in the card system state to not be populated properly. I removed the special condition and wasn't able to reproduce the old out of sync state it was added for so I think this version should be good to go.

Ticket: https://jira.publiq.be/browse/III-5881