### PR TITLE
Fixed setting price to free not triggering validation refresh

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -357,6 +357,7 @@ const PriceInformation = ({
                                 shouldValidate: false,
                               });
                               onSubmit();
+                              // @ts-expect-error
                               getOfferByIdQuery.remove();
                             }}
                           >

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -357,6 +357,7 @@ const PriceInformation = ({
                                 shouldValidate: false,
                               });
                               onSubmit();
+                              getOfferByIdQuery.remove();
                             }}
                           >
                             {t('create.additionalInformation.price_info.free')}


### PR DESCRIPTION
### Fixed

- Fixed setting price to free not triggering validation refresh

---

Overriding the price value does not seem to trigger the `useEffect` that handles validation, neither did trying to refetch or invalidate or blur the fields or something. Since this form has been a lot of back and forth to make it both reactive and optimistic I just reset the offer data to trigger the effect, although I'm still confused as to why that's the only solution that seems to work but since we handle the price mutation in a special way I'm guessing it's related? 
I'm unsure why `refetch` doesn't work but `remove` does, I thought both would yield the same result in the end but could be mistaken since the data is automatically refetched upon removal but I don't know 🤔 

Ticket: https://jira.publiq.be/browse/III-6008
