### PR TITLE
III-6701 - Remove ownerId param from requestOwnership mutation

### DIFF
--- a/src/hooks/api/ownerships.ts
+++ b/src/hooks/api/ownerships.ts
@@ -48,14 +48,12 @@ export type OwnershipState = Values<typeof OwnershipState>;
 type RequestOwnershipArguments = {
   itemId: string;
   ownerEmail?: string;
-  ownerId?: string;
 };
 
 const requestOwnership = async ({
   headers,
   itemId,
   ownerEmail,
-  ownerId,
 }: { headers: Headers } & RequestOwnershipArguments) =>
   fetchFromApi({
     path: `/ownerships`,
@@ -66,7 +64,6 @@ const requestOwnership = async ({
         itemId,
         itemType: 'organizer',
         ...(ownerEmail && { ownerEmail }),
-        ...(ownerId && { ownerId }),
       }),
     },
   });

--- a/src/pages/organizers/[organizerId]/preview/RequestOwnershipModal.tsx
+++ b/src/pages/organizers/[organizerId]/preview/RequestOwnershipModal.tsx
@@ -76,7 +76,6 @@ const RequestOwnershipModal = ({
         onConfirm={() => {
           requestOwnershipMutation.mutate({
             itemId: organizerId,
-            ownerId: userId,
           });
         }}
         size={ModalSizes.MD}


### PR DESCRIPTION
### Removed
- [ownerId param from requestOwnership mutation](https://github.com/cultuurnet/udb3-frontend/commit/f7bb0f50ff681d0d0da75dd28cc05dc46a55ec74)

---
Ticket: https://jira.uitdatabank.be/browse/III-6701
