### PR TITLE
III-6775 - Use uitpas labels from API for uitpas organizer check

### DIFF
--- a/src/hooks/api/labels.ts
+++ b/src/hooks/api/labels.ts
@@ -51,6 +51,9 @@ const useGetUitpasLabelsQuery = () =>
     queryFn: getUitpasLabelsQuery,
     staleTime: 1000 * 60 * 60, // 1 hour
     cacheTime: 1000 * 60 * 60 * 24, // 24 hours
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
   });
 
 export {

--- a/src/hooks/api/labels.ts
+++ b/src/hooks/api/labels.ts
@@ -1,8 +1,12 @@
+import { useQuery } from 'react-query';
+
 import { useAuthenticatedQuery } from '@/hooks/api/authenticated-query';
 import type { Headers } from '@/hooks/api/types/Headers';
 import { Label } from '@/types/Offer';
 import { PaginatedData } from '@/types/PaginatedData';
-import { fetchFromApi, isErrorObject } from '@/utils/fetchFromApi';
+import { fetchFromApi } from '@/utils/fetchFromApi';
+
+type UitpasLabels = Record<string, string>;
 
 const getLabelsByQuery = async ({
   headers,
@@ -34,4 +38,24 @@ const useGetLabelsByQuery = ({ query }: { query: string }) =>
     enabled: !!query,
   });
 
-export { getLabelsByQuery, useGetLabelsByQuery };
+const getUitpasLabelsQuery = async (): Promise<UitpasLabels> => {
+  const res = await fetchFromApi({
+    path: '/uitpas/labels',
+  });
+  return await res.json();
+};
+
+const useGetUitpasLabelsQuery = () =>
+  useQuery({
+    queryKey: ['uitpas-labels'],
+    queryFn: getUitpasLabelsQuery,
+    staleTime: 1000 * 60 * 60, // 1 hour
+    cacheTime: 1000 * 60 * 60 * 24, // 24 hours
+  });
+
+export {
+  getLabelsByQuery,
+  getUitpasLabelsQuery,
+  useGetLabelsByQuery,
+  useGetUitpasLabelsQuery,
+};

--- a/src/hooks/useUitpasLabels.tsx
+++ b/src/hooks/useUitpasLabels.tsx
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+
+import { useGetUitpasLabelsQuery } from '@/hooks/api/labels';
+
+export const useUitpasLabels = () => {
+  const { data = [], isLoading, error } = useGetUitpasLabelsQuery();
+  const uitpasLabels = useMemo(() => Object.values(data), [data]);
+
+  return { uitpasLabels, isLoading, error };
+};

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from 'react-query';
 import { useGetOffersByCreatorQuery } from '@/hooks/api/offers';
 import { useGetOrganizersByQueryQuery } from '@/hooks/api/organizers';
 import { useGetUserQuery } from '@/hooks/api/user';
+import { useUitpasLabels } from '@/hooks/useUitpasLabels';
 import { SupportedLanguages } from '@/i18n/index';
 import { Organizer } from '@/types/Organizer';
 import { Values } from '@/types/Values';
@@ -30,15 +31,15 @@ const MAX_RECENT_USED_ORGANIZERS = 4;
 
 const getValueFromGlobalTheme = getValueFromTheme('global');
 
-const isUitpasOrganizer = (organizer: Organizer) => {
+const isUitpasOrganizer = (organizer: Organizer, uitpasLabels: string[]) => {
+  if (!uitpasLabels || uitpasLabels.length === 0) return false;
+
   const combinedLabels = (organizer.labels || []).concat(
     organizer.hiddenLabels || [],
   );
 
   return combinedLabels.some(
-    (label) =>
-      (typeof label === 'string' && label.toLowerCase().includes('uitpas')) ||
-      label.toLowerCase().includes('paspartoe'),
+    (label) => typeof label === 'string' && uitpasLabels.includes(label),
   );
 };
 
@@ -55,6 +56,8 @@ const RecentUsedOrganizers = ({
   onChange: (organizerId: string) => void;
 } & StackProps) => {
   const { t } = useTranslation();
+
+  const { uitpasLabels } = useUitpasLabels();
 
   if (organizers.length === 0) {
     return null;
@@ -98,13 +101,15 @@ const RecentUsedOrganizers = ({
 
           return (
             <ButtonCard
-              key={index}
+              key={organizer['@id']}
               onClick={() => onChange(parseOfferId(organizer['@id']))}
               title={name}
               hasEllipsisOnTitle={true}
               badge={
                 <Inline>
-                  {isUitpasOrganizer(organizer) && <UitpasIcon width="2rem" />}
+                  {isUitpasOrganizer(organizer, uitpasLabels) && (
+                    <UitpasIcon width="2rem" />
+                  )}
                   {isCultuurkuurOrganizer(organizer) && (
                     <CultuurKuurIcon width="2rem" />
                   )}
@@ -144,6 +149,8 @@ const OrganizerPicker = ({
 
   const getUserQuery = useGetUserQuery();
   const user = getUserQuery.data;
+
+  const { uitpasLabels } = useUitpasLabels();
 
   const [addButtonHasBeenPressed, setAddButtonHasBeenPressed] = useState(false);
   const [organizerSearchInput, setOrganizerSearchInput] = useState('');
@@ -287,7 +294,7 @@ const OrganizerPicker = ({
                             <Highlighter search={text}>{name}</Highlighter>
                           </Text>
                           <Inline spacing={2}>
-                            {isUitpasOrganizer(org) && (
+                            {isUitpasOrganizer(org, uitpasLabels) && (
                               <UitpasIcon width="2rem" />
                             )}
                             {isCultuurkuurOrganizer(org) && (

--- a/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerPicker.tsx
@@ -101,7 +101,7 @@ const RecentUsedOrganizers = ({
 
           return (
             <ButtonCard
-              key={organizer['@id']}
+              key={index}
               onClick={() => onChange(parseOfferId(organizer['@id']))}
               title={name}
               hasEllipsisOnTitle={true}

--- a/src/pages/steps/AdditionalInformationStep/OrganizerStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/OrganizerStep.tsx
@@ -18,6 +18,7 @@ import {
   useGetCardSystemForEventQuery,
   useGetCardSystemsForOrganizerQuery,
 } from '@/hooks/api/uitpas';
+import { useUitpasLabels } from '@/hooks/useUitpasLabels';
 import { Event } from '@/types/Event';
 import { Alert, AlertVariants } from '@/ui/Alert';
 import { Button, ButtonVariants } from '@/ui/Button';
@@ -52,6 +53,7 @@ const OrganizerStep = ({
 }: Props) => {
   const { t, i18n } = useTranslation();
   const { ...router } = useRouter();
+  const { uitpasLabels } = useUitpasLabels();
   const queryClient = useQueryClient();
 
   const getOfferByIdQuery = useGetOfferByIdQuery({ id: offerId, scope });
@@ -61,7 +63,9 @@ const OrganizerStep = ({
 
   const organizer = offer?.organizer?.name ? offer?.organizer : undefined;
   const hasPriceInfo = (offer?.priceInfo ?? []).length > 0;
-  const hasUitpasLabel = organizer ? isUitpasOrganizer(organizer) : false;
+  const hasUitpasLabel = organizer
+    ? isUitpasOrganizer(organizer, uitpasLabels)
+    : false;
   const [hasUitpasTicketSales, setHasUitpasTicketSales] = useState(false);
 
   const getCardSystemForEventQuery = useGetCardSystemForEventQuery(

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -260,7 +260,12 @@ const PriceInformation = ({
     }
 
     replace(
-      reconcileRates(ratesRef.current, priceInfo, offer) as FormData['rates'],
+      reconcileRates(
+        ratesRef.current,
+        priceInfo,
+        uitpasLabels,
+        offer,
+      ) as FormData['rates'],
     );
     reset({}, { keepValues: true });
 

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -32,6 +32,7 @@ import { Text, TextVariants } from '@/ui/Text';
 import { Breakpoints, getValueFromTheme } from '@/ui/theme';
 import { FetchError } from '@/utils/fetchFromApi';
 import { reconcileRates } from '@/utils/reconcileRates';
+import { useUitpasLabels } from '@/hooks/useUitpasLabels';
 
 const PRICE_CURRENCY: string = 'EUR';
 
@@ -161,6 +162,8 @@ const PriceInformation = ({
     { refetchOnWindowFocus: false },
   );
 
+  const { uitpasLabels } = useUitpasLabels();
+
   const offer: Offer | undefined = getOfferByIdQuery.data;
 
   const {
@@ -244,7 +247,7 @@ const PriceInformation = ({
 
     const hasUitpasLabel =
       offer?.organizer && scope === OfferTypes.EVENTS
-        ? isUitpasOrganizer(offer?.organizer)
+        ? isUitpasOrganizer(offer?.organizer, uitpasLabels)
         : false;
 
     if (priceInfo.length === 0) {

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -242,13 +242,14 @@ const PriceInformation = ({
   const isCultuurkuurAlertVisible =
     isCultuurkuurEvent && (!hasBasePriceInfo || hasMultiplePrices);
 
+  const hasUitpasLabel = useMemo(() => {
+    return offer?.organizer && scope === OfferTypes.EVENTS
+      ? isUitpasOrganizer(offer?.organizer, uitpasLabels)
+      : false;
+  }, [offer?.organizer, scope, uitpasLabels]);
+
   useEffect(() => {
     const priceInfo = offer?.priceInfo ?? ([] as FormData['rates']);
-
-    const hasUitpasLabel =
-      offer?.organizer && scope === OfferTypes.EVENTS
-        ? isUitpasOrganizer(offer?.organizer, uitpasLabels)
-        : false;
 
     if (priceInfo.length === 0) {
       return onValidationChange(
@@ -284,6 +285,7 @@ const PriceInformation = ({
     onValidationChange,
     replace,
     reset,
+    hasUitpasLabel,
   ]);
 
   return (

--- a/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
+++ b/src/pages/steps/AdditionalInformationStep/PriceInformation.tsx
@@ -12,6 +12,7 @@ import {
   useAddOfferPriceInfoMutation,
   useGetOfferByIdQuery,
 } from '@/hooks/api/offers';
+import { useUitpasLabels } from '@/hooks/useUitpasLabels';
 import i18n, { SupportedLanguage } from '@/i18n/index';
 import {
   TabContentProps,
@@ -32,7 +33,6 @@ import { Text, TextVariants } from '@/ui/Text';
 import { Breakpoints, getValueFromTheme } from '@/ui/theme';
 import { FetchError } from '@/utils/fetchFromApi';
 import { reconcileRates } from '@/utils/reconcileRates';
-import { useUitpasLabels } from '@/hooks/useUitpasLabels';
 
 const PRICE_CURRENCY: string = 'EUR';
 

--- a/src/utils/reconcileRates.test.ts
+++ b/src/utils/reconcileRates.test.ts
@@ -7,6 +7,8 @@ const uitpasOffer = {
   organizer: { labels: ['uitpas'] },
 } as Offer;
 
+const uitpasLabels = ['uitpas'];
+
 describe('reconcileRates', () => {
   it('can overwrite default values', () => {
     const currentRates = [
@@ -54,7 +56,7 @@ describe('reconcileRates', () => {
       },
     ];
 
-    expect(reconcileRates(currentRates, [])).toEqual([
+    expect(reconcileRates(currentRates, [], uitpasLabels)).toEqual([
       {
         name: { nl: 'foo' },
         category: PriceCategory.BASE,
@@ -96,7 +98,7 @@ describe('reconcileRates', () => {
     ];
 
     expect(
-      reconcileRates(currentRates, newRates, uitpasOffer),
+      reconcileRates(currentRates, newRates, uitpasLabels, uitpasOffer),
     ).toMatchSnapshot();
   });
 
@@ -132,7 +134,7 @@ describe('reconcileRates', () => {
     ];
 
     expect(
-      reconcileRates(currentRates, newRates, uitpasOffer),
+      reconcileRates(currentRates, newRates, uitpasLabels, uitpasOffer),
     ).toMatchSnapshot();
   });
 
@@ -174,7 +176,7 @@ describe('reconcileRates', () => {
     ];
 
     expect(
-      reconcileRates(currentRates, newRates, uitpasOffer),
+      reconcileRates(currentRates, newRates, uitpasLabels, uitpasOffer),
     ).toMatchSnapshot();
   });
 
@@ -204,7 +206,7 @@ describe('reconcileRates', () => {
     ];
 
     expect(
-      reconcileRates(currentRates, newRates, {
+      reconcileRates(currentRates, newRates, uitpasLabels, {
         ...uitpasOffer,
         mainLanguage: 'fr',
       }),
@@ -252,6 +254,8 @@ describe('reconcileRates', () => {
       },
     ];
 
-    expect(reconcileRates(currentRates, [], uitpasOffer)).toHaveLength(2);
+    expect(
+      reconcileRates(currentRates, [], uitpasLabels, uitpasOffer),
+    ).toHaveLength(2);
   });
 });

--- a/src/utils/reconcileRates.test.ts
+++ b/src/utils/reconcileRates.test.ts
@@ -29,8 +29,10 @@ describe('reconcileRates', () => {
       },
     ];
 
-    expect(reconcileRates(currentRates, newRates)).toMatchSnapshot();
-    expect(reconcileRates(currentRates, [])).toEqual([
+    expect(
+      reconcileRates(currentRates, newRates, uitpasLabels),
+    ).toMatchSnapshot();
+    expect(reconcileRates(currentRates, [], uitpasLabels)).toEqual([
       {
         name: { nl: 'Base Tarif' },
         category: PriceCategory.BASE,

--- a/src/utils/reconcileRates.ts
+++ b/src/utils/reconcileRates.ts
@@ -25,7 +25,7 @@ export function reconcileRates(
     currentRates.length === 1 && currentRates[0].price === '';
 
   const hasUitpasOrganizer =
-    offer?.organizer && isUitpasOrganizer(offer?.organizer);
+    offer?.organizer && isUitpasOrganizer(offer?.organizer, ['uitpas']);
 
   // If the form is in its initial state, replace it entirely
   if (isDefaultValue && newRates.length) {

--- a/src/utils/reconcileRates.ts
+++ b/src/utils/reconcileRates.ts
@@ -8,6 +8,7 @@ const parseNumber = (number: string | number): number =>
 export function reconcileRates(
   currentRates: PriceInfo[],
   newRates: PriceInfo[],
+  uitpasLabels: string[],
   offer?: Offer,
 ): PriceInfo[] {
   const mainLanguage = offer?.mainLanguage;
@@ -25,7 +26,7 @@ export function reconcileRates(
     currentRates.length === 1 && currentRates[0].price === '';
 
   const hasUitpasOrganizer =
-    offer?.organizer && isUitpasOrganizer(offer?.organizer, ['uitpas']);
+    offer?.organizer && isUitpasOrganizer(offer?.organizer, uitpasLabels);
 
   // If the form is in its initial state, replace it entirely
   if (isDefaultValue && newRates.length) {


### PR DESCRIPTION
### Added
- [useGetUitpasLabelsQuery hook for fetchin uitpas labels](https://github.com/cultuurnet/udb3-frontend/commit/da72a9737c77ff74143b56cb95a6aeec2e422493)
- [hook useUitpasLabels](https://github.com/cultuurnet/udb3-frontend/commit/819a1368a1f2c251145e09c7c6aece24f910b287)

### Changed
- Use list of uitpas labels from api instead of check on fixed string uitpas | paspartoe

<img width="965" height="395" alt="Screenshot 2025-09-02 at 14 10 25" src="https://github.com/user-attachments/assets/4f960f0a-9309-4150-a151-c3cf9e521a5c" />


---
Ticket: https://jira.uitdatabank.be/browse/III-6775
