### PR TITLE
III-5882 - Use url param to trigger hotjar survey on /preview

### DIFF
--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -1,3 +1,4 @@
+import Hotjar from '@hotjar/browser';
 import getConfig from 'next/config';
 import { useRouter } from 'next/router';
 import type { ChangeEvent, ReactNode } from 'react';
@@ -362,6 +363,8 @@ const Sidebar = () => {
   const queryClient = useQueryClient();
   const storage = useLocalStorage();
 
+  const router = useRouter();
+
   const [isJobLoggerVisible, setIsJobLoggerVisible] = useState(true);
   const [jobLoggerState, setJobLoggerState] = useState(JobLoggerStates.IDLE);
 
@@ -410,6 +413,27 @@ const Sidebar = () => {
     () => setIsJobLoggerVisible((prevValue) => !prevValue),
     [],
   );
+
+  useEffect(() => {
+    if (!router.query.hj) return;
+
+    const hotjarEvent = Array.isArray(router.query.hj)
+      ? router.query.hj[0]
+      : router.query.hj;
+
+    Hotjar.event(hotjarEvent);
+
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: {
+          params: router.query.params,
+        },
+      },
+      undefined,
+      { shallow: true },
+    );
+  }, [router]);
 
   useEffect(() => {
     if (announcementModalContext.visible) {

--- a/src/pages/steps/StepsForm.tsx
+++ b/src/pages/steps/StepsForm.tsx
@@ -128,8 +128,8 @@ const StepsForm = ({
       const scopePath = scope === OfferTypes.EVENTS ? 'event' : 'place';
 
       const params =
-        eventName && missingFieldName
-          ? { hj: !offer?.[`${missingFieldName}`] && eventName }
+        eventName && missingFieldName && !offer?.[`${missingFieldName}`]
+          ? { hj: eventName }
           : {};
 
       const searchParams = new URLSearchParams(params);


### PR DESCRIPTION
### Changed
- Use url param to trigger hotjar survey on /preview.
Since hotjar was triggered before a route push, the hotjar survey was only visible in a flash. 
Now the hotjar survey will be triggered by the `hj` param in the url

---

Ticket: https://jira.uitdatabank.be/browse/III-5882
