### PR TITLE
Add copy about max length of a price tariff

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -487,7 +487,7 @@
         "duplicate_name_error": "Tarif mit dem Namen \"Hallo\" existiert bereits, bitte verwenden Sie einen anderen Namen.",
         "euro": "euro",
         "free": "Kostenlos",
-        "global_info": "Vergewissern Sie sich, dass Ihre Preisinformationen immer gültig sind:<ul><li>Schreiben Sie Dezimalzahlen mit einem Komma.</li><li>Lassen Sie keine Zeile leer, geben Sie immer eine Zielgruppe und einen Betrag an.</li><li>Geben Sie maximal zwei Dezimalstellen an.</li></ul>",
+        "global_info": "Vergewissern Sie sich, dass Ihre Preisinformationen immer gültig sind:<ul><li>Der Name deiner Preiskategorie darf maximal 90 Zeichen enthalten.</li><li>Schreiben Sie Dezimalzahlen mit einem Komma.</li><li>Lassen Sie keine Zeile leer, geben Sie immer eine Zielgruppe und einen Betrag an.</li><li>Geben Sie maximal zwei Dezimalstellen an.</li></ul>",
         "price": "Preis",
         "prices": "Preise",
         "save": "Speichern",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -489,7 +489,7 @@
         "duplicate_name_error": " Le tarif avec le nom \"{{priceName}}\" existe déjà, veuillez utiliser un autre nom.",
         "euro": "euro",
         "free": "Gratuit",
-        "global_info": "Assurez-vous que vos informations tarifaires sont toujours valables : <ul><li>Écrivez les décimales avec une virgule.</li> <li>Ne laissez aucune ligne en blanc, saisissez toujours un groupe cible et un montant.</li><li>Donnez un maximum de deux décimales.</li></ul>",
+        "global_info": "Assurez-vous que vos informations tarifaires sont toujours valables : <ul><li>Le nom de votre catégorie de prix peut contenir jusqu'à 90 caractères.</li><li>Écrivez les décimales avec une virgule.</li> <li>Ne laissez aucune ligne en blanc, saisissez toujours un groupe cible et un montant.</li><li>Donnez un maximum de deux décimales.</li></ul>",
         "price": "Prix",
         "prices": "Prix",
         "save": "Sauver",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -489,7 +489,7 @@
         "duplicate_name_error": "Tarief met de naam \"{{priceName}}\" bestaat al, gelieve een andere naam te gebruiken.",
         "euro": "euro",
         "free": "Gratis",
-        "global_info": "Zorg ervoor dat je prijsinformatie steeds geldig is: <ul><li>Noteer decimalen met een komma.</li><li>Laat geen enkele rij leeg, vul steeds een doelgroep en een bedrag in.</li> <li>Geef maximum twee cijfers na de komma.</li></ul>",
+        "global_info": "Zorg ervoor dat je prijsinformatie steeds geldig is: <ul><li>De naam van je prijscategorie mag maximaal 90 tekens bevatten.</li><li>Noteer decimalen met een komma.</li><li>Laat geen enkele rij leeg, vul steeds een doelgroep en een bedrag in.</li> <li>Geef maximum twee cijfers na de komma.</li></ul>",
         "price": "Prijs",
         "prices": "Prijzen",
         "save": "Bewaren",


### PR DESCRIPTION
### Added
- Copy about the max length of price tariff names

Note that this is a quick solution, and we might think of an extra one (validation / counter / progress bar), etc. just like we have for the title of an event or place.

![Screenshot 2024-09-09 at 4 09 13 PM](https://github.com/user-attachments/assets/2acf835d-2c83-4af3-9971-567724b363b8)

---

Ticket: https://jira.uitdatabank.be/browse/III-6305
