### PR TITLE
Ensure Ownerships table don't crash on missing creator prop (cf. pending table)

### DIFF
--- a/src/pages/organizers/[organizerId]/ownerships/OwnershipsTable.tsx
+++ b/src/pages/organizers/[organizerId]/ownerships/OwnershipsTable.tsx
@@ -45,7 +45,7 @@ export const OwnershipsTable = ({
         <Title size={3}>{t('organizers.ownerships.table.actions.title')}</Title>
       </Inline>
       <List paddingY={3}>
-        <List.Item>{creator.email}</List.Item>
+        {creator && <List.Item>{creator.email}</List.Item>}
         {requests.map((request) => (
           <Inline
             key={request.id}


### PR DESCRIPTION
### Fixed

- Ensure Ownerships table don't crash on missing creator prop (cf. pending table)

---


Spotted as part of https://jira.publiq.be/browse/III-6146 but unrelated to the described problem (besides that the page crashes on this also)

---

I just don't understand why Typescript doesn't flag `creator` as nullable here even though the prop explicitely states that it is a few lines above 🤔 This should have been caught by the static analysis normally

![Screenshot 2024-12-11 at 17 24 06](https://github.com/user-attachments/assets/4a8ddd7a-fca5-490f-96b2-ba258486a6e1)