### PR TITLE
Fixed invalid organizers causing crashes on offer form

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/OrganizerStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerStep.tsx
@@ -58,7 +58,7 @@ const OrganizerStep = ({
   // @ts-expect-error
   const offer: Event | Place | undefined = getOfferByIdQuery.data;
 
-  const organizer = offer?.organizer;
+  const organizer = offer?.organizer?.name ? offer?.organizer : undefined;
   const hasPriceInfo = (offer?.priceInfo ?? []).length > 0;
   const hasUitpasLabel = organizer ? isUitpasOrganizer(organizer) : false;
   const [hasUitpasTicketSales, setHasUitpasTicketSales] = useState(false);


### PR DESCRIPTION
### Fixed

- Fixed invalid organizers causing crashes on offer views

---

Seems some offer have "phantom" organizers that don't exist in the DB but still get embedded, this is just to ignore those and prevent crashes where the logic expect Organizer properties to be present.

![Screenshot 2024-07-30 at 11 27 28](https://github.com/user-attachments/assets/0c0c9da7-5737-4672-8293-598c04c4cd89)


Ticket: https://jira.publiq.be/browse/III-6237
