### PR TITLE
III-5947 - Don't make page crash if there's no object at all

### DIFF
--- a/src/utils/getLanguageObjectOrFallback.ts
+++ b/src/utils/getLanguageObjectOrFallback.ts
@@ -5,7 +5,9 @@ const getLanguageObjectOrFallback = <TReturned>(
   language: SupportedLanguage,
   mainLanguage?: SupportedLanguage,
 ) => {
-  if (obj[language]) {
+  if (!obj) return;
+
+  if (obj?.[language]) {
     return obj[language] as TReturned;
   }
 


### PR DESCRIPTION
### Changed
- `getLanguageObjectOrFallback` add early return if obj is undefined

### Fixed
- `getLanguageObjectOrFallback` Don't make page crash if there's no object at all

---
Ticket: https://jira.uitdatabank.be/browse/III-5947
