### PR TITLE
Override default success progress bar color

### DIFF
--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -152,6 +152,10 @@ const GlobalStyle = createGlobalStyle`
   .badge-secondary {
     background-color: ${globalColors.grey5};
   }
+  
+  .progress-bar.bg-success {
+    background-color: ${globalColors.udbMainPositiveGreen} !important;
+  }
 
   .dropdown-menu {
     padding: 0;


### PR DESCRIPTION
### Fixed

- Override default success progress bar color

---

Since we embed Bootstrap from CDN I wasn't able to customize the variables so this is a bit of a bandaid but we can revisit if we have more usecases like this.

Ticket: https://jira.publiq.be/browse/III-5936
