### PR TITLE
List /404 as default not found path to allow manual 404s within Angular

### DIFF
--- a/src/pages/[...params].page.js
+++ b/src/pages/[...params].page.js
@@ -41,7 +41,7 @@ const Fallback = () => {
   // for the current path, because it's possible to navigate from a 404 path to
   // another page that's handled by this same Fallback component and then the
   // boolean notFound state would not update.
-  const [notFoundPaths, setNotFoundPaths] = useState([]);
+  const [notFoundPaths, setNotFoundPaths] = useState(['/404']);
   useHandleWindowMessage({
     [WindowMessageTypes.URL_UNKNOWN]: () =>
       setNotFoundPaths([asPath, ...notFoundPaths]),


### PR DESCRIPTION
### Changed

- List /404 as default not found path to allow manual 404s within Angular

---

Ticket: https://jira.publiq.be/browse/III-5993
Needs https://github.com/cultuurnet/udb3-angular-app/pull/213 and https://github.com/cultuurnet/udb3-angular/pull/779