### PR TITLE
III-6516 - Fix inference fetch from api

### DIFF
--- a/src/hooks/api/events.ts
+++ b/src/hooks/api/events.ts
@@ -147,10 +147,6 @@ const getEventsToModerate = async ({ headers, queryKey, ...queryData }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -180,10 +176,6 @@ const getEventById = async ({ headers, id }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -232,10 +224,6 @@ const getEventsByIds = async ({
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return (await res.json()) as { member: Event[] };
 };
 
@@ -280,10 +268,6 @@ const getEventsByCreator = async ({ headers, ...queryData }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -338,11 +322,6 @@ const getCalendarSummary = async ({ headers, id, format, locale }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
-
   return res.text();
 };
 

--- a/src/hooks/api/labels.ts
+++ b/src/hooks/api/labels.ts
@@ -15,12 +15,6 @@ const getLabelsByQuery = async ({ headers, query }) => {
       headers: headers as unknown as Record<string, string>,
     },
   });
-
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
-
   return await res.json();
 };
 

--- a/src/hooks/api/offers.ts
+++ b/src/hooks/api/offers.ts
@@ -29,10 +29,6 @@ const getOffersByCreator = async ({ headers, ...queryData }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 

--- a/src/hooks/api/organizers.ts
+++ b/src/hooks/api/organizers.ts
@@ -12,8 +12,7 @@ import {
 } from '@/hooks/api/authenticated-query';
 import type { Organizer } from '@/types/Organizer';
 import { createSortingArgument } from '@/utils/createSortingArgument';
-import { fetchFromApi, isErrorObject } from '@/utils/fetchFromApi';
-import { handleErrorObject } from '@/utils/handleErrorObject';
+import { fetchFromApi } from '@/utils/fetchFromApi';
 
 import type { Headers } from './types/Headers';
 import type { User } from './user';
@@ -85,10 +84,6 @@ const getOrganizers = async ({
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -127,10 +122,6 @@ const getOrganizerById = async ({ headers, id }: GetOrganizerByIdArguments) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -166,10 +157,6 @@ const getOrganizersByCreator = async ({
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -183,7 +170,7 @@ const getOrganizerPermissions = async ({ headers, organizerId }) => {
     options: { headers },
   });
 
-  return handleErrorObject(res);
+  return await res.json();
 };
 
 export type GetOrganizerPermissionsResponse = {
@@ -210,7 +197,7 @@ const getSuggestedOrganizersQuery = async ({ headers }) => {
     searchParams: { itemType: 'organizer' },
   });
 
-  return handleErrorObject(res);
+  return await res.json();
 };
 
 const useGetSuggestedOrganizersQuery = (

--- a/src/hooks/api/ownerships.ts
+++ b/src/hooks/api/ownerships.ts
@@ -99,10 +99,6 @@ const getOwnershipRequests = async ({
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -214,10 +210,6 @@ const getOwnershipCreator = async ({ headers, organizerId }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 

--- a/src/hooks/api/places.ts
+++ b/src/hooks/api/places.ts
@@ -36,10 +36,6 @@ const getPlaceById = async ({ headers, id }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -74,10 +70,6 @@ const getPlacesByCreator = async ({ headers, ...queryData }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -166,11 +158,6 @@ const getPlacesByQuery = async ({
       headers: headers as unknown as Record<string, string>,
     },
   });
-
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 

--- a/src/hooks/api/productions.ts
+++ b/src/hooks/api/productions.ts
@@ -16,10 +16,6 @@ const getProductions = async ({ headers, ...queryData }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -118,7 +114,7 @@ const getSuggestedEvents = async ({ headers }) => {
       headers,
     },
   });
-  if (response.status !== 200 || isErrorObject(response)) {
+  if (response.status !== 200) {
     // eslint-disable-next-line no-console
     console.error(response);
     return { events: [], similarity: 0 };

--- a/src/hooks/api/uitpas.ts
+++ b/src/hooks/api/uitpas.ts
@@ -24,10 +24,6 @@ const getCardSystemForEvent = async ({ headers, eventId }) => {
   if (res.status === 404) {
     return [];
   }
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -53,10 +49,6 @@ const getCardSystemsForOrganizer = async ({ headers, organizerId }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 

--- a/src/hooks/api/user.ts
+++ b/src/hooks/api/user.ts
@@ -85,10 +85,6 @@ const getPermissions = async ({ headers }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 
@@ -106,10 +102,6 @@ const getRoles = async ({ headers }) => {
       headers,
     },
   });
-  if (isErrorObject(res)) {
-    // eslint-disable-next-line no-console
-    return console.error(res);
-  }
   return await res.json();
 };
 

--- a/src/utils/fetchFromApi.ts
+++ b/src/utils/fetchFromApi.ts
@@ -48,12 +48,14 @@ type FetchFromApiArguments = {
 
 const { publicRuntimeConfig } = getConfig();
 
-const fetchFromApi = async ({
+const fetchFromApi = async <TConfig extends FetchFromApiArguments>({
   path,
   searchParams: searchParamsInit,
   options = {},
   silentError = false,
-}: FetchFromApiArguments): Promise<ErrorObject | Response> => {
+}: TConfig): Promise<
+  TConfig extends { silentError?: true } ? Response | ErrorObject : Response
+> => {
   let response: Response;
   let url: URL;
 

--- a/src/utils/handleErrorObject.ts
+++ b/src/utils/handleErrorObject.ts
@@ -1,5 +1,0 @@
-import { ErrorObject, isErrorObject } from './fetchFromApi';
-
-export const handleErrorObject = async (response: ErrorObject | Response) =>
-  // eslint-disable-next-line no-console
-  isErrorObject(response) ? console.error(response) : await response.json();


### PR DESCRIPTION
### Changed

- [Infer different return type depending on silentError](https://github.com/cultuurnet/udb3-frontend/commit/21ec91846be87919a9f09537583ab8e7c5862adc)

### Removed

- [Remove unneeded checking of error object](https://github.com/cultuurnet/udb3-frontend/commit/aecdb0a30ca8241356fc7b8888478ae76fb2093d)


> This is needed to correctly infer the data returned from queryFns.
> At the moment this is TData | void because of the returns we do when it is an error object

---

Ticket: https://jira.uitdatabank.be/browse/III-6516

<img width="487" alt="Screenshot 2025-02-17 at 14 08 41" src="https://github.com/user-attachments/assets/0d959496-fbb5-4383-8775-7b513cca0c06" />
<img width="488" alt="Screenshot 2025-02-17 at 14 08 33" src="https://github.com/user-attachments/assets/d938129f-057f-4b0d-8627-0090d40189e6" />

