### PR TITLE
III-6090 - Add clarifying copy in location modal of event entry form 

### DIFF
--- a/src/pages/PlaceAddModal.tsx
+++ b/src/pages/PlaceAddModal.tsx
@@ -11,6 +11,7 @@ import { useHeaders } from '@/hooks/api/useHeaders';
 import { Countries, Country } from '@/types/Country';
 import { Place } from '@/types/Place';
 import { AlertVariants } from '@/ui/Alert';
+import { parseSpacing } from '@/ui/Box';
 import { Button, ButtonVariants } from '@/ui/Button';
 import { FormElement } from '@/ui/FormElement';
 import { Inline } from '@/ui/Inline';
@@ -178,6 +179,15 @@ const PlaceAddModal = ({
           id="location-name"
           label={t('location.add_modal.labels.name')}
           error={formState.errors.name && t('location.add_modal.errors.name')}
+          info={
+            <Text
+              variant={TextVariants.MUTED}
+              maxWidth={parseSpacing(9)}
+              dangerouslySetInnerHTML={{
+                __html: t(`create.name_and_age.name.tip_places`),
+              }}
+            />
+          }
         />
         <FormElement
           Component={<Input {...register('streetAndNumber')} />}

--- a/src/ui/FormElement.tsx
+++ b/src/ui/FormElement.tsx
@@ -23,6 +23,25 @@ type Props = {
   Component: ReactNode;
 } & StackProps;
 
+const MaxLengthCounter = ({
+  currentLength,
+  maxLength,
+}: {
+  currentLength: number;
+  maxLength: number;
+}) => {
+  return (
+    <Text
+      variant={TextVariants.MUTED}
+      fontSize="0.9rem"
+      className="text-right"
+      css={{ maxWidth: '43rem' }}
+    >
+      {currentLength} / {maxLength}
+    </Text>
+  );
+};
+
 const FormElement = ({
   id,
   ref,
@@ -102,17 +121,27 @@ const FormElement = ({
           </Inline>
           {error && <Text variant={TextVariants.ERROR}>{error}</Text>}
         </Stack>
-        {maxLength && (
-          <Text
-            variant={TextVariants.MUTED}
-            fontSize="0.9rem"
-            className="text-right"
-            css={{ maxWidth: '43rem' }}
-          >
-            {currentLength} / {maxLength}
-          </Text>
+        {maxLength && info && (
+          <Inline justifyContent="space-between" maxWidth="43rem">
+            {typeof info === 'string' ? (
+              <Text variant={TextVariants.MUTED}>{info}</Text>
+            ) : (
+              info
+            )}
+            <MaxLengthCounter
+              currentLength={currentLength}
+              maxLength={maxLength}
+            />
+          </Inline>
         )}
-        {info &&
+        {maxLength && !info && (
+          <MaxLengthCounter
+            currentLength={currentLength}
+            maxLength={maxLength}
+          />
+        )}
+        {!maxLength &&
+          info &&
           (typeof info === 'string' ? (
             <Text variant={TextVariants.MUTED}>{info}</Text>
           ) : (

--- a/src/ui/FormElement.tsx
+++ b/src/ui/FormElement.tsx
@@ -35,7 +35,7 @@ const MaxLengthCounter = ({
       variant={TextVariants.MUTED}
       fontSize="0.9rem"
       className="text-right"
-      css={{ maxWidth: '43rem' }}
+      maxWidth="43rem"
     >
       {currentLength} / {maxLength}
     </Text>


### PR DESCRIPTION
### Added
- [Add clarifying copy in location modal of event entry form](https://github.com/cultuurnet/udb3-frontend/commit/a2b0d00085c346c23d743dea82cc6b15e6589865)

- [Position characterCounter next to info if defined](https://github.com/cultuurnet/udb3-frontend/commit/02ca59da5669aa719b0172c515f877fe6fe3638b)

Screenshot
<img width="791" alt="Screenshot 2024-04-08 at 16 49 11" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/8159d4e7-17cd-4f24-b630-06c37cdd8dce">

---
Ticket: https://jira.uitdatabank.be/browse/III-6090
