### PR TITLE
III-6689 bugfix municipal mergers

### DIFF
--- a/public/assets/citiesBE.json
+++ b/public/assets/citiesBE.json
@@ -5430,8 +5430,8 @@
       "zip": "9130"
     },
     {
-      "label": "9130 Kieldrecht (Beveren)",
-      "name": "Kieldrecht (Beveren)",
+      "label": "9130 Kieldrecht (Beveren-Kruibeke-Zwijndrecht)",
+      "name": "Kieldrecht (Beveren-Kruibeke-Zwijndrecht)",
       "zip": "9130"
     },
     { "label": "9130 Doel (Beveren)", "name": "Doel (Beveren)", "zip": "9130" },

--- a/public/assets/citiesBE.json
+++ b/public/assets/citiesBE.json
@@ -5434,7 +5434,7 @@
       "name": "Kieldrecht (Beveren-Kruibeke-Zwijndrecht)",
       "zip": "9130"
     },
-    { "label": "9130 Doel (Beveren)", "name": "Doel (Beveren)", "zip": "9130" },
+    { "label": "9130 Doel (Beveren-Kruibeke-Zwijndrecht)", "name": "Doel (Beveren-Kruibeke-Zwijndrecht)", "zip": "9130" },
     {
       "label": "9120 Vrasene (Beveren)",
       "name": "Vrasene (Beveren)",

--- a/public/assets/citiesBE.json
+++ b/public/assets/citiesBE.json
@@ -5436,8 +5436,8 @@
     },
     { "label": "9130 Doel (Beveren-Kruibeke-Zwijndrecht)", "name": "Doel (Beveren-Kruibeke-Zwijndrecht)", "zip": "9130" },
     {
-      "label": "9120 Vrasene (Beveren)",
-      "name": "Vrasene (Beveren)",
+      "label": "9120 Vrasene (Beveren-Kruibeke-Zwijndrecht)",
+      "name": "Vrasene (Beveren-Kruibeke-Zwijndrecht)",
       "zip": "9120"
     },
     {

--- a/public/assets/citiesBE.json
+++ b/public/assets/citiesBE.json
@@ -5441,8 +5441,8 @@
       "zip": "9120"
     },
     {
-      "label": "9120 Melsele (Beveren)",
-      "name": "Melsele (Beveren)",
+      "label": "9120 Melsele (Beveren-Kruibeke-Zwijndrecht)",
+      "name": "Melsele (Beveren-Kruibeke-Zwijndrecht)",
       "zip": "9120"
     },
     {

--- a/public/assets/citiesBE.json
+++ b/public/assets/citiesBE.json
@@ -5425,8 +5425,8 @@
       "zip": "9140"
     },
     {
-      "label": "9130 Verrebroek (Beveren)",
-      "name": "Verrebroek (Beveren)",
+      "label": "9130 Verrebroek (Beveren-Kruibeke-Zwijndrecht)",
+      "name": "Verrebroek (Beveren-Kruibeke-Zwijndrecht)",
       "zip": "9130"
     },
     {

--- a/public/assets/citiesBE.json
+++ b/public/assets/citiesBE.json
@@ -5446,8 +5446,8 @@
       "zip": "9120"
     },
     {
-      "label": "9120 Haasdonk (Beveren)",
-      "name": "Haasdonk (Beveren)",
+      "label": "9120 Haasdonk (Beveren-Kruibeke-Zwijndrecht)",
+      "name": "Haasdonk (Beveren-Kruibeke-Zwijndrecht)",
       "zip": "9120"
     },
     {


### PR DESCRIPTION
### Changed

- `citiesBE.json`: Fix some submunicipalites which still hade `Beveren` as mainMunicipality.

---

Ticket: https://jira.publiq.be/browse/III-6689
