### PR TITLE
Removed back button from organizer preview page

### DIFF
--- a/src/pages/organizers/[organizerId]/preview/index.page.tsx
+++ b/src/pages/organizers/[organizerId]/preview/index.page.tsx
@@ -137,14 +137,6 @@ const OrganizersPreview = () => {
                     {t('organizers.detail.actions.manage')}
                   </Link>
                 )}
-                <Button
-                  variant={ButtonVariants.SECONDARY}
-                  spacing={3}
-                  iconName={Icons.ARROW_LEFT}
-                  onClick={() => router.back()}
-                >
-                  {t('organizers.detail.actions.back')}
-                </Button>
               </Stack>
             </Inline>
           </Stack>


### PR DESCRIPTION
### Removed

- Removed back button from organizer preview page

---

Ticket: https://jira.publiq.be/browse/III-6503
