### PR TITLE
Fixed Add Image modal closing when errors are present

### DIFF
--- a/src/pages/steps/modals/PictureUploadModal.tsx
+++ b/src/pages/steps/modals/PictureUploadModal.tsx
@@ -257,7 +257,7 @@ const PictureUploadModal = ({
       cancelTitle={t('pictures.upload_modal.actions.cancel')}
       size={ModalSizes.MD}
       onConfirm={() => {
-        if (!dirtyFields.description) {
+        if (!Object.keys(dirtyFields).length) {
           onClose();
         }
 


### PR DESCRIPTION
### Fixed

- Fixed Add Image modal closing when errors are present

---

There was a bit of logic to simply close the modal if nothing was changed in it but it wasn't checking all fields, this ensures we don't close it if the user changed anything or uploaded a media

Ticket: https://jira.publiq.be/browse/III-5910
