### PR TITLE
Fixed truncating of Organizer picker

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -444,7 +444,7 @@
       },
       "organizer": {
         "add_new_button": "Organisation hinzufügen",
-        "add_new_label": "Organisation nicht gefunden? Neue Organisation hinzufügen: ",
+        "add_new_label": "Neue Organisation hinzufügen: ",
         "change": "Ändern Organisator",
         "title": "Organisator",
         "select_recent_used_organizer": "Eine Organisation wiederverwenden",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -446,7 +446,7 @@
       },
       "organizer": {
         "add_new_button": "Organisatie toevoegen",
-        "add_new_label": "Organisatie niet gevonden? Voeg nieuwe organisatie toe: ",
+        "add_new_label": "Voeg nieuwe organisatie toe: ",
         "change": "Wijzig organisatie",
         "title": "Organisatie",
         "select_recent_used_organizer": "Een organisatie hergebruiken",

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -193,7 +193,7 @@ const OrganizerPicker = ({
     <Stack width="100%" {...getStackProps(props)}>
       <FormElement
         id="create-organizer"
-        className={'w-full'}
+        className="w-full"
         Component={
           organizer ? (
             <Stack>

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -262,19 +262,29 @@ const OrganizerPicker = ({
                     // @ts-expect-error
                     isLoading={getOrganizersByQueryQuery.isLoading}
                     labelKey={(org) => getOrganizerName(org, i18n.language)}
+                    css={`
+                      .dropdown-item {
+                        display: flex;
+                        align-items: center;
+                        justify-content: space-between;
+                      }
+
+                      .dropdown-item span:first-child {
+                        white-space: nowrap;
+                        text-overflow: ellipsis;
+                        overflow: hidden;
+                      }
+                    `}
                     renderMenuItemChildren={(org: Organizer, { text }) => {
                       const name = getOrganizerName(org, i18n.language);
+
                       return (
-                        <Inline
-                          spacing={3}
-                          alignItems="center"
-                          justifyContent="space-between"
-                        >
+                        <>
                           <Text>
                             <Highlighter search={text}>{name}</Highlighter>
                           </Text>
                           {isUitpasOrganizer(org) && <UitpasBadge />}
-                        </Inline>
+                        </>
                       );
                     }}
                     selected={valueToArray(organizer)}

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -193,6 +193,7 @@ const OrganizerPicker = ({
     <Stack width="100%" {...getStackProps(props)}>
       <FormElement
         id="create-organizer"
+        className={'w-full'}
         Component={
           organizer ? (
             <Stack>
@@ -228,13 +229,13 @@ const OrganizerPicker = ({
               </Inline>
             </Stack>
           ) : (
-            <Inline spacing={2}>
+            <Inline spacing={2} width="100%">
               <RecentUsedOrganizers
                 organizers={recentUsedOrganizers}
                 onChange={handleSelectRecentOrganizer}
                 maxWidth="45rem"
               />
-              <Stack>
+              <Stack width="100%">
                 <Text fontWeight="bold" marginBottom={4}>
                   {recentUsedOrganizers.length > 0
                     ? t(

--- a/src/ui/Typeahead.tsx
+++ b/src/ui/Typeahead.tsx
@@ -97,7 +97,6 @@ const TypeaheadInner = <T extends TypeaheadModel>(
 
         .dropdown-item {
           border-bottom: 1px solid ${({ theme }) => theme.colors.grey1};
-          text-wrap: auto;
         }
 
         .dropdown-item > .rbt-highlight-text {


### PR DESCRIPTION
### Fixed

- Fixed truncating of Organizer picker

---

The problem was mainly with the extra wrapping span added by the `Inline`, so I moved the logic to plain CSS, but since targeting the element itself messed more with the other dropdowns I moved the styling purely to the Organizer picker instead of the main Typeahead.

Ticket: https://jira.publiq.be/browse/III-6218
