### PR TITLE
III-5884 - Disable refetchOnWindowFocus for getOrganizerByIdQuery

### DIFF
--- a/src/hooks/api/organizers.ts
+++ b/src/hooks/api/organizers.ts
@@ -136,6 +136,7 @@ const useGetOrganizerByIdQuery = (
     queryKey: ['organizers'],
     queryFn: getOrganizerById,
     queryArguments: { id },
+    refetchOnWindowFocus: false,
     enabled: !!id,
     ...configuration,
   });


### PR DESCRIPTION
### Changed
- Disable refetchOnWindowFocus for getOrganizerByIdQuery (just like for event)

---
Ticket: https://jira.uitdatabank.be/browse/III-5884
