### PR TITLE
Fixed deletion modal not showing on dashboard

### DIFF
--- a/src/pages/dashboard/DashboardRow.tsx
+++ b/src/pages/dashboard/DashboardRow.tsx
@@ -221,7 +221,12 @@ export const DashboardRow = ({
           <Inline width="25%" justifyContent="flex-start" alignItems="center">
             <StatusIndicator label={status.label} color={status.color} />
           </Inline>
-          <Inline width="22.5%" justifyContent="flex-end" alignItems="center">
+          <Inline
+            width="22.5%"
+            justifyContent="flex-end"
+            alignItems="center"
+            data-testid="row-actions"
+          >
             {finishedAt ? (
               <Text
                 color={getValue('listItem.passedEvent.color')}

--- a/src/pages/dashboard/index.page.tsx
+++ b/src/pages/dashboard/index.page.tsx
@@ -608,9 +608,9 @@ const Dashboard = (): any => {
   });
 
   const deleteItemByIdMutation = useDeleteItemById({
-    onSuccess: () => {
+    onSuccess: async () => {
       setIsModalVisible(false);
-      return queryClient.invalidateQueries(tab);
+      await queryClient.invalidateQueries(tab);
     },
   });
 

--- a/src/pages/dashboard/index.page.tsx
+++ b/src/pages/dashboard/index.page.tsx
@@ -291,13 +291,13 @@ const OfferRow = ({ item: offer, onDelete, ...props }: OfferRowProps) => {
         <Dropdown.Item href={previewUrl} key="preview">
           {t('dashboard.actions.preview')}
         </Dropdown.Item>,
-        offerType === 'event' && <Dropdown.Divider key="divider" />,
+        offerType === 'event' && <Dropdown.Divider key="divider1" />,
         offerType === 'event' && (
           <Dropdown.Item href={duplicateUrl} key="duplicate">
             {t('dashboard.actions.duplicate')}
           </Dropdown.Item>
         ),
-        <Dropdown.Divider key="divider" />,
+        <Dropdown.Divider key="divider2" />,
         <Dropdown.Item onClick={() => onDelete(offer)} key="delete">
           {t('dashboard.actions.delete')}
         </Dropdown.Item>,

--- a/src/pages/dashboard/index.page.tsx
+++ b/src/pages/dashboard/index.page.tsx
@@ -800,32 +800,32 @@ const Dashboard = (): any => {
         </Stack>
         {i18n.language === 'nl' && <NewsletterSignupForm />}
         <Footer />
+        <Modal
+          variant={ModalVariants.QUESTION}
+          visible={isModalVisible}
+          onConfirm={async () => {
+            deleteItemByIdMutation.mutate({
+              id: parseOfferId(toBeDeletedItem['@id']),
+            });
+          }}
+          onClose={() => setIsModalVisible(false)}
+          title={t('dashboard.modal.title', {
+            type: t(`dashboard.modal.types.${tab}`),
+          })}
+          confirmTitle={t('dashboard.actions.delete')}
+          cancelTitle={t('dashboard.actions.cancel')}
+        >
+          {toBeDeletedItem && (
+            <Box padding={4}>
+              {t('dashboard.modal.question', {
+                name:
+                  toBeDeletedItem.name[i18n.language] ??
+                  toBeDeletedItem.name[toBeDeletedItem.mainLanguage],
+              })}
+            </Box>
+          )}
+        </Modal>
       </Page.Content>
-      <Modal
-        variant={ModalVariants.QUESTION}
-        visible={isModalVisible}
-        onConfirm={async () => {
-          deleteItemByIdMutation.mutate({
-            id: parseOfferId(toBeDeletedItem['@id']),
-          });
-        }}
-        onClose={() => setIsModalVisible(false)}
-        title={t('dashboard.modal.title', {
-          type: t(`dashboard.modal.types.${tab}`),
-        })}
-        confirmTitle={t('dashboard.actions.delete')}
-        cancelTitle={t('dashboard.actions.cancel')}
-      >
-        {toBeDeletedItem && (
-          <Box padding={4}>
-            {t('dashboard.modal.question', {
-              name:
-                toBeDeletedItem.name[i18n.language] ??
-                toBeDeletedItem.name[toBeDeletedItem.mainLanguage],
-            })}
-          </Box>
-        )}
-      </Modal>
     </Page>
   );
 };

--- a/src/test/e2e/dashboard.spec.ts
+++ b/src/test/e2e/dashboard.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('can see deletion modal', async ({ baseURL, page }) => {
+  await page.goto(baseURL + '/dashboard');
+  await page.getByTestId('row-actions').getByRole('button').nth(1).click();
+  await page.getByRole('button', { name: 'Verwijderen' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+});


### PR DESCRIPTION
### Fixed

- Fixed deletion modal not showing on dashboard
- Fixed offers not disappearing on dashboard after deletion
- Fixed React warning about duplicate `divider` keys in offer dropdowns

---

Because `Page` only accepts children [that are Page slots](https://github.com/cultuurnet/udb3-frontend/blob/main/src/ui/Page.tsx#L28), it would discard the Modal in the `filter`ing being done of the raw children. Putting it in one of the slots makes it render in the DOM again.

I also weirdly had to switch to manually await for the queries invalidation, otherwise the cache gets busted but the refetch doesn't trigger. Not entirely sure why as to me a Promise returned from an `onSuccess` would be resolved but maybe not.

Ticket: https://jira.publiq.be/browse/III-6547
