### PR TITLE
III-5932 - Also reset location after selecting the online toggle

### DIFF
--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -396,7 +396,13 @@ const LocationStep = ({
                     {...getInlineProps(props)}
                   >
                     <ToggleBox
-                      onClick={() => onFieldChange({ isOnline: false })}
+                      onClick={() =>
+                        onFieldChange({
+                          isOnline: false,
+                          municipality: undefined,
+                          place: undefined,
+                        })
+                      }
                       active={!isOnline}
                       icon={
                         <CustomIcon


### PR DESCRIPTION
### Changed
- [Also reset location after selecting the online toggle](https://github.com/cultuurnet/udb3-frontend/commit/2c28d9582e4d784ed1ee2af9bc82ae1b4fca4101)

### Fixed
- CultuurkuurInfo visible in the wrong cases

---
Ticket: https://jira.uitdatabank.be/browse/III-5932
