### PR TITLE
Fixed Typeahead items not wrapping properly

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -264,7 +264,11 @@ const OrganizerPicker = ({
                     renderMenuItemChildren={(org: Organizer, { text }) => {
                       const name = getOrganizerName(org, i18n.language);
                       return (
-                        <Inline spacing={3}>
+                        <Inline
+                          spacing={3}
+                          alignItems="center"
+                          justifyContent="space-between"
+                        >
                           <Text>
                             <Highlighter search={text}>{name}</Highlighter>
                           </Text>

--- a/src/ui/Typeahead.tsx
+++ b/src/ui/Typeahead.tsx
@@ -97,6 +97,7 @@ const TypeaheadInner = <T extends TypeaheadModel>(
 
         .dropdown-item {
           border-bottom: 1px solid ${({ theme }) => theme.colors.grey1};
+          text-wrap: auto;
         }
 
         .dropdown-item > .rbt-highlight-text {


### PR DESCRIPTION
### Fixed

- Fixed Typeahead items not wrapping properly

---

Before:
![Screenshot 2024-07-02 at 13 30 45](https://github.com/cultuurnet/udb3-frontend/assets/1321596/e5257cb8-92f3-4203-a8f1-bebf9b6736a3)

After:
![Screenshot 2024-07-02 at 13 30 07](https://github.com/cultuurnet/udb3-frontend/assets/1321596/5c1b1e18-397f-4be5-8061-7efb72ff804c)

---

Ticket: https://jira.publiq.be/browse/III-6218