### PR TITLE
III-6778 - Show specific error message when ownership request throws a 409

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1109,7 +1109,11 @@
           "title": "Verwaltungsanfrage für {{organizerName}}",
           "body": "Sind Sie im Vorstand von {{organizerName}} und möchten Sie die Organisationsseite und Veranstaltungen verwalten? Starten Sie hier Ihre Anfrage, um Administrator zu werden. Sobald ein aktueller Administrator Ihre Anfrage genehmigt, erhalten Sie Zugriff und eine Bestätigung per E-Mail.",
           "cancel": "Abbrechen",
-          "confirm": "Verwaltungsanfrage"
+          "confirm": "Verwaltungsanfrage",
+          "error": {
+            "general": "Eine Fehler ist aufgetreten.",
+            "409": "Sie haben bereits eine laufende Anfrage für diese Organisation."
+          }
         },
         "pending": "Ihre Anfrage zur Verwaltung von {{organizerName}} wird bearbeitet.<br/>Sobald ein aktueller Administrator Ihre Anfrage genehmigt hat, erhalten Sie Zugriff und eine Bestätigung per E-Mail.",
         "success": "Ihre Anfrage zur Verwaltung der Seite von {{organizerName}} und ihrer Veranstaltungen wurde erfolgreich gesendet!<br/>Sobald ein aktueller Administrator Ihre Anfrage genehmigt, erhalten Sie Zugriff und eine Bestätigung per E-Mail."

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1111,7 +1111,7 @@
           "cancel": "Abbrechen",
           "confirm": "Verwaltungsanfrage",
           "error": {
-            "general": "Eine Fehler ist aufgetreten.",
+            "general": "Ein Fehler ist aufgetreten.",
             "409": "Sie haben bereits eine laufende Anfrage für diese Organisation."
           }
         },

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1109,7 +1109,11 @@
           "title": "Demande de gestion pour {{organizerName}}",
           "body": "Êtes-vous impliqué dans la gestion de {{organizerName}} et souhaitez-vous gérer la page de l'organisation et de ses événements ? Commencez ici votre demande pour devenir administrateur. Une fois qu'un administrateur actuel approuve votre demande, vous recevrez l'accès et une confirmation par e-mail.",
           "cancel": "Annuler",
-          "confirm": "Demander la gestion"
+          "confirm": "Demander la gestion",
+          "error": {
+            "general": "Une erreur s'est produite lors de l'envoi de votre demande.",
+            "409": "Vous avez déjà une demande en cours pour cette organisation."
+          }
         },
         "pending": "Votre demande pour gérer {{organizerName}} est en cours de traitement.<br/>Dès qu'un administrateur actuel aura approuvé votre demande, vous recevrez l'accès et une confirmation par e-mail.",
         "success": "Votre demande pour gérer la page de {{organizerName}} et ses événements a été envoyée avec succès !<br/>Dès qu'un administrateur actuel approuve votre demande, vous recevrez l'accès et une confirmation par e-mail."

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -1163,7 +1163,10 @@
           "body": "Ben je betrokken bij het bestuur van {{organizerName}} en wil je de organisatiepagina en evenementen ervan beheren? Start hier je aanvraag om beheerder te worden. Zodra een huidige beheerder je aanvraag goedkeurt, krijg je toegang en ontvang je een bevestiging via e-mail.",
           "cancel": "Annuleren",
           "confirm": "Beheer aanvragen",
-          "error": "Er is iets misgelopen"
+          "error": {
+            "general": "Er is iets misgelopen",
+            "409": "Je hebt al een lopende aanvraag voor deze organisatie."
+          }
         },
         "pending": "Je aanvraag tot het beheer van {{organizerName}} is in behandeling.<br/>Zodra een huidige beheerder je aanvraag heeft goedgekeurd, krijg je toegang en ontvang je een bevestiging via e-mail.",
         "success": "Je aanvraag om beheerder te worden van {{organizerName}} is succesvol verzonden!<br/>Zodra een huidige beheerder je aanvraag heeft goedgekeurd, krijg je toegang en ontvang je een bevestiging via e-mail."

--- a/src/pages/organizers/[organizerId]/preview/RequestOwnershipModal.tsx
+++ b/src/pages/organizers/[organizerId]/preview/RequestOwnershipModal.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQueryClient, UseQueryResult } from 'react-query';
+import { useQueryClient } from 'react-query';
 
 import { useRequestOwnershipMutation } from '@/hooks/api/ownerships';
 import { useGetUserQuery, User } from '@/hooks/api/user';
@@ -43,8 +43,6 @@ const RequestOwnershipModal = ({
     i18n.language as SupportedLanguage,
     organizer?.mainLanguage as SupportedLanguage,
   );
-
-  const getUserQuery = useGetUserQuery() as UseQueryResult<User, FetchError>;
 
   const requestOwnershipMutation = useRequestOwnershipMutation({
     onSuccess: async () => {

--- a/src/pages/organizers/[organizerId]/preview/RequestOwnershipModal.tsx
+++ b/src/pages/organizers/[organizerId]/preview/RequestOwnershipModal.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 
 import { useRequestOwnershipMutation } from '@/hooks/api/ownerships';
-import { useGetUserQuery, User } from '@/hooks/api/user';
 import { SupportedLanguage } from '@/i18n/index';
 import { Organizer } from '@/types/Organizer';
 import { Alert, AlertVariants } from '@/ui/Alert';
@@ -37,6 +36,7 @@ const RequestOwnershipModal = ({
     parseOfferId(organizer?.['@id'] ?? '');
   const [isSuccessAlertVisible, setIsSuccessAlertVisible] = useState(false);
   const [isErrorAlertVisible, setIsErrorAlertVisible] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
   const organizerName: string = getLanguageObjectOrFallback(
     organizer?.name,
@@ -51,7 +51,15 @@ const RequestOwnershipModal = ({
       setIsSuccessAlertVisible(true);
       if (onSuccess) onSuccess();
     },
-    onError: () => {
+    onError: (err: FetchError) => {
+      err.status === 409
+        ? setErrorMessage(
+            t('organizers.ownerships.request.confirm_modal.error.409'),
+          )
+        : setErrorMessage(
+            t('organizers.ownerships.request.confirm_modal.error.general'),
+          );
+
       onClose();
       setIsErrorAlertVisible(true);
       if (onError) onError();
@@ -104,7 +112,7 @@ const RequestOwnershipModal = ({
           closable
           onClose={() => setIsErrorAlertVisible(false)}
         >
-          {t('organizers.ownerships.request.confirm_modal.error')}
+          {errorMessage}
         </Alert>
       )}
     </>

--- a/src/pages/organizers/[organizerId]/preview/RequestOwnershipModal.tsx
+++ b/src/pages/organizers/[organizerId]/preview/RequestOwnershipModal.tsx
@@ -46,8 +46,6 @@ const RequestOwnershipModal = ({
 
   const getUserQuery = useGetUserQuery() as UseQueryResult<User, FetchError>;
 
-  const userId = getUserQuery.data?.sub;
-
   const requestOwnershipMutation = useRequestOwnershipMutation({
     onSuccess: async () => {
       await queryClient.invalidateQueries('ownership-requests');


### PR DESCRIPTION
### Added
- [translations for ownership request errors](https://github.com/cultuurnet/udb3-frontend/commit/d5351a39a3bd6f28d52c72153bac52729ef663d6)

### Changed
- [specific errorMessage for ownership request](https://github.com/cultuurnet/udb3-frontend/commit/6320b1741e41d84e563d2de3c5203d293480b345)

### Removed
- [userId, since it's not necessary](https://github.com/cultuurnet/udb3-frontend/commit/e055b593326207bc5df9aa9583f12ace5cb1bac6)
- [unused imports and const](https://github.com/cultuurnet/udb3-frontend/commit/183e608bbf10475624ff8f91495e16887056995a)

<img width="1473" height="484" alt="Screenshot 2025-09-11 at 14 14 29" src="https://github.com/user-attachments/assets/3b162d5d-ad04-4b15-9fd8-cbb0ab527a8e" />


---
Ticket: https://jira.uitdatabank.be/browse/III-6778
