### PR TITLE
III-6779 - Don't return anything if organizer doesn't have a name

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -84,7 +84,7 @@ const RecentUsedOrganizers = ({
       </Alert>
       <Inline spacing={4} justifyContent="flex-start" flexWrap="wrap">
         {organizers.map((organizer, index) => {
-          if (organizer.name === undefined) return null;
+          if (!organizer.name) return null;
 
           const name =
             typeof organizer.name === 'string'

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -84,6 +84,8 @@ const RecentUsedOrganizers = ({
       </Alert>
       <Inline spacing={4} justifyContent="flex-start" flexWrap="wrap">
         {organizers.map((organizer, index) => {
+          if (organizer.name === undefined) return null;
+
           const name =
             typeof organizer.name === 'string'
               ? organizer.name


### PR DESCRIPTION
### Changed
- OrganizerPicker: [Don't return anything if organizer doesn't have a name](https://github.com/cultuurnet/udb3-frontend/commit/afb61338e68400b73f52c2aa8a69c5951506f8de)

### Fixed
- TypeError: can't access property "undefined", e.name is undefined
<img width="1351" height="644" alt="Screenshot 2025-09-01 at 10 43 17" src="https://github.com/user-attachments/assets/75f87225-589b-4363-9d7b-8fa35ba8ae13" />


**Cause:**
One of the recent events has an organizer which has been deleted (and doesn't have a name):
<img width="1346" height="384" alt="Screenshot 2025-09-01 at 10 45 02" src="https://github.com/user-attachments/assets/ec8e2ae6-4408-40b3-b0f3-1a10484e13fe" />

---
Ticket: https://jira.publiq.be/browse/III-6779
