### PR TITLE
III-5789 - Improve hasLegacyLocation check

### DIFF
--- a/src/types/Offer.ts
+++ b/src/types/Offer.ts
@@ -2,6 +2,7 @@ import type { BookingAvailabilityType } from '@/constants/BookingAvailabilityTyp
 import type { CalendarType } from '@/constants/CalendarType';
 import type { OfferStatus } from '@/constants/OfferStatus';
 import { PriceCategory } from '@/pages/steps/AdditionalInformationStep/PriceInformation';
+import { parseOfferType } from '@/utils/parseOfferType';
 
 import type { SupportedLanguages } from '../i18n';
 import type { ContactPoint } from './ContactPoint';
@@ -146,8 +147,15 @@ type Label = {
   excluded: boolean;
 };
 
-export const hasLegacyLocation = (offer) =>
-  offer?.location && !offer?.location?.['@id'];
+export const hasLegacyLocation = (offer: Offer) => {
+  if (!offer) return false;
+
+  if (parseOfferType(offer['@context']) === 'place') {
+    return false;
+  }
+
+  return (offer as Event).location && !(offer as Event).location?.['@id'];
+};
 
 export type {
   BaseOffer,


### PR DESCRIPTION
### Fixed
- Logic in hasLegacyLocation check (should only return true on Events with a missing location id, so it shouldn't show the alert on places).

Before:
<img width="788" alt="Screenshot 2024-04-08 at 16 06 44" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/2fb5e87f-201d-41d6-ac9f-36872a6a649d">

After:
<img width="797" alt="Screenshot 2024-04-08 at 15 56 01" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/43339338-cdd1-49bd-8b46-8be443c96485">

---
Ticket: https://jira.uitdatabank.be/browse/III-5789
