### PR TITLE
III-6009 - Slightly modify subArcs EventScore barometer

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/FormScore.tsx
+++ b/src/pages/steps/AdditionalInformationStep/FormScore.tsx
@@ -168,8 +168,8 @@ const DynamicBarometerIcon = ({ minimumScore, score, size = 70 }) => (
         width: 0.4,
         subArcs: [
           { limit: 75, color: '#F19E49' },
-          { limit: 90, color: '#F9DE58' },
-          { limit: 95, color: '#C2DF6B' },
+          { limit: 89, color: '#F9DE58' },
+          { limit: 94, color: '#C2DF6B' },
           { limit: 100, color: '#90CC4F' },
         ],
       }}


### PR DESCRIPTION
### Changed
- [Slightly modify subArcs EventScore barometer](https://github.com/cultuurnet/udb3-frontend/commit/74f01b082c7e62e1effee67cd512fdf5ec35cb43)

Screenshots:
<img width="327" alt="Screenshot 2024-03-20 at 15 20 59" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/f90cf2bb-4f83-4b82-94d2-917fb18aa4fb">

<img width="328" alt="Screenshot 2024-03-20 at 15 23 07" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/a171c1f3-1e06-4c4e-807f-da77ec5eec09">

<img width="332" alt="Screenshot 2024-03-20 at 15 25 01" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/31c7534b-0fd6-42b6-bc94-a279fdd0c3fb">

<img width="475" alt="Screenshot 2024-03-20 at 15 30 26" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/6c1afac8-4d0e-44ff-9532-aef66d575931">


---
Ticket: https://jira.uitdatabank.be/browse/III-6009
