### PR TITLE
Do not crop uploaded images

### DIFF
--- a/src/pages/steps/modals/PictureUploadModal.tsx
+++ b/src/pages/steps/modals/PictureUploadModal.tsx
@@ -101,9 +101,9 @@ const PictureUploadBox = forwardRef<HTMLInputElement, Props>(
               src={imagePreviewUrl}
               alt="preview"
               width="auto"
-              maxHeight="8rem"
+              maxHeight="10rem"
               maxWidth="100%"
-              objectFit="cover"
+              objectFit="contain"
             />
             <Text>{image.name}</Text>
           </Stack>


### PR DESCRIPTION
### Fixed

- Do not crop uploaded images

---

Added 2rem to the max height to prevent tall images from being "too" squeezed now that we don't crop but I can keep it at 8 depending on why it was picked (in case a bug happened with taller previews)

Ticket: https://jira.publiq.be/browse/III-5935
