### PR TITLE
III-6802 - Ck don't show error on themes when there are no themes for types

### DIFF
--- a/src/pages/steps/EventTypeAndThemeStep.tsx
+++ b/src/pages/steps/EventTypeAndThemeStep.tsx
@@ -281,6 +281,7 @@ const EventTypeAndThemeStep = ({
     error?.message?.includes(CULTUURKUUR_THEME_ERROR) && !selectedThemeId;
 
   const isCultuurkuurThemeErrorVisible =
+    themes.length > 0 &&
     isCultuurkuurEvent &&
     !!selectedTypeId &&
     (isNewCultuurkuurEventWithoutTheme ||

--- a/src/pages/steps/hooks/useAddOffer.ts
+++ b/src/pages/steps/hooks/useAddOffer.ts
@@ -83,7 +83,8 @@ const useAddOffer = ({
       const isTypeSelected = !!fullOffer?.typeAndTheme?.type;
       const selectedTypeId = fullOffer?.typeAndTheme?.type?.id;
 
-      const typeHasNoThemes = eventTypesWithNoThemes.includes(selectedTypeId);
+      const typeHasNoThemes =
+        selectedTypeId && eventTypesWithNoThemes.includes(selectedTypeId);
 
       if (!educationLabels || educationLabels.length === 0) {
         errors.push(CULTUURKUUR_EDUCATION_LABELS_ERROR);

--- a/src/pages/steps/hooks/useAddOffer.ts
+++ b/src/pages/steps/hooks/useAddOffer.ts
@@ -79,7 +79,13 @@ const useAddOffer = ({
 
       const isThemeSelected = !!fullOffer?.typeAndTheme?.theme;
 
+      console.log('isThemeSelected', isThemeSelected);
+
+      // TODO check if type is selected but without themes it should still submit
+
       const isTypeSelected = !!fullOffer?.typeAndTheme?.type;
+
+      console.log('isTypeSelected', isTypeSelected);
 
       if (!educationLabels || educationLabels.length === 0) {
         errors.push(CULTUURKUUR_EDUCATION_LABELS_ERROR);
@@ -97,6 +103,7 @@ const useAddOffer = ({
       }
 
       if (!isThemeSelected) {
+        // This is happening but it should only happen when there are actual themes for the selected type
         errors.push(CULTUURKUUR_THEME_ERROR);
       }
     }

--- a/src/pages/steps/hooks/useAddOffer.ts
+++ b/src/pages/steps/hooks/useAddOffer.ts
@@ -83,7 +83,7 @@ const useAddOffer = ({
       const isTypeSelected = !!fullOffer?.typeAndTheme?.type;
       const selectedTypeId = fullOffer?.typeAndTheme?.type?.id;
 
-      const typeHasNoThemes =
+      const hasTypeNoThemes =
         selectedTypeId && eventTypesWithNoThemes.includes(selectedTypeId);
 
       if (!educationLabels || educationLabels.length === 0) {
@@ -101,7 +101,7 @@ const useAddOffer = ({
         errors.push(CULTUURKUUR_TYPE_ERROR);
       }
 
-      if (!isThemeSelected && !typeHasNoThemes) {
+      if (!isThemeSelected && !hasTypeNoThemes) {
         errors.push(CULTUURKUUR_THEME_ERROR);
       }
     }

--- a/src/pages/steps/hooks/useAddOffer.ts
+++ b/src/pages/steps/hooks/useAddOffer.ts
@@ -9,6 +9,7 @@ import {
   CULTUURKUUR_TYPE_ERROR,
 } from '@/constants/Cultuurkuur';
 import { ErrorCodes } from '@/constants/ErrorCodes';
+import { eventTypesWithNoThemes } from '@/constants/EventTypes';
 import { OfferTypes, ScopeTypes } from '@/constants/OfferType';
 import { useAddEventMutation } from '@/hooks/api/events';
 import { useAddOfferLabelMutation } from '@/hooks/api/offers';
@@ -79,13 +80,10 @@ const useAddOffer = ({
 
       const isThemeSelected = !!fullOffer?.typeAndTheme?.theme;
 
-      console.log('isThemeSelected', isThemeSelected);
-
-      // TODO check if type is selected but without themes it should still submit
-
       const isTypeSelected = !!fullOffer?.typeAndTheme?.type;
+      const selectedTypeId = fullOffer?.typeAndTheme?.type?.id;
 
-      console.log('isTypeSelected', isTypeSelected);
+      const typeHasNoThemes = eventTypesWithNoThemes.includes(selectedTypeId);
 
       if (!educationLabels || educationLabels.length === 0) {
         errors.push(CULTUURKUUR_EDUCATION_LABELS_ERROR);
@@ -102,8 +100,7 @@ const useAddOffer = ({
         errors.push(CULTUURKUUR_TYPE_ERROR);
       }
 
-      if (!isThemeSelected) {
-        // This is happening but it should only happen when there are actual themes for the selected type
+      if (!isThemeSelected && !typeHasNoThemes) {
         errors.push(CULTUURKUUR_THEME_ERROR);
       }
     }


### PR DESCRIPTION
### Changed
- [Only show error when there are actual themes](https://github.com/cultuurnet/udb3-frontend/pull/1082/commits/2cf7a8afc3eebb3e8e35394987a54bce5de75e48)
- [Don't push error when eventType has no themes](https://github.com/cultuurnet/udb3-frontend/pull/1082/commits/e66b945bf02e7bff4908c943339b1ec6a1b3b65f)

---

Ticket: https://jira.publiq.be/browse/III-6802
