### PR TITLE
Fixed offer background updates overwriting currently edited values

### DIFF
--- a/src/pages/steps/StepsForm.tsx
+++ b/src/pages/steps/StepsForm.tsx
@@ -120,6 +120,7 @@ const StepsForm = ({
     onSuccess: (offer: Offer) => {
       reset(convertOfferToFormData(offer), {
         keepDirty: true,
+        keepDirtyValues: true,
       });
     },
     enabled: !!scope,


### PR DESCRIPTION
### Fixed

- Fixed offer background updates overwriting currently edited values

---

I thought `keepDirty` kept the actual values but it seems it only keeps the boolean state, meaning values that are still being edited when anything triggers a refetch (such as a window blur/focus) would revert the empty value to its original filled value.

Ticket: https://jira.publiq.be/browse/III-5839