### PR TITLE
Add feature flag for new duplicate

### DIFF
--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -14,6 +14,7 @@ import { useCookiesWithOptions } from './useCookiesWithOptions';
 const FeatureFlags = {
   REACT_CREATE: 'react_create',
   ORGANIZER_CREATE: 'organizer_create',
+  REACT_DUPLICATE: 'react_duplicate',
 } as const;
 
 const createCookieName = (identifier: string) => `ff_${identifier}`;

--- a/src/redirects.tsx
+++ b/src/redirects.tsx
@@ -75,6 +75,7 @@ const getRedirects = (
     source: '/event/:eventId/duplicate',
     destination: '/events/:eventId/duplicate',
     permanent: false,
+    featureFlag: FeatureFlags.REACT_DUPLICATE,
   },
   {
     source: '/place/:placeId/edit',


### PR DESCRIPTION
### Added

- Add feature flag for new duplicate

---

Because the Angular app still points to the Angular duplication, this is all that is needed to revert the new duplication logic unless the corresponding feature flag is present.

Ticket: https://jira.publiq.be/browse/III-5672
