### PR TITLE
III-7147: correct cultuurkuur event path

### DIFF
--- a/src/pages/events/[eventId]/Preview.tsx
+++ b/src/pages/events/[eventId]/Preview.tsx
@@ -229,7 +229,7 @@ const Preview = () => {
       ? t('brand_cultuurkuur')
       : t('brand_uitinvlaanderen');
     const publicUrl = isCultuurkuurEvent
-      ? `${publicRuntimeConfig.ckUrl}/event/${parseOfferId(offer['@id'])}`
+      ? `${publicRuntimeConfig.ckUrl}/agenda/e/x/${parseOfferId(offer['@id'])}`
       : `${publicRuntimeConfig.uivUrl}/agenda/e/x/${parseOfferId(offer['@id'])}`;
 
     const publicationRulesUrl = publicRuntimeConfig.udbPublicationRulesUrl;

--- a/src/test/e2e/cultuurkuur/cultuurkuur-event-publication-status.spec.ts
+++ b/src/test/e2e/cultuurkuur/cultuurkuur-event-publication-status.spec.ts
@@ -106,7 +106,7 @@ test.describe('Cultuurkuur Event - Publication Status Display', () => {
 
     await expect(publicUrlLink).toHaveAttribute(
       'href',
-      `${process.env.NEXT_PUBLIC_CK_URL}/event/${cultuurkuurEventId}`,
+      `${process.env.NEXT_PUBLIC_CK_URL}/agenda/e/x/${cultuurkuurEventId}`,
     );
 
     await expect(publicUrlLink).toHaveAttribute('target', '_blank');


### PR DESCRIPTION
### Changed
- cultuurkuur url path from `${publicRuntimeConfig.ckUrl}/event/${parseOfferId(offer['@id'])} `to `${publicRuntimeConfig.ckUrl}/agenda/e/x/${parseOfferId(offer['@id'])}`


---

Ticket: https://jira.publiq.be/browse/III-7147
