### PR TITLE
III-5890 - Use mainImage property for organizers instead of image

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/MediaStep.tsx
@@ -75,10 +75,16 @@ const MediaStep = ({
   );
 
   const eventImage = useMemo(
+    () => {
+      if (scope === ScopeTypes.ORGANIZERS) {
+        // @ts-expect-error
+        return getEntityByIdQuery.data?.mainImage;
+      }
+      // @ts-expect-error
+      return getEntityByIdQuery.data?.image ?? [];
+    },
     // @ts-expect-error
-    () => getEntityByIdQuery.data?.image ?? [],
-    // @ts-expect-error
-    [getEntityByIdQuery.data?.image],
+    [getEntityByIdQuery.data?.image, getEntityByIdQuery.data?.mainImage, scope],
   );
 
   const [isPictureUploadModalVisible, setIsPictureUploadModalVisible] =


### PR DESCRIPTION
### Changed
-  Use `mainImage` property for organizers instead of `image`

---
Ticket: https://jira.uitdatabank.be/browse/III-5890
