### PR TITLE
Fixed invalid contact information being saved if others are valid

### DIFF
--- a/src/pages/OrganizerAddModal.tsx
+++ b/src/pages/OrganizerAddModal.tsx
@@ -29,6 +29,7 @@ import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback
 
 import { City, CityPicker } from './CityPicker';
 import { DUTCH_ZIP_REGEX, GERMAN_ZIP_REGEX } from './steps/LocationStep';
+import { ScopeTypes } from '@/constants/OfferType';
 
 const getValue = getValueFromTheme('organizerAddModal');
 
@@ -381,7 +382,7 @@ const OrganizerAddModal = ({
         <Stack spacing={2}>
           <Title size={2}>Contact</Title>
           <ContactInfoStep
-            isOrganizer={true}
+            scope={ScopeTypes.ORGANIZERS}
             onSuccessfulChange={handleSetContactInfo}
             organizerContactInfo={contactInfo}
           />

--- a/src/pages/OrganizerAddModal.tsx
+++ b/src/pages/OrganizerAddModal.tsx
@@ -4,6 +4,7 @@ import { Controller, useForm, useWatch } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
+import { ScopeTypes } from '@/constants/OfferType';
 import { useGetOrganizersByWebsiteQuery } from '@/hooks/api/organizers';
 import { useAutoFocus } from '@/hooks/useAutoFocus';
 import { SupportedLanguage } from '@/i18n/index';
@@ -29,7 +30,6 @@ import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback
 
 import { City, CityPicker } from './CityPicker';
 import { DUTCH_ZIP_REGEX, GERMAN_ZIP_REGEX } from './steps/LocationStep';
-import { ScopeTypes } from '@/constants/OfferType';
 
 const getValue = getValueFromTheme('organizerAddModal');
 

--- a/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
@@ -147,16 +147,16 @@ const ContactInfoStep = ({
   const handleAddContactInfoMutation = async (
     newContactInfo: NewContactInfo[],
   ) => {
+    const contactPoint = parseNewContactInfo(newContactInfo);
+    if (!offerId) {
+      return onSuccessfulChange(contactPoint);
+    }
+
     await addContactPointMutation.mutateAsync({
       eventId: offerId,
-      contactPoint: parseNewContactInfo(newContactInfo),
+      contactPoint,
       scope,
     });
-  };
-
-  const handleAddOrganizerContactInfo = (newContactInfo: NewContactInfo[]) => {
-    const contactInfo = parseNewContactInfo(newContactInfo);
-    onSuccessfulChange(contactInfo);
   };
 
   const handleChangeValue = async (
@@ -177,11 +177,6 @@ const ContactInfoStep = ({
 
     if (newValue === '') return;
 
-    if (isOrganizer) {
-      handleAddOrganizerContactInfo(newContactInfo);
-      return;
-    }
-
     await handleAddContactInfoMutation(newContactInfo);
   };
 
@@ -196,11 +191,6 @@ const ContactInfoStep = ({
     newContactInfo.splice(index, 1);
 
     setContactInfoState(newContactInfo);
-
-    if (isOrganizer) {
-      handleAddOrganizerContactInfo(newContactInfo);
-      return;
-    }
 
     await handleAddContactInfoMutation(newContactInfo);
   };
@@ -264,13 +254,12 @@ const ContactInfoStep = ({
                 )
               }
             />
-
             <Button
               alignSelf="flex-start"
               onClick={() => handleDeleteContactInfo(index)}
               variant={ButtonVariants.DANGER}
               iconName={Icons.TRASH}
-            ></Button>
+            />
           </Inline>
         );
       })}

--- a/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
@@ -15,7 +15,6 @@ import { isValidInfo } from '@/utils/isValidInfo';
 import { prefixUrlWithHttps } from '@/utils/url';
 
 import { TabContentProps, ValidationStatus } from './AdditionalInformationStep';
-import { ScopeTypes } from '@/constants/OfferType';
 
 const ContactInfoTypes = {
   EMAIL: 'email',

--- a/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
@@ -15,6 +15,7 @@ import { isValidInfo } from '@/utils/isValidInfo';
 import { prefixUrlWithHttps } from '@/utils/url';
 
 import { TabContentProps, ValidationStatus } from './AdditionalInformationStep';
+import { ScopeTypes } from '@/constants/OfferType';
 
 const ContactInfoTypes = {
   EMAIL: 'email',
@@ -35,7 +36,6 @@ type NewContactInfo = {
 
 type Props = StackProps &
   TabContentProps & {
-    isOrganizer?: boolean;
     organizerContactInfo: ContactInfo;
   };
 
@@ -45,9 +45,9 @@ const ContactInfoStep = ({
   onSuccessfulChange,
   onValidationChange,
   organizerContactInfo,
-  isOrganizer,
   ...props
 }: Props) => {
+  const isOrganizer = scope === ScopeTypes.ORGANIZERS;
   const { t } = useTranslation();
 
   const getEntityByIdQuery = useGetEntityByIdAndScope({ id: offerId, scope });
@@ -286,10 +286,6 @@ const ContactInfoStep = ({
       </Inline>
     </Stack>
   );
-};
-
-ContactInfoStep.defaultProps = {
-  isOrganizer: false,
 };
 
 export { ContactInfoStep };

--- a/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/ContactInfoStep.tsx
@@ -47,7 +47,6 @@ const ContactInfoStep = ({
   organizerContactInfo,
   ...props
 }: Props) => {
-  const isOrganizer = scope === ScopeTypes.ORGANIZERS;
   const { t } = useTranslation();
 
   const getEntityByIdQuery = useGetEntityByIdAndScope({ id: offerId, scope });
@@ -137,7 +136,12 @@ const ContactInfoStep = ({
     const [email, phone, url] = Object.values(ContactInfoTypes).map(
       (infoType) =>
         newContactInfo
-          .filter((info) => info.type === infoType && info.value !== '')
+          .filter(
+            (info) =>
+              info.type === infoType &&
+              info.value !== '' &&
+              isValidInfo(infoType, info.value),
+          )
           .map((info) => info.value),
     );
 


### PR DESCRIPTION
### Fixed

- Fixed invalid contact information being saved if others are valid

---

The issue was that the step is not an actual form, so one field being invalid wouldn't prevent saving everything since errors are displayed on a per-field basis. So I now filter out invalid information from the contact info being sent as payload to at least avoid the bug.

I also removed the `isOrganizer` prop since we can rely on the scope now, and it was used to signify the step was used in a modal and should not do requests. So I changed it to check for `offerId` since it's only provided by AdditionalSteps and it was less confusing now that the step is actually used for organizers in a different context which requires sending requests.

Ticket: https://jira.publiq.be/browse/III-5883
