### PR TITLE
Make back button on organizer preview go to previous URL always

### DIFF
--- a/src/pages/organizers/[organizerId]/preview/index.page.tsx
+++ b/src/pages/organizers/[organizerId]/preview/index.page.tsx
@@ -210,14 +210,14 @@ const OrganizersPreview = () => {
                     {t('organizers.detail.actions.manage')}
                   </Link>
                 )}
-                <Link
-                  variant={LinkButtonVariants.BUTTON_SECONDARY}
+                <Button
+                  variant={ButtonVariants.SECONDARY}
                   spacing={3}
                   iconName={Icons.ARROW_LEFT}
-                  href={`/organizers`}
+                  onClick={() => router.back()}
                 >
                   {t('organizers.detail.actions.back')}
-                </Link>
+                </Button>
               </Stack>
             </Inline>
           </Stack>


### PR DESCRIPTION
### Changed

- Make back button on organizer preview go to previous URL always

---

Ticket: https://jira.publiq.be/browse/III-6423