### PR TITLE
III-6141 - Add dynamic robots.txt

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,14 @@ const moduleExports = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: '/robots.txt',
+        destination: '/api/robots',
+      },
+    ];
+  },
   publicRuntimeConfig: {
     baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
     environment: process.env.NEXT_PUBLIC_ENVIRONMENT,

--- a/src/pages/api/robots/index.api.ts
+++ b/src/pages/api/robots/index.api.ts
@@ -1,0 +1,52 @@
+import { NextApiHandler } from 'next';
+
+const removeExtraWhitespace = (str: string) => {
+    return str
+        .split('\n')
+        .map((line) => line.trim())
+        .join('\n');
+};
+
+const productionSitemap = `
+    User-agent: *
+    Disallow: /dashboard
+    Disallow: /create
+    Disallow: /event
+    Disallow: /place
+    Disallow: /organizer
+    Disallow: /manage
+    Allow: /login
+
+    User-agent: GPTBot
+    Disallow: /
+
+    User-agent: ChatGPT-User
+    Disallow: /
+
+    User-agent: CCBot
+    Disallow: /
+
+    User-agent: anthropic-ai
+    Disallow: /
+`;
+
+const developmentSitemap = `
+    User-agent: *
+    Disallow: /
+`;
+
+const robots: NextApiHandler = async (req, res) => {
+    const env = process.env.NEXT_PUBLIC_ENVIRONMENT;
+
+    res.setHeader('Content-Type', 'text/plain');
+
+    if (env === 'production') {
+        res.write(removeExtraWhitespace(productionSitemap));
+    } else {
+        res.write(removeExtraWhitespace(developmentSitemap));
+    }
+
+    res.end();
+};
+
+export default robots;

--- a/src/pages/api/robots/index.api.ts
+++ b/src/pages/api/robots/index.api.ts
@@ -1,10 +1,10 @@
 import { NextApiHandler } from 'next';
 
 const removeExtraWhitespace = (str: string) => {
-    return str
-        .split('\n')
-        .map((line) => line.trim())
-        .join('\n');
+  return str
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n');
 };
 
 const productionSitemap = `
@@ -36,17 +36,17 @@ const developmentSitemap = `
 `;
 
 const robots: NextApiHandler = async (req, res) => {
-    const env = process.env.NEXT_PUBLIC_ENVIRONMENT;
+  const env = process.env.NEXT_PUBLIC_ENVIRONMENT;
 
-    res.setHeader('Content-Type', 'text/plain');
+  res.setHeader('Content-Type', 'text/plain');
 
-    if (env === 'production') {
-        res.write(removeExtraWhitespace(productionSitemap));
-    } else {
-        res.write(removeExtraWhitespace(developmentSitemap));
-    }
+  if (env === 'production') {
+    res.write(removeExtraWhitespace(productionSitemap));
+  } else {
+    res.write(removeExtraWhitespace(developmentSitemap));
+  }
 
-    res.end();
+  res.end();
 };
 
 export default robots;

--- a/src/pages/api/robots/index.api.ts
+++ b/src/pages/api/robots/index.api.ts
@@ -1,38 +1,31 @@
 import { NextApiHandler } from 'next';
 
-const removeExtraWhitespace = (str: string) => {
-  return str
-    .split('\n')
-    .map((line) => line.trim())
-    .join('\n');
-};
-
 const productionSitemap = `
-    User-agent: *
-    Disallow: /dashboard
-    Disallow: /create
-    Disallow: /event
-    Disallow: /place
-    Disallow: /organizer
-    Disallow: /manage
-    Allow: /login
+User-agent: *
+Disallow: /dashboard
+Disallow: /create
+Disallow: /event
+Disallow: /place
+Disallow: /organizer
+Disallow: /manage
+Allow: /login
 
-    User-agent: GPTBot
-    Disallow: /
+User-agent: GPTBot
+Disallow: /
 
-    User-agent: ChatGPT-User
-    Disallow: /
+User-agent: ChatGPT-User
+Disallow: /
 
-    User-agent: CCBot
-    Disallow: /
+User-agent: CCBot
+Disallow: /
 
-    User-agent: anthropic-ai
-    Disallow: /
+User-agent: anthropic-ai
+Disallow: /
 `;
 
 const developmentSitemap = `
-    User-agent: *
-    Disallow: /
+User-agent: *
+Disallow: /
 `;
 
 const robots: NextApiHandler = async (req, res) => {
@@ -40,13 +33,7 @@ const robots: NextApiHandler = async (req, res) => {
 
   res.setHeader('Content-Type', 'text/plain');
 
-  if (env === 'production') {
-    res.write(removeExtraWhitespace(productionSitemap));
-  } else {
-    res.write(removeExtraWhitespace(developmentSitemap));
-  }
-
-  res.end();
+  res.send(env === 'production' ? productionSitemap : developmentSitemap);
 };
 
 export default robots;


### PR DESCRIPTION
### Added
- [/api/robots rewrite in next.config](https://github.com/cultuurnet/udb3-frontend/commit/d3d05bd243e9e43f2e5691a1609c1a1caacb7402)
- [robots.txt](https://github.com/cultuurnet/udb3-frontend/commit/d2d6194ce87f87d14f201aff39ca67aebd26a0f4)

This is how the production sitemap will look like (I took some things over from the uitinvlaanderen.be/robots.txt).
On **production** we don't the robots to scan anything which isn't the homepage / login page.
<img width="635" alt="Screenshot 2024-04-09 at 13 24 07" src="https://github.com/cultuurnet/udb3-frontend/assets/9402377/96da6575-085d-4498-a526-9f3f0d718860">

On the other environments, no robots are allowed at all.

There's a tool which allows you to test your sitemap.
See: https://technicalseo.com/tools/robots-txt/

---
Ticket: https://jira.uitdatabank.be/browse/III-6141