### PR TITLE
Ensure pasting rich text strips non supported styling

### DIFF
--- a/src/pages/RichTextEditor.tsx
+++ b/src/pages/RichTextEditor.tsx
@@ -36,6 +36,7 @@ function RichTextEditor(props: ComponentProps<typeof Editor>) {
             component: CustomRichTextEditorLink,
           },
         }}
+        handlePastedText={() => false}
         editorStyle={{ minHeight: 250, resize: 'vertical' }}
         {...props}
       />


### PR DESCRIPTION
### Fixed

- Ensure pasting rich text strips non supported styling

---

I'm not sure I can fix it retroactively without some intervention from the back-end but this will prevent future unwanted HTML to make it to descriptions.

https://github.com/cultuurnet/udb3-frontend/assets/1321596/d041f9fd-efd0-4f49-ab75-89ff807bb160


Ticket: https://jira.publiq.be/browse/III-5951
