### PR TITLE
III-5948 - Don't use Object.hasOwn since it's only supported in node 16.19

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/BookingInfoStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/BookingInfoStep.tsx
@@ -429,7 +429,7 @@ const BookingInfoStep = ({
       eventId,
       bookingInfo: {
         ...bookingInfo,
-        ...(Object.hasOwn(bookingInfo, 'url') && {
+        ...('url' in bookingInfo && {
           urlLabel: newUrlLabels,
         }),
       },


### PR DESCRIPTION
### Changed
- Don't use `Object.hasOwn()` since it's only supported in node 16.19

---
Ticket: https://jira.uitdatabank.be/browse/III-5948
