### PR TITLE
III-7151 - Add new accessibility tab

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,110 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: PR Review with Progress Tracking
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Enable progress tracking
+          track_progress: true
+
+          # Your custom review instructions
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            Review this pull request and provide inline feedback using the GitHub review system. Follow these steps:
+
+            1. Start a review: Use `mcp__github__create_pending_pull_request_review` to start a pending review.
+            2. Get diff information: Use `mcp__github__get_pull_request_diff` to see the code changes and line numbers.
+               - If the pull request has many changes, paginate the diff using the `page` and `per_page` parameters.
+               - Example: To get the first 100 lines, call `mcp__github__get_pull_request_diff` with `per_page=100` and `page=1`. For the next 100 lines, use `page=2`, and so on.
+               - Continue fetching pages until all changes are retrieved.
+            3. Add inline comments: Use `mcp__github__add_comment_to_pending_review` to provide feedback on specific lines of code snippets.
+               - **When suggesting code changes, format them as GitHub suggestion blocks so they can be committed directly:**
+                 - For single-line suggestions, use:
+                   ```suggestion
+                   suggested code here
+                   ```
+                 - For multi-line suggestions, use:
+                   ```suggestion:-0+1
+                   suggested code here
+                   ```
+                   (Adjust the numbers to match how many lines to remove and add)
+               - Only provide suggestion blocks when you have a concrete, actionable fix
+               - Include explanation text before or after the suggestion block
+            4. Submit for review: Use `mcp__github__submit_pending_pull_request_review` with the event type set to "COMMENT" (not "REQUEST_CHANGES") to publish all comments for non-blocking review.
+
+            Focus on the following focus areas:
+
+            1. **Code Quality**
+               - Clean code principles and best practices
+               - Proper error handling and edge cases
+               - Code readability and maintainability
+               - **Provide suggestion blocks for improvements when possible**
+
+            2. **Security**
+               - Check for potential security vulnerabilities
+               - Validate input sanitization
+               - Review authentication/authorization logic
+               - **Suggest secure alternatives with suggestion blocks**
+
+            3. **Performance**
+               - Identify potential performance bottlenecks
+               - Review database queries for efficiency
+               - Check for memory leaks or resource issues
+               - **Offer optimized code via suggestion blocks**
+
+            4. **Testing**
+               - Verify adequate test coverage
+               - Review test quality and edge cases
+               - Check for missing test scenarios
+
+            5. **Documentation**
+               - Ensure code is properly documented
+               - Verify README updates for new features
+               - Check API documentation accuracy
+
+            Provide detailed feedback using inline comments for specific issues.
+            Use suggestion blocks liberally to make it easy for developers to apply fixes.
+            Use top-level comments for general observations or praise.
+
+          # Tools for comprehensive PR review
+          claude_args: |
+            --allowedTools "mcp__github__get_pull_request,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+
+      # When track_progress is enabled:
+      # - Creates a tracking comment with progress checkboxes
+      # - Includes all PR context (comments, attachments, images)
+      # - Updates progress as the review proceeds
+      # - Marks as completed when done

--- a/src/hooks/api/authenticated-query.ts
+++ b/src/hooks/api/authenticated-query.ts
@@ -218,6 +218,7 @@ const isDuplicateMutation = (
     'roles-remove-user',
     'labels-update-visibility',
     'labels-update-privacy',
+    'events-change-departure-places',
   ];
 
   if (disabledMutations.includes(mutationKey)) {

--- a/src/hooks/api/events.ts
+++ b/src/hooks/api/events.ts
@@ -827,6 +827,33 @@ const useDeleteOnlineUrlMutation = (configuration = {}) =>
     ...configuration,
   });
 
+type ChangeDeparturePlacesArguments = {
+  headers: Headers;
+  eventId: string;
+  departurePlaces: string[];
+};
+
+const changeDeparturePlaces = async ({
+  headers,
+  eventId,
+  departurePlaces,
+}: ChangeDeparturePlacesArguments) =>
+  fetchFromApi({
+    path: `/events/${eventId}/departurePlaces`,
+    options: {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(departurePlaces),
+    },
+  });
+
+const useChangeDeparturePlacesMutation = (configuration = {}) =>
+  useAuthenticatedMutation({
+    mutationFn: changeDeparturePlaces,
+    mutationKey: 'events-change-departure-places',
+    ...configuration,
+  });
+
 type DuplicateEventArguments = {
   headers: Headers;
   eventId: string;
@@ -872,6 +899,7 @@ export {
   useChangeAudienceMutation,
   useChangeAvailableFromMutation,
   useChangeCalendarMutation,
+  useChangeDeparturePlacesMutation,
   useChangeLocationMutation,
   useChangeNameMutation,
   useChangeOnlineUrlMutation,

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -273,6 +273,19 @@
       "refine": "Verfeinere"
     },
     "additionalInformation": {
+      "accessibility": {
+        "title": "Barrierefreiheit",
+        "departure": {
+          "title": "Von welcher Schule oder einem anderen Standort aus ist ein Transport zu Ihrer Aktivität für Kinder vorgesehen?",
+          "info": "Das kann zum Beispiel eine Laufschlange, ein Bus oder ein Fahrradtaxi sein, das Kinder von einer Schule oder Betreuungseinrichtung zu Ihrer Aktivität bringt.",
+          "location_title": "Abholort {{number}}",
+          "place_label": "Ort auswählen",
+          "place_placeholder": "",
+          "add": "Weiteren Ort hinzufügen",
+          "delete": "Abholort entfernen",
+          "max_reached": "Sie können maximal 20 Abholorte hinzufügen."
+        }
+      },
       "audience": {
         "education": "Nur für Schulen",
         "everyone": "Für alle",
@@ -806,7 +819,8 @@
         "contact_info": "Kontaktdaten wurden erfolgreich geändert",
         "booking_info": "Reservierungsinformationen wurden erfolgreich geändert",
         "media": "Medien erfolgreich gewechselt",
-        "audience": "Zugang wurde erfolgreich geändert"
+        "audience": "Zugang wurde erfolgreich geändert",
+        "accessibility": "Barrierefreiheit wurde erfolgreich geändert"
       }
     }
   },

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -283,7 +283,7 @@
           "place_placeholder": "",
           "add": "Weiteren Ort hinzufügen",
           "delete": "Abholort entfernen",
-          "max_reached": "Sie können maximal 20 Abholorte hinzufügen."
+          "max_reached": "Sie können maximal {{maxLocations}} Abholorte hinzufügen."
         }
       },
       "audience": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -285,7 +285,7 @@
           "place_placeholder": "",
           "add": "Ajouter un lieu",
           "delete": "Supprimer le lieu de départ",
-          "max_reached": "Vous pouvez ajouter au maximum 20 lieux de départ."
+          "max_reached": "Vous pouvez ajouter au maximum {{maxLocations}} lieux de départ."
         }
       },
       "audience": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -275,6 +275,19 @@
     "additionalInformation": {
       "title_events": "Faites ressortir cette activité",
       "title_places": "Faites en sorte que cet emplacement se démarque",
+      "accessibility": {
+        "title": "Accessibilité",
+        "departure": {
+          "title": "Depuis quelle école ou quel autre lieu un transport est-il prévu pour amener les enfants à votre activité ?",
+          "info": "Il peut s'agir par exemple d'une corde de promenade, d'un bus ou d'un vélo-taxi qui amène les enfants depuis une école ou une garderie jusqu'au lieu de votre activité.",
+          "location_title": "Lieu de départ {{number}}",
+          "place_label": "Choisir un lieu",
+          "place_placeholder": "",
+          "add": "Ajouter un lieu",
+          "delete": "Supprimer le lieu de départ",
+          "max_reached": "Vous pouvez ajouter au maximum 20 lieux de départ."
+        }
+      },
       "audience": {
         "education": "Spécifiquement pour des écoles",
         "everyone": "Pour tout le monde",
@@ -812,7 +825,8 @@
         "contact_info": "Les coordonnées ont été modifiées avec succès",
         "booking_info": "Les informations de réservation ont été modifiées avec succès",
         "media": "Image/vidéo modifiée avec succès",
-        "audience": "Accès modifié avec succès"
+        "audience": "Accès modifié avec succès",
+        "accessibility": "L'accessibilité a été modifiée avec succès"
       }
     }
   },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -303,7 +303,7 @@
           "place_placeholder": "",
           "add": "Voeg nog een locatie toe",
           "delete": "Verwijder vertreklocatie",
-          "max_reached": "Je kan maximum 20 vertreklocaties toevoegen."
+          "max_reached": "Je kan maximum {{maxLocations}} vertreklocaties toevoegen."
         }
       },
       "audience": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -301,7 +301,8 @@
           "location_title": "Vertreklocatie {{number}}",
           "place_label": "Kies een locatie",
           "place_placeholder": "",
-          "add": "Voeg nog een locatie toe"
+          "add": "Voeg nog een locatie toe",
+          "delete": "Verwijder vertreklocatie"
         }
       },
       "audience": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -294,7 +294,15 @@
       "title_events": "Laat deze activiteit extra opvallen",
       "title_places": "Laat deze locatie extra opvallen",
       "accessibility": {
-        "title": "Bereikbaarheid"
+        "title": "Bereikbaarheid",
+        "departure": {
+          "title": "Vanuit welke school of andere locatie is er vervoer voorzien dat kinderen tot bij jouw activiteit brengt?",
+          "info": "Dat kan bijvoorbeeld een wandelslang, een bus of een fietstaxi zijn die kinderen vanuit een school of opvang naar de locatie van je activiteit brengt.",
+          "location_title": "Vertreklocatie {{number}}",
+          "place_label": "Kies een locatie",
+          "place_placeholder": "",
+          "add": "Voeg nog een locatie toe"
+        }
       },
       "audience": {
         "title": "Toegang",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -573,7 +573,8 @@
         "contact_info": "Contactinfo is succesvol gewijzigd",
         "booking_info": "Reservatie informatie is succesvol gewijzigd",
         "media": "Media is succesvol gewijzigd",
-        "audience": "Toegang is succesvol gewijzigd"
+        "audience": "Toegang is succesvol gewijzigd",
+        "accessibility": "Bereikbaarheid is succesvol gewijzigd"
       }
     }
   },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -293,6 +293,9 @@
     "additionalInformation": {
       "title_events": "Laat deze activiteit extra opvallen",
       "title_places": "Laat deze locatie extra opvallen",
+      "accessibility": {
+        "title": "Bereikbaarheid"
+      },
       "audience": {
         "title": "Toegang",
         "education": "Specifiek voor scholen",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -302,7 +302,8 @@
           "place_label": "Kies een locatie",
           "place_placeholder": "",
           "add": "Voeg nog een locatie toe",
-          "delete": "Verwijder vertreklocatie"
+          "delete": "Verwijder vertreklocatie",
+          "max_reached": "Je kan maximum 20 vertreklocaties toevoegen."
         }
       },
       "audience": {

--- a/src/pages/create/OfferForm.tsx
+++ b/src/pages/create/OfferForm.tsx
@@ -305,6 +305,7 @@ const OfferForm = () => {
           contact_info: t('create.toast.success.contact_info'),
           description: t('create.toast.success.description'),
           audience: t('create.toast.success.audience'),
+          accessibility: t('create.toast.success.accessibility'),
           price_info: t('create.toast.success.price_info'),
           organizer: t('create.toast.success.organizer'),
         },

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -1,5 +1,199 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { SupportedLanguage } from '@/i18n/index';
+import { Countries, Country } from '@/types/Country';
+import type { Place } from '@/types/Place';
+import { Button, ButtonVariants } from '@/ui/Button';
+import { FormElement } from '@/ui/FormElement';
+import { Icon, Icons } from '@/ui/Icon';
+import { Inline } from '@/ui/Inline';
+import { Panel } from '@/ui/Panel';
+import { Stack } from '@/ui/Stack';
+import { Text } from '@/ui/Text';
+import { getValueFromTheme } from '@/ui/theme';
+import { Title } from '@/ui/Title';
+import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback';
+
+import { City, CityPicker } from '../CityPicker';
+import { CountryPicker } from './CountryPicker';
+import { PlaceTypeahead } from './PlaceTypeahead';
+
+const MAX_DEPARTURE_LOCATIONS = 20;
+
+const getGlobalValue = getValueFromTheme('global');
+
+type DepartureLocation = {
+  city?: City;
+  country: Country;
+  place?: Place;
+};
+
+const createEmptyDepartureLocation = (): DepartureLocation => ({
+  city: undefined,
+  country: Countries.BE,
+  place: undefined,
+});
+
 const AccessibilityStep = () => {
-  return <p>Bereikbaarheid</p>;
+  const { t, i18n } = useTranslation();
+
+  const [departureLocations, setDepartureLocations] = useState<
+    DepartureLocation[]
+  >([createEmptyDepartureLocation()]);
+
+  const updateDepartureLocation = (
+    index: number,
+    update: Partial<DepartureLocation>,
+  ) => {
+    setDepartureLocations((prev) =>
+      prev.map((location, i) =>
+        i === index ? { ...location, ...update } : location,
+      ),
+    );
+  };
+
+  const handleAddDepartureLocation = () => {
+    if (departureLocations.length >= MAX_DEPARTURE_LOCATIONS) return;
+    setDepartureLocations((prev) => [...prev, createEmptyDepartureLocation()]);
+  };
+
+  return (
+    <Stack spacing={4}>
+      <Stack spacing={3}>
+        <Title size={3}>
+          {t('create.additionalInformation.accessibility.departure.title')}
+        </Title>
+        <Text>
+          {t('create.additionalInformation.accessibility.departure.info')}
+        </Text>
+      </Stack>
+
+      <Stack spacing={5}>
+        {departureLocations.map((location, index) => (
+          <Panel key={index} padding={4} maxWidth="40rem">
+            <Stack spacing={4}>
+              <Title size={3} color="primary">
+                {t(
+                  'create.additionalInformation.accessibility.departure.location_title',
+                  { number: index + 1 },
+                )}
+              </Title>
+
+              {!location.city ? (
+                <Inline spacing={1} alignItems="center">
+                  <CityPicker
+                    name={`departure-city-${index}`}
+                    country={location.country}
+                    value={location.city}
+                    onChange={(city) =>
+                      updateDepartureLocation(index, { city, place: undefined })
+                    }
+                    width="22rem"
+                  />
+                  <CountryPicker
+                    value={location.country}
+                    onChange={(country) =>
+                      updateDepartureLocation(index, {
+                        country,
+                        city: undefined,
+                        place: undefined,
+                      })
+                    }
+                    css={`
+                      & button {
+                        margin-bottom: 0.3rem;
+                      }
+                    `}
+                  />
+                </Inline>
+              ) : (
+                <Inline alignItems="center" spacing={3}>
+                  <Icon
+                    name={Icons.CHECK_CIRCLE}
+                    color={getGlobalValue('successColor')}
+                  />
+                  <Text>
+                    {location.city.name}
+                    {location.city.zip ? `, ${location.city.zip}` : ''}
+                  </Text>
+                  <Button
+                    variant={ButtonVariants.LINK}
+                    onClick={() =>
+                      updateDepartureLocation(index, {
+                        city: undefined,
+                        place: undefined,
+                      })
+                    }
+                  >
+                    {t(
+                      `create.location.municipality.change_${location.country.toLowerCase()}`,
+                    )}
+                  </Button>
+                </Inline>
+              )}
+
+              {location.city &&
+                (!location.place ? (
+                  <FormElement
+                    id={`departure-place-${index}`}
+                    label={t(
+                      'create.additionalInformation.accessibility.departure.place_label',
+                    )}
+                    Component={
+                      <PlaceTypeahead
+                        value={location.place}
+                        municipality={location.city}
+                        country={location.country}
+                        placeholder={t(
+                          'create.additionalInformation.accessibility.departure.place_placeholder',
+                        )}
+                        onChange={(place) =>
+                          updateDepartureLocation(index, { place })
+                        }
+                      />
+                    }
+                  />
+                ) : (
+                  <Inline alignItems="center" spacing={3}>
+                    <Icon
+                      name={Icons.CHECK_CIRCLE}
+                      color={getGlobalValue('successColor')}
+                    />
+                    <Text>
+                      {getLanguageObjectOrFallback(
+                        location.place.name,
+                        i18n.language as SupportedLanguage,
+                        location.place.mainLanguage ?? 'nl',
+                      )}
+                    </Text>
+                    <Button
+                      variant={ButtonVariants.LINK}
+                      onClick={() =>
+                        updateDepartureLocation(index, { place: undefined })
+                      }
+                    >
+                      {t('create.location.country.change_location')}
+                    </Button>
+                  </Inline>
+                ))}
+            </Stack>
+          </Panel>
+        ))}
+      </Stack>
+
+      <Button
+        iconName={Icons.PLUS}
+        variant={ButtonVariants.SECONDARY}
+        onClick={handleAddDepartureLocation}
+        disabled={departureLocations.length >= MAX_DEPARTURE_LOCATIONS}
+        width="auto"
+        alignSelf="flex-start"
+      >
+        {t('create.additionalInformation.accessibility.departure.add')}
+      </Button>
+    </Stack>
+  );
 };
 
 export { AccessibilityStep };

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChangeDeparturePlacesMutation } from '@/hooks/api/events';
@@ -46,6 +46,26 @@ const createEmptyDepartureLocation = (): DepartureLocation => ({
   place: undefined,
 });
 
+type CollapsedSelectionProps = {
+  label: ReactNode;
+  onClear: () => void;
+  clearLabel: string;
+};
+
+const CollapsedSelection = ({
+  label,
+  onClear,
+  clearLabel,
+}: CollapsedSelectionProps) => (
+  <Inline alignItems="center" spacing={3}>
+    <Icon name={Icons.CHECK_CIRCLE} color={getGlobalValue('successColor')} />
+    <Text>{label}</Text>
+    <Button variant={ButtonVariants.LINK} onClick={onClear}>
+      {clearLabel}
+    </Button>
+  </Inline>
+);
+
 const AccessibilityStep = ({
   offerId,
   scope,
@@ -87,12 +107,16 @@ const AccessibilityStep = ({
     if (!entity?.departurePlaces?.length) return;
     hasInitialized.current = true;
 
+    let cancelled = false;
+
     (async () => {
       const places = await Promise.all(
         entity.departurePlaces!.map((uri) =>
           getPlaceById({ headers, id: parseOfferId(uri) }),
         ),
       );
+
+      if (cancelled) return;
 
       const loaded: DepartureLocation[] = places
         .filter((place): place is Place => !!place)
@@ -117,6 +141,10 @@ const AccessibilityStep = ({
 
       if (loaded.length > 0) setDepartureLocations(loaded);
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [entity, headers, i18n.language]);
 
   const setAndPersist = (next: DepartureLocation[]) => {
@@ -148,9 +176,7 @@ const AccessibilityStep = ({
 
   const handleDeleteDepartureLocation = (index: number) => {
     const next = departureLocations.filter((_, i) => i !== index);
-    setAndPersist(
-      next.length > 0 ? next : [createEmptyDepartureLocation()],
-    );
+    setAndPersist(next.length > 0 ? next : [createEmptyDepartureLocation()]);
   };
 
   return (
@@ -209,29 +235,20 @@ const AccessibilityStep = ({
                   />
                 </Inline>
               ) : (
-                <Inline alignItems="center" spacing={3}>
-                  <Icon
-                    name={Icons.CHECK_CIRCLE}
-                    color={getGlobalValue('successColor')}
-                  />
-                  <Text>
-                    {location.city.name}
-                    {location.city.zip ? `, ${location.city.zip}` : ''}
-                  </Text>
-                  <Button
-                    variant={ButtonVariants.LINK}
-                    onClick={() =>
+                <Stack spacing={3}>
+                  <CollapsedSelection
+                    label={`${location.city.name}${location.city.zip ? `, ${location.city.zip}` : ''}`}
+                    clearLabel={t(
+                      `create.location.municipality.change_${location.country.toLowerCase()}`,
+                    )}
+                    onClear={() =>
                       updateDepartureLocation(index, {
                         city: undefined,
                         place: undefined,
                       })
                     }
-                  >
-                    {t(
-                      `create.location.municipality.change_${location.country.toLowerCase()}`,
-                    )}
-                  </Button>
-                </Inline>
+                  />
+                </Stack>
               )}
 
               {location.city &&
@@ -256,27 +273,17 @@ const AccessibilityStep = ({
                     }
                   />
                 ) : (
-                  <Inline alignItems="center" spacing={3}>
-                    <Icon
-                      name={Icons.CHECK_CIRCLE}
-                      color={getGlobalValue('successColor')}
-                    />
-                    <Text>
-                      {getLanguageObjectOrFallback(
-                        location.place.name,
-                        i18n.language as SupportedLanguage,
-                        location.place.mainLanguage ?? 'nl',
-                      )}
-                    </Text>
-                    <Button
-                      variant={ButtonVariants.LINK}
-                      onClick={() =>
-                        updateDepartureLocation(index, { place: undefined })
-                      }
-                    >
-                      {t('create.location.country.change_location')}
-                    </Button>
-                  </Inline>
+                  <CollapsedSelection
+                    label={getLanguageObjectOrFallback(
+                      location.place.name,
+                      i18n.language as SupportedLanguage,
+                      location.place.mainLanguage ?? 'nl',
+                    )}
+                    clearLabel={t('create.location.country.change_location')}
+                    onClear={() =>
+                      updateDepartureLocation(index, { place: undefined })
+                    }
+                  />
                 ))}
             </Stack>
           </Panel>

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -1,8 +1,15 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useChangeDeparturePlacesMutation } from '@/hooks/api/events';
+import { getPlaceById } from '@/hooks/api/places';
+import { useGetEntityByIdAndScope } from '@/hooks/api/scope';
+import { useHeaders } from '@/hooks/api/useHeaders';
 import { SupportedLanguage } from '@/i18n/index';
+import type { TabContentProps } from '@/pages/steps/AdditionalInformationStep/AdditionalInformationStep';
+import { AddressInternal } from '@/types/Address';
 import { Countries, Country } from '@/types/Country';
+import type { Event } from '@/types/Event';
 import type { Place } from '@/types/Place';
 import { Button, ButtonVariants } from '@/ui/Button';
 import { FormElement } from '@/ui/FormElement';
@@ -14,6 +21,7 @@ import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
 import { Title } from '@/ui/Title';
 import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback';
+import { parseOfferId } from '@/utils/parseOfferId';
 
 import { City, CityPicker } from '../CityPicker';
 import { CountryPicker } from './CountryPicker';
@@ -35,22 +43,91 @@ const createEmptyDepartureLocation = (): DepartureLocation => ({
   place: undefined,
 });
 
-const AccessibilityStep = () => {
+const AccessibilityStep = ({
+  offerId,
+  scope,
+  onSuccessfulChange,
+}: TabContentProps) => {
   const { t, i18n } = useTranslation();
+  const headers = useHeaders();
 
   const [departureLocations, setDepartureLocations] = useState<
     DepartureLocation[]
   >([createEmptyDepartureLocation()]);
 
+  const hasInitialized = useRef(false);
+
+  const changeDeparturePlacesMutation = useChangeDeparturePlacesMutation({
+    onSuccess: onSuccessfulChange,
+  });
+
+  const getEntityByIdQuery = useGetEntityByIdAndScope({
+    id: offerId,
+    scope,
+  });
+  const entity = getEntityByIdQuery.data as Event | undefined;
+
+  useEffect(() => {
+    if (hasInitialized.current) return;
+    if (!entity?.departurePlaces?.length) return;
+    hasInitialized.current = true;
+
+    (async () => {
+      const places = await Promise.all(
+        entity.departurePlaces!.map((uri) =>
+          getPlaceById({ headers, id: parseOfferId(uri) }),
+        ),
+      );
+
+      const loaded: DepartureLocation[] = places
+        .filter((place): place is Place => !!place)
+        .map((place) => {
+          const localized = getLanguageObjectOrFallback<AddressInternal>(
+            place.address,
+            i18n.language as SupportedLanguage,
+            place.mainLanguage,
+          );
+          return {
+            place,
+            country: (localized?.addressCountry as Country) ?? Countries.BE,
+            city: localized
+              ? {
+                  name: localized.addressLocality,
+                  zip: localized.postalCode,
+                  label: `${localized.addressLocality} ${localized.postalCode}`,
+                }
+              : undefined,
+          };
+        });
+
+      if (loaded.length > 0) setDepartureLocations(loaded);
+    })();
+  }, [entity, headers, i18n.language]);
+
+  const getPlaceUris = (locations: DepartureLocation[]) =>
+    locations.flatMap((location) =>
+      location.place ? [location.place['@id']] : [],
+    );
+
   const updateDepartureLocation = (
     index: number,
     update: Partial<DepartureLocation>,
   ) => {
-    setDepartureLocations((prev) =>
-      prev.map((location, i) =>
-        i === index ? { ...location, ...update } : location,
-      ),
+    const next = departureLocations.map((location, i) =>
+      i === index ? { ...location, ...update } : location,
     );
+    setDepartureLocations(next);
+
+    if (!offerId) return;
+
+    const prevUris = getPlaceUris(departureLocations);
+    const nextUris = getPlaceUris(next);
+    if (prevUris.join(',') === nextUris.join(',')) return;
+
+    changeDeparturePlacesMutation.mutate({
+      eventId: offerId,
+      departurePlaces: nextUris,
+    });
   };
 
   const handleAddDepartureLocation = () => {

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -145,7 +145,8 @@ const AccessibilityStep = ({
     return () => {
       cancelled = true;
     };
-  }, [entity, headers, i18n.language]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entity?.departurePlaces]);
 
   const setAndPersist = (next: DepartureLocation[]) => {
     setDepartureLocations(next);

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -1,0 +1,5 @@
+const AccessibilityStep = () => {
+  return <p>Bereikbaarheid</p>;
+};
+
+export { AccessibilityStep };

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -283,16 +283,24 @@ const AccessibilityStep = ({
         ))}
       </Stack>
 
-      <Button
-        iconName={Icons.PLUS}
-        variant={ButtonVariants.SECONDARY}
-        onClick={handleAddDepartureLocation}
-        disabled={departureLocations.length >= MAX_DEPARTURE_LOCATIONS}
-        width="auto"
-        alignSelf="flex-start"
-      >
-        {t('create.additionalInformation.accessibility.departure.add')}
-      </Button>
+      <Stack spacing={2} alignItems="flex-start">
+        <Button
+          iconName={Icons.PLUS}
+          variant={ButtonVariants.SECONDARY}
+          onClick={handleAddDepartureLocation}
+          disabled={departureLocations.length >= MAX_DEPARTURE_LOCATIONS}
+          width="auto"
+        >
+          {t('create.additionalInformation.accessibility.departure.add')}
+        </Button>
+        {departureLocations.length >= MAX_DEPARTURE_LOCATIONS && (
+          <Text color="red">
+            {t(
+              'create.additionalInformation.accessibility.departure.max_reached',
+            )}
+          </Text>
+        )}
+      </Stack>
     </Stack>
   );
 };

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -146,7 +146,7 @@ const AccessibilityStep = ({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entity?.departurePlaces]);
+  }, [entity?.departurePlaces?.length]);
 
   const setAndPersist = (next: DepartureLocation[]) => {
     setDepartureLocations(next);
@@ -203,6 +203,7 @@ const AccessibilityStep = ({
                   )}
                 </Title>
                 <Button
+                  id={`departure-delete-${index}`}
                   iconName={Icons.TRASH}
                   variant={ButtonVariants.DANGER}
                   size={ButtonSizes.SMALL}

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -100,11 +100,6 @@ const AccessibilityStep = () => {
                         place: undefined,
                       })
                     }
-                    css={`
-                      & button {
-                        margin-bottom: 0.3rem;
-                      }
-                    `}
                   />
                 </Inline>
               ) : (

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -102,12 +102,18 @@ const AccessibilityStep = ({
     );
   }, [entity?.departurePlaces, field, onValidationChange]);
 
+  const isMountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
+
   useEffect(() => {
     if (hasInitialized.current) return;
     if (!entity?.departurePlaces?.length) return;
     hasInitialized.current = true;
-
-    let cancelled = false;
 
     (async () => {
       const places = await Promise.all(
@@ -116,7 +122,7 @@ const AccessibilityStep = ({
         ),
       );
 
-      if (cancelled) return;
+      if (!isMountedRef.current) return;
 
       const loaded: DepartureLocation[] = places
         .filter((place): place is Place => !!place)
@@ -141,12 +147,7 @@ const AccessibilityStep = ({
 
       if (loaded.length > 0) setDepartureLocations(loaded);
     })();
-
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entity?.departurePlaces?.length]);
+  }, [entity, headers, i18n.language]);
 
   const setAndPersist = (next: DepartureLocation[]) => {
     setDepartureLocations(next);

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -6,7 +6,10 @@ import { getPlaceById } from '@/hooks/api/places';
 import { useGetEntityByIdAndScope } from '@/hooks/api/scope';
 import { useHeaders } from '@/hooks/api/useHeaders';
 import { SupportedLanguage } from '@/i18n/index';
-import type { TabContentProps } from '@/pages/steps/AdditionalInformationStep/AdditionalInformationStep';
+import {
+  TabContentProps,
+  ValidationStatus,
+} from '@/pages/steps/AdditionalInformationStep/AdditionalInformationStep';
 import { AddressInternal } from '@/types/Address';
 import { Countries, Country } from '@/types/Country';
 import type { Event } from '@/types/Event';
@@ -46,7 +49,9 @@ const createEmptyDepartureLocation = (): DepartureLocation => ({
 const AccessibilityStep = ({
   offerId,
   scope,
+  field,
   onSuccessfulChange,
+  onValidationChange,
 }: TabContentProps) => {
   const { t, i18n } = useTranslation();
   const headers = useHeaders();
@@ -66,6 +71,16 @@ const AccessibilityStep = ({
     scope,
   });
   const entity = getEntityByIdQuery.data as Event | undefined;
+
+  useEffect(() => {
+    if (!field) return;
+    onValidationChange?.(
+      entity?.departurePlaces?.length
+        ? ValidationStatus.SUCCESS
+        : ValidationStatus.NONE,
+      field,
+    );
+  }, [entity?.departurePlaces, field, onValidationChange]);
 
   useEffect(() => {
     if (hasInitialized.current) return;

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -307,6 +307,7 @@ const AccessibilityStep = ({
           <Text color="red">
             {t(
               'create.additionalInformation.accessibility.departure.max_reached',
+              { maxLocations: MAX_DEPARTURE_LOCATIONS },
             )}
           </Text>
         )}

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -14,7 +14,7 @@ import { AddressInternal } from '@/types/Address';
 import { Countries, Country } from '@/types/Country';
 import type { Event } from '@/types/Event';
 import type { Place } from '@/types/Place';
-import { Button, ButtonVariants } from '@/ui/Button';
+import { Button, ButtonSizes, ButtonVariants } from '@/ui/Button';
 import { FormElement } from '@/ui/FormElement';
 import { Icon, Icons } from '@/ui/Icon';
 import { Inline } from '@/ui/Inline';
@@ -119,35 +119,38 @@ const AccessibilityStep = ({
     })();
   }, [entity, headers, i18n.language]);
 
-  const getPlaceUris = (locations: DepartureLocation[]) =>
-    locations.flatMap((location) =>
-      location.place ? [location.place['@id']] : [],
-    );
+  const setAndPersist = (next: DepartureLocation[]) => {
+    setDepartureLocations(next);
+    if (!offerId) return;
+    changeDeparturePlacesMutation.mutate({
+      eventId: offerId,
+      departurePlaces: next.flatMap((location) =>
+        location.place ? [location.place['@id']] : [],
+      ),
+    });
+  };
 
   const updateDepartureLocation = (
     index: number,
     update: Partial<DepartureLocation>,
   ) => {
-    const next = departureLocations.map((location, i) =>
-      i === index ? { ...location, ...update } : location,
+    setAndPersist(
+      departureLocations.map((location, i) =>
+        i === index ? { ...location, ...update } : location,
+      ),
     );
-    setDepartureLocations(next);
-
-    if (!offerId) return;
-
-    const prevUris = getPlaceUris(departureLocations);
-    const nextUris = getPlaceUris(next);
-    if (prevUris.join(',') === nextUris.join(',')) return;
-
-    changeDeparturePlacesMutation.mutate({
-      eventId: offerId,
-      departurePlaces: nextUris,
-    });
   };
 
   const handleAddDepartureLocation = () => {
     if (departureLocations.length >= MAX_DEPARTURE_LOCATIONS) return;
     setDepartureLocations((prev) => [...prev, createEmptyDepartureLocation()]);
+  };
+
+  const handleDeleteDepartureLocation = (index: number) => {
+    const next = departureLocations.filter((_, i) => i !== index);
+    setAndPersist(
+      next.length > 0 ? next : [createEmptyDepartureLocation()],
+    );
   };
 
   return (
@@ -165,12 +168,23 @@ const AccessibilityStep = ({
         {departureLocations.map((location, index) => (
           <Panel key={index} padding={4} maxWidth="40rem">
             <Stack spacing={4}>
-              <Title size={3} color="primary">
-                {t(
-                  'create.additionalInformation.accessibility.departure.location_title',
-                  { number: index + 1 },
-                )}
-              </Title>
+              <Inline justifyContent="space-between" alignItems="center">
+                <Title size={3} color="primary">
+                  {t(
+                    'create.additionalInformation.accessibility.departure.location_title',
+                    { number: index + 1 },
+                  )}
+                </Title>
+                <Button
+                  iconName={Icons.TRASH}
+                  variant={ButtonVariants.DANGER}
+                  size={ButtonSizes.SMALL}
+                  aria-label={t(
+                    'create.additionalInformation.accessibility.departure.delete',
+                  )}
+                  onClick={() => handleDeleteDepartureLocation(index)}
+                />
+              </Inline>
 
               {!location.city ? (
                 <Inline spacing={1} alignItems="center">

--- a/src/pages/steps/AccessibilityStep.tsx
+++ b/src/pages/steps/AccessibilityStep.tsx
@@ -260,6 +260,7 @@ const AccessibilityStep = ({
                     )}
                     Component={
                       <PlaceTypeahead
+                        name={`departure-place-${index}`}
                         value={location.place}
                         municipality={location.city}
                         country={location.country}

--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -22,6 +22,7 @@ import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
 import { hasCultuurkuurOrganizerLabel } from '@/utils/hasCultuurkuurOrganizerLabel';
 
+import { AccessibilityStep } from '../AccessibilityStep';
 import { AudienceStep } from '../AudienceStep';
 import { StepsConfiguration } from '../Steps';
 import { BookingInfoStep } from './BookingInfoStep';
@@ -52,6 +53,7 @@ const Fields = {
   LABELS: 'labels',
   LOCATION: 'location',
   CULTUURKUUR: 'cultuurkuur',
+  ACCESSIBILITY: 'accessibility',
 };
 
 type Field = Values<typeof Fields>;
@@ -145,6 +147,12 @@ const tabConfigurations: TabConfig[] = [
       AdditionalInformationStepVariant.EVENT,
       AdditionalInformationStepVariant.MOVIE,
     ],
+  },
+  {
+    field: Fields.ACCESSIBILITY,
+    TabContent: AccessibilityStep,
+    shouldInvalidate: true,
+    shouldShowOn: [AdditionalInformationStepVariant.EVENT],
   },
   {
     field: Fields.CULTUURKUUR,
@@ -277,6 +285,9 @@ const AdditionalInformationStep = ({
   const isCultuurkuurEvent =
     offer?.audience?.audienceType === AudienceTypes.EDUCATION;
 
+  const isChildrenOnly = true;
+  // const isChildrenOnly = offer?.audience?.audienceType === 'childrenOnly'
+
   const [, hash] = asPath.split('#');
 
   const handleScroll = useCallback(() => {
@@ -365,6 +376,8 @@ const AdditionalInformationStep = ({
             if (!shouldShowTab) return null;
 
             if (field === 'audience' && isCultuurkuurEvent) return null;
+
+            if (field === 'accessibility' && !isChildrenOnly) return null;
 
             return (
               <Tabs.Tab

--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -239,6 +239,7 @@ const initialValidatedFields: Record<Field, ValidationStatus> = {
   price_info: ValidationStatus.NONE,
   booking_info: ValidationStatus.NONE,
   contact_point: ValidationStatus.NONE,
+  accessibility: ValidationStatus.NONE,
 };
 
 const AdditionalInformationStep = ({

--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -374,10 +374,7 @@ const AdditionalInformationStep = ({
 
             if (field === 'audience' && isCultuurkuurEvent) return null;
 
-            if (
-              field === 'accessibility' &&
-              (!isChildrenOnly || !isBoaEnabled)
-            )
+            if (field === 'accessibility' && (!isChildrenOnly || !isBoaEnabled))
               return null;
 
             return (

--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -257,6 +257,7 @@ const AdditionalInformationStep = ({
 }: Props) => {
   const { asPath, ...router } = useRouter();
   const containerRef = useRef(null);
+  const [isBoaEnabled] = useFeatureFlag(FeatureFlags.BOA);
 
   const queryClient = useQueryClient();
 
@@ -287,8 +288,9 @@ const AdditionalInformationStep = ({
   const isCultuurkuurEvent =
     offer?.audience?.audienceType === AudienceTypes.EDUCATION;
 
-  const isChildrenOnly = true;
-  // const isChildrenOnly = offer?.audience?.audienceType === 'childrenOnly'
+  // @ts-expect-error
+  // Remove ts error when the  childrenOnly audienceType has been added
+  const isChildrenOnly = offer?.audience?.audienceType === 'childrenOnly';
 
   const [, hash] = asPath.split('#');
 
@@ -372,7 +374,11 @@ const AdditionalInformationStep = ({
 
             if (field === 'audience' && isCultuurkuurEvent) return null;
 
-            if (field === 'accessibility' && !isChildrenOnly) return null;
+            if (
+              field === 'accessibility' &&
+              (!isChildrenOnly || !isBoaEnabled)
+            )
+              return null;
 
             return (
               <Tabs.Tab

--- a/src/pages/steps/CountryPicker.tsx
+++ b/src/pages/steps/CountryPicker.tsx
@@ -44,12 +44,15 @@ const CountryPicker = ({
         & button.btn.dropdown-toggle {
           height: ${getGlobalFormInputHeight};
           border: var(--bs-border-width) solid var(--bs-border-color);
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
         }
       `}
       {...getBoxProps(props)}
     >
       <Button customChildren>
-        <FlagIcon country={value} paddingRight={1} />
+        <FlagIcon country={value} />
       </Button>
 
       {countries.map((countryValue) => (

--- a/src/pages/steps/CountryPicker.tsx
+++ b/src/pages/steps/CountryPicker.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/ui/Button';
 import { Dropdown, DropDownVariants } from '@/ui/Dropdown';
 import { Inline } from '@/ui/Inline';
 import { Text } from '@/ui/Text';
-import { getValueFromTheme } from '@/ui/theme';
+import { getGlobalFormInputHeight } from '@/ui/theme';
 
 import { FlagIcon } from '../../ui/FlagIcon';
 
@@ -15,8 +15,6 @@ type Props = BoxProps & {
   onChange: (value: Country) => void;
   showSchoolLocation?: boolean;
 };
-
-const getGlobalValue = getValueFromTheme('global');
 
 const countries = [Countries.BE, Countries.NL, Countries.DE];
 
@@ -39,12 +37,13 @@ const CountryPicker = ({
           box-shadow: none;
         }
 
-        & button {
-          height: 2.4rem;
+        & button.btn {
+          box-shadow: none;
         }
 
-        .btn-outline-secondary {
-          box-shadow: ${getGlobalValue('boxShadow.heavy')};
+        & button.btn.dropdown-toggle {
+          height: ${getGlobalFormInputHeight};
+          border: var(--bs-border-width) solid var(--bs-border-color);
         }
       `}
       {...getBoxProps(props)}
@@ -64,8 +63,6 @@ const CountryPicker = ({
           </Inline>
         </Dropdown.Item>
       ))}
-
-      <Dropdown.Divider />
     </Dropdown>
   );
 };

--- a/src/pages/steps/LocationStep.tsx
+++ b/src/pages/steps/LocationStep.tsx
@@ -765,11 +765,6 @@ const LocationStep = ({
                           place: newCountry ? place : undefined,
                         });
                       }}
-                      css={`
-                        & button {
-                          margin-bottom: 0.3rem;
-                        }
-                      `}
                     />
                   </Inline>,
                 )}

--- a/src/pages/steps/PlaceStep.tsx
+++ b/src/pages/steps/PlaceStep.tsx
@@ -1,20 +1,15 @@
 import { TFunction } from 'i18next';
-import debounce from 'lodash/debounce';
-import { useMemo, useState } from 'react';
-import { Highlighter } from 'react-bootstrap-typeahead';
-import { TypeaheadMenu } from 'react-bootstrap-typeahead';
+import { useState } from 'react';
+import { Highlighter, TypeaheadMenu } from 'react-bootstrap-typeahead';
 import { Controller, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
 import { EventTypes } from '@/constants/EventTypes';
 import { ScopeTypes } from '@/constants/OfferType';
-import { useGetPlacesByQuery } from '@/hooks/api/places';
 import { useStreetAddressTypeahead } from '@/hooks/useStreetAddressTypeAhead';
-import { useUitpasLabels } from '@/hooks/useUitpasLabels';
 import { SupportedLanguage } from '@/i18n/index';
 import type { StepProps, StepsConfiguration } from '@/pages/steps/Steps';
-import { Address, AddressInternal } from '@/types/Address';
 import { Countries, Country } from '@/types/Country';
 import type { Place } from '@/types/Place';
 import type { Values } from '@/types/Values';
@@ -27,14 +22,12 @@ import { getStackProps, Stack } from '@/ui/Stack';
 import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
 import { isOneTimeSlotValid } from '@/ui/TimeTable';
-import { isNewEntry, Typeahead } from '@/ui/Typeahead';
-import { UitpasIcon } from '@/ui/UitpasIcon';
+import { Typeahead } from '@/ui/Typeahead';
 import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback';
-import { isUitpasLocation } from '@/utils/uitpas';
-import { valueToArray } from '@/utils/valueToArray';
 
 import { City } from '../CityPicker';
 import { PlaceAddModal } from '../PlaceAddModal';
+import { PlaceTypeahead } from './PlaceTypeahead';
 
 const getGlobalValue = getValueFromTheme('global');
 
@@ -67,24 +60,10 @@ const PlaceStep = ({
   ...props
 }: PlaceStepProps) => {
   const { t, i18n } = useTranslation();
-  const [searchInput, setSearchInput] = useState(defaultStreetAndNumber);
   const [prefillPlaceName, setPrefillPlaceName] = useState('');
   const [isPlaceAddModalVisible, setIsPlaceAddModalVisible] = useState(false);
 
-  const { uitpasLabels } = useUitpasLabels();
-
   const isMovie = terms.includes(EventTypes.Bioscoop);
-
-  const useGetPlacesQuery = useGetPlacesByQuery(
-    {
-      searchTerm: searchInput,
-      terms,
-      zip: municipality?.zip,
-      addressLocality: municipality?.name,
-      addressCountry: country,
-    },
-    { enabled: !!searchInput && scope === ScopeTypes.EVENTS },
-  );
 
   const formatMunicipalityName = (name: string) => {
     if (typeof name !== 'string' || !name.includes('/')) return name;
@@ -93,7 +72,6 @@ const PlaceStep = ({
     return firstPart.trim();
   };
 
-  // Inside PlaceStep component, replace the existing street address logic with:
   const streetAddressTypeahead = useStreetAddressTypeahead({
     city: {
       zip: municipality?.zip,
@@ -104,49 +82,7 @@ const PlaceStep = ({
     defaultValue: defaultStreetAndNumber,
   });
 
-  const places = useMemo(() => {
-    if (scope !== ScopeTypes.EVENTS) {
-      return streetAddressTypeahead.options;
-    }
-
-    return useGetPlacesQuery.data?.member ?? [];
-  }, [useGetPlacesQuery.data?.member, streetAddressTypeahead.options, scope]);
-
   const place = useWatch({ control, name: 'location.place' });
-
-  const getPlaceName = (
-    name: Place['name'],
-    mainLanguage: SupportedLanguage,
-  ): AddressInternal['streetAddress'] => {
-    return getLanguageObjectOrFallback(
-      name,
-      i18n.language as SupportedLanguage,
-      mainLanguage,
-    );
-  };
-
-  const getAddress = (
-    address: Address,
-    mainLanguage: SupportedLanguage,
-  ): AddressInternal => {
-    return getLanguageObjectOrFallback(
-      address,
-      i18n.language as SupportedLanguage,
-      mainLanguage,
-    );
-  };
-
-  const filterByCallback = (place: Place, props) => {
-    const name = getPlaceName(place.name, place.mainLanguage);
-    const address = getAddress(place.address, place.mainLanguage);
-
-    return (
-      address?.streetAddress
-        ?.toLowerCase()
-        .includes(props.text.toLowerCase()) ||
-      name?.toLowerCase().includes(props.text.toLowerCase())
-    );
-  };
 
   return (
     <Stack {...getStackProps(props)}>
@@ -264,79 +200,25 @@ const PlaceStep = ({
                       : undefined
                   }
                   Component={
-                    <Typeahead
-                      isLoading={useGetPlacesQuery.isLoading}
-                      options={places}
-                      onInputChange={debounce(setSearchInput, 275)}
-                      filterBy={filterByCallback}
-                      labelKey={(place: Place) =>
-                        getPlaceName(place.name, place.mainLanguage)
-                      }
-                      renderMenuItemChildren={(place: Place, { text }) => {
-                        const { mainLanguage, name, address } = place;
-                        const placeName = getPlaceName(name, mainLanguage);
-                        const { streetAddress } = getAddress(
-                          address,
-                          mainLanguage,
-                        );
-
-                        const isUitpas = isUitpasLocation(place, uitpasLabels);
-
-                        return (
-                          <Stack>
-                            <Inline justifyContent="space-between">
-                              <Text
-                                maxWidth={`calc(100% - ${
-                                  isUitpas ? '3rem' : '0rem'
-                                })`}
-                                css={`
-                                  overflow: hidden;
-                                  text-overflow: ellipsis;
-                                  white-space: nowrap;
-                                `}
-                              >
-                                <Highlighter search={text}>
-                                  {placeName}
-                                </Highlighter>
-                              </Text>
-                              {isUitpas && <UitpasIcon width="2rem" />}
-                            </Inline>
-                            <Text
-                              className={'address'}
-                              css={`
-                                color: ${({ theme }) => theme.colors.grey6};
-                              `}
-                            >
-                              <Highlighter search={text}>
-                                {streetAddress}
-                              </Highlighter>
-                            </Text>
-                          </Stack>
-                        );
-                      }}
-                      selected={valueToArray(selectedPlace as Place)}
-                      maxWidth="28rem"
-                      onChange={(places) => {
-                        const place = places[0];
-
-                        if (isNewEntry(place)) {
-                          setPrefillPlaceName(place.label);
-                          setIsPlaceAddModalVisible(true);
-                          return;
-                        }
-
+                    <PlaceTypeahead
+                      value={selectedPlace as Place}
+                      terms={terms}
+                      municipality={municipality}
+                      country={country}
+                      placeholder={placeholderLabel(t)}
+                      onChange={(place) => {
                         const updatedValue = { ...field.value, place };
-
                         field.onChange(updatedValue);
                         onChange(updatedValue);
                       }}
-                      minLength={3}
-                      placeholder={placeholderLabel(t)}
-                      newSelectionPrefix={t(
-                        'create.additionalInformation.place.add_new_label',
-                      )}
-                      hideNewInputText
-                      allowNew={() => !isMovie}
+                      onAddNewPlace={
+                        isMovie
+                          ? undefined
+                          : (name) => {
+                              setPrefillPlaceName(name);
+                              setIsPlaceAddModalVisible(true);
+                            }
+                      }
                     />
                   }
                 />

--- a/src/pages/steps/PlaceTypeahead.tsx
+++ b/src/pages/steps/PlaceTypeahead.tsx
@@ -100,9 +100,7 @@ const PlaceTypeahead = ({
       options={places}
       onInputChange={debounce(setSearchInput, 275)}
       filterBy={filterByCallback}
-      labelKey={(place: Place) =>
-        getPlaceName(place.name, place.mainLanguage)
-      }
+      labelKey={(place: Place) => getPlaceName(place.name, place.mainLanguage)}
       renderMenuItemChildren={(place: Place, { text }) => {
         const { mainLanguage, name, address } = place;
         const placeName = getPlaceName(name, mainLanguage);
@@ -149,9 +147,7 @@ const PlaceTypeahead = ({
       }}
       minLength={3}
       placeholder={placeholder}
-      newSelectionPrefix={t(
-        'create.additionalInformation.place.add_new_label',
-      )}
+      newSelectionPrefix={t('create.additionalInformation.place.add_new_label')}
       hideNewInputText
       allowNew={onAddNewPlace ? () => !isMovie : false}
     />

--- a/src/pages/steps/PlaceTypeahead.tsx
+++ b/src/pages/steps/PlaceTypeahead.tsx
@@ -23,6 +23,7 @@ import { valueToArray } from '@/utils/valueToArray';
 import { City } from '../CityPicker';
 
 type Props = {
+  name?: string;
   value?: Place | null;
   onChange: (place: Place) => void;
   onAddNewPlace?: (name: string) => void;
@@ -34,6 +35,7 @@ type Props = {
 };
 
 const PlaceTypeahead = ({
+  name,
   value,
   onChange,
   onAddNewPlace,
@@ -96,6 +98,7 @@ const PlaceTypeahead = ({
 
   return (
     <Typeahead
+      name={name}
       isLoading={useGetPlacesQuery.isLoading}
       options={places}
       onInputChange={debounce(setSearchInput, 275)}

--- a/src/pages/steps/PlaceTypeahead.tsx
+++ b/src/pages/steps/PlaceTypeahead.tsx
@@ -1,0 +1,161 @@
+import debounce from 'lodash/debounce';
+import { useState } from 'react';
+import { Highlighter } from 'react-bootstrap-typeahead';
+import { useTranslation } from 'react-i18next';
+
+import { EventTypes } from '@/constants/EventTypes';
+import { useGetPlacesByQuery } from '@/hooks/api/places';
+import { useUitpasLabels } from '@/hooks/useUitpasLabels';
+import { SupportedLanguage } from '@/i18n/index';
+import { Address, AddressInternal } from '@/types/Address';
+import { Country } from '@/types/Country';
+import type { Place } from '@/types/Place';
+import type { Values } from '@/types/Values';
+import { Inline } from '@/ui/Inline';
+import { Stack } from '@/ui/Stack';
+import { Text } from '@/ui/Text';
+import { isNewEntry, Typeahead } from '@/ui/Typeahead';
+import { UitpasIcon } from '@/ui/UitpasIcon';
+import { getLanguageObjectOrFallback } from '@/utils/getLanguageObjectOrFallback';
+import { isUitpasLocation } from '@/utils/uitpas';
+import { valueToArray } from '@/utils/valueToArray';
+
+import { City } from '../CityPicker';
+
+type Props = {
+  value?: Place | null;
+  onChange: (place: Place) => void;
+  onAddNewPlace?: (name: string) => void;
+  terms?: Array<Values<typeof EventTypes>>;
+  municipality?: City;
+  country?: Country;
+  placeholder?: string;
+  maxWidth?: string;
+};
+
+const PlaceTypeahead = ({
+  value,
+  onChange,
+  onAddNewPlace,
+  terms = [],
+  municipality,
+  country,
+  placeholder,
+  maxWidth = '28rem',
+}: Props) => {
+  const { t, i18n } = useTranslation();
+  const [searchInput, setSearchInput] = useState('');
+  const { uitpasLabels } = useUitpasLabels();
+
+  const isMovie = terms.includes(EventTypes.Bioscoop);
+
+  const useGetPlacesQuery = useGetPlacesByQuery(
+    {
+      searchTerm: searchInput,
+      terms,
+      zip: municipality?.zip,
+      addressLocality: municipality?.name,
+      addressCountry: country,
+    },
+    { enabled: !!searchInput },
+  );
+
+  const places = useGetPlacesQuery.data?.member ?? [];
+
+  const getPlaceName = (
+    name: Place['name'],
+    mainLanguage: SupportedLanguage,
+  ): AddressInternal['streetAddress'] =>
+    getLanguageObjectOrFallback(
+      name,
+      i18n.language as SupportedLanguage,
+      mainLanguage,
+    );
+
+  const getAddress = (
+    address: Address,
+    mainLanguage: SupportedLanguage,
+  ): AddressInternal =>
+    getLanguageObjectOrFallback(
+      address,
+      i18n.language as SupportedLanguage,
+      mainLanguage,
+    );
+
+  const filterByCallback = (place: Place, props) => {
+    const name = getPlaceName(place.name, place.mainLanguage);
+    const address = getAddress(place.address, place.mainLanguage);
+
+    return (
+      address?.streetAddress
+        ?.toLowerCase()
+        .includes(props.text.toLowerCase()) ||
+      name?.toLowerCase().includes(props.text.toLowerCase())
+    );
+  };
+
+  return (
+    <Typeahead
+      isLoading={useGetPlacesQuery.isLoading}
+      options={places}
+      onInputChange={debounce(setSearchInput, 275)}
+      filterBy={filterByCallback}
+      labelKey={(place: Place) =>
+        getPlaceName(place.name, place.mainLanguage)
+      }
+      renderMenuItemChildren={(place: Place, { text }) => {
+        const { mainLanguage, name, address } = place;
+        const placeName = getPlaceName(name, mainLanguage);
+        const { streetAddress } = getAddress(address, mainLanguage);
+        const isUitpas = isUitpasLocation(place, uitpasLabels);
+
+        return (
+          <Stack>
+            <Inline justifyContent="space-between">
+              <Text
+                maxWidth={`calc(100% - ${isUitpas ? '3rem' : '0rem'})`}
+                css={`
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                `}
+              >
+                <Highlighter search={text}>{placeName}</Highlighter>
+              </Text>
+              {isUitpas && <UitpasIcon width="2rem" />}
+            </Inline>
+            <Text
+              className={'address'}
+              css={`
+                color: ${({ theme }) => theme.colors.grey6};
+              `}
+            >
+              <Highlighter search={text}>{streetAddress}</Highlighter>
+            </Text>
+          </Stack>
+        );
+      }}
+      selected={valueToArray(value as Place)}
+      maxWidth={maxWidth}
+      onChange={(selected) => {
+        const place = selected[0];
+
+        if (isNewEntry(place)) {
+          onAddNewPlace?.(place.label);
+          return;
+        }
+
+        onChange(place);
+      }}
+      minLength={3}
+      placeholder={placeholder}
+      newSelectionPrefix={t(
+        'create.additionalInformation.place.add_new_label',
+      )}
+      hideNewInputText
+      allowNew={onAddNewPlace ? () => !isMovie : false}
+    />
+  );
+};
+
+export { PlaceTypeahead };

--- a/src/pages/steps/PlaceTypeahead.tsx
+++ b/src/pages/steps/PlaceTypeahead.tsx
@@ -23,6 +23,7 @@ import { valueToArray } from '@/utils/valueToArray';
 import { City } from '../CityPicker';
 
 type Props = {
+  id?: string;
   name?: string;
   value?: Place | null;
   onChange: (place: Place) => void;
@@ -35,6 +36,7 @@ type Props = {
 };
 
 const PlaceTypeahead = ({
+  id,
   name,
   value,
   onChange,
@@ -98,6 +100,7 @@ const PlaceTypeahead = ({
 
   return (
     <Typeahead
+      id={id}
       name={name}
       isLoading={useGetPlacesQuery.isLoading}
       options={places}

--- a/src/test/e2e/events/event-edit-accessibility.spec.ts
+++ b/src/test/e2e/events/event-edit-accessibility.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+
+const EVENT_ID = 'a0b6534b-3a64-4dfe-9875-968414cc26be';
+
+test.describe('Event Edit - Accessibility', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies([
+      {
+        name: 'ff_boa',
+        value: 'true',
+        domain: 'localhost',
+        path: '/',
+      },
+    ]);
+  });
+
+  test('shows existing departure place and supports add and delete', async ({
+    page,
+    baseURL,
+  }) => {
+    await page.goto(`${baseURL}/events/${EVENT_ID}/edit`);
+
+    await page.getByRole('tab', { name: 'Bereikbaarheid' }).click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Vertreklocatie 1' }),
+    ).toBeVisible();
+    await expect(page.getByText('E2E Place Preview Test')).toBeVisible();
+
+    await page
+      .getByRole('button', { name: 'Voeg nog een locatie toe' })
+      .click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Vertreklocatie 2' }),
+    ).toBeVisible();
+
+    await page.locator('input[name="departure-city-1"]').fill('9000');
+    await page.getByRole('option', { name: '9000 Gent' }).click();
+
+    await page.locator('input[name="departure-place-1"]').fill('S.M');
+    await page
+      .getByRole('option', { name: 'S.M.A.K.', exact: true })
+      .first()
+      .click();
+
+    await page.waitForLoadState('networkidle');
+
+    await page
+      .getByRole('button', { name: 'Verwijder vertreklocatie' })
+      .nth(1)
+      .click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Vertreklocatie 2' }),
+    ).toBeHidden();
+  });
+});

--- a/src/test/e2e/events/event-edit-accessibility.spec.ts
+++ b/src/test/e2e/events/event-edit-accessibility.spec.ts
@@ -35,24 +35,29 @@ test.describe('Event Edit - Accessibility', () => {
       page.getByRole('heading', { name: 'Vertreklocatie 2' }),
     ).toBeVisible();
 
-    await page.locator('input[name="departure-city-1"]').fill('9000');
+    await page.getByTestId('departure-city-1').fill('9000');
     await page.getByRole('option', { name: '9000 Gent' }).click();
 
-    await page.locator('input[name="departure-place-1"]').fill('S.M');
+    await page.getByTestId('departure-place-1').fill('S.M');
     await page
       .getByRole('option', { name: 'S.M.A.K.', exact: true })
       .first()
       .click();
 
     await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
 
-    await page
-      .getByRole('button', { name: 'Verwijder vertreklocatie' })
-      .nth(1)
-      .click();
+    await page.locator('#departure-delete-1').click();
+
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
 
     await expect(
       page.getByRole('heading', { name: 'Vertreklocatie 2' }),
     ).toBeHidden();
+
+    await page
+      .getByRole('button', { name: 'Klaar met bewerken' })
+      .click({ force: true });
   });
 });

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -30,6 +30,7 @@ type Event = BaseOffer & {
   production?: ProductionOnEvent;
   attendanceMode: Values<typeof AttendanceMode>;
   bookingAvailability: { type: Values<typeof BookingAvailability> };
+  departurePlaces?: string[];
 };
 
 const isEvent = (value: unknown): value is Event => {

--- a/src/ui/Inline.tsx
+++ b/src/ui/Inline.tsx
@@ -111,7 +111,7 @@ const linkPropTypes = ['rel', 'target'];
 
 const getInlineProps = (props: Record<string, any>) =>
   pickBy(props, (_value, key) => {
-    if (key.startsWith('aria-')) return true;
+    if (key.startsWith('aria-') || key.startsWith('data-')) return true;
     const propTypes: string[] = [
       ...boxPropTypes,
       ...inlinePropTypes,

--- a/src/ui/Typeahead.tsx
+++ b/src/ui/Typeahead.tsx
@@ -79,7 +79,6 @@ const TypeaheadInner = <T extends TypeaheadOption = TypeaheadOption>(
     <Box
       forwardedAs={BootstrapTypeahead}
       id={id}
-      name={name}
       allowNew={allowNew && !isLoading}
       newSelectionPrefix={newSelectionPrefix}
       options={options}
@@ -158,12 +157,15 @@ const TypeaheadInner = <T extends TypeaheadOption = TypeaheadOption>(
       onBlur={onBlur}
       onFocus={onFocus}
       positionFixed={positionFixed}
-      inputProps={{
-        id,
-        name,
-        type: inputType,
-        required: inputRequired,
-      }}
+      inputProps={
+        {
+          id,
+          name,
+          type: inputType,
+          required: inputRequired,
+          'data-testid': name,
+        } as React.InputHTMLAttributes<HTMLInputElement>
+      }
       filterBy={filterBy ?? (() => true)}
       useCache={false}
       {...getBoxProps(props)}

--- a/src/ui/Typeahead.tsx
+++ b/src/ui/Typeahead.tsx
@@ -160,6 +160,7 @@ const TypeaheadInner = <T extends TypeaheadOption = TypeaheadOption>(
       positionFixed={positionFixed}
       inputProps={{
         id,
+        name,
         type: inputType,
         required: inputRequired,
       }}


### PR DESCRIPTION
### Added
- New "Bereikbaarheid" (Accessibility) tab in the additional information step for events. Lets users add up to 20 departure places (city + place picker per card), with delete buttons, max-reached warning, success toast, and a green checkmark on the tab when the offer has departure places.
- `useChangeDeparturePlacesMutation` API hook (PUT `/events/{eventId}/departurePlaces`) 
- Optional `departurePlaces: string[]` field on the `Event` type.
- Reusable `PlaceTypeahead` component extracted from `PlaceStep` (place search by name/address with optional "add new place" hook).
- NL translations for the new accessibility section, delete button, max-reached warning, and toast message.

### Changed
- `PlaceStep` now delegates the place search UI to the new `PlaceTypeahead` component.
- `CountryPicker` toggle button now uses the global form input height (`getGlobalFormInputHeight`) and matches form input border styling via Bootstrap CSS variables, so it lines up with `CityPicker` consistently across all consumers.

### Removed
- Inline place-typeahead logic and helpers (`getPlaceName`, `getAddress`, `filterByCallback`, `useGetPlacesByQuery` call) from `PlaceStep` — now lives in `PlaceTypeahead`.
- Per-call `margin-bottom: 0.3rem` alignment hack on `CountryPicker` in `LocationStep` (no longer needed after the global height fix).
- Trailing `Dropdown.Divider` at the bottom of the `CountryPicker` menu (caused a visible double line under the last item).
- Unused `box-shadow` styling on `CountryPicker`'s toggle button.

### Fixed
- `CountryPicker` and `CityPicker` are now vertically aligned on the same line in `LocationStep` and the new `AccessibilityStep`.
- `CountryPicker` toggle border now matches sibling form inputs instead of the previous heavy box-shadow.


<img width="1346" height="689" alt="Screenshot 2026-04-27 at 16 05 59" src="https://github.com/user-attachments/assets/7d6e87e8-e90b-414d-9913-acf8ac353834" />

<img width="1091" height="545" alt="Screenshot 2026-04-27 at 16 08 50" src="https://github.com/user-attachments/assets/c09a0024-02a7-4bda-a670-40aa68d213f8" />



## Test plan
> The accessibility ("Bereikbaarheid") tab is gated on:
> - The `boa` feature flag being enabled
> - The event's `audience.audienceType` being `childrenOnly`
> The `childrenOnly` audience type cannot yet be set from the UI, so we work around that by replaying the audience PUT request with the desired value.

### Setup
- [ ] Enable the BOA feature flag by setting cookie `ff_boa=true` (e.g. via DevTools → Application → Cookies, or `document.cookie = 'ff_boa=true; path=/'` in the console)

### Steps
- [ ] Create a new event from the dashboard
- [ ] Complete all required steps (type/theme, calendar, location, name, age range)
- [ ] Land on the "Aanvullende informatie" step
- [ ] Open the **Toegang** tab
- [ ] Change the audience type to anything (e.g. "enkel voor leden") to trigger the audience PUT request
- [ ] In the browser's network tab, find the request to `PUT /events/{id}/audience`, right-click → **Edit and resend**
- [ ] In the request body, change `audienceType` to `"childrenOnly"` and send
- [ ] The **Bereikbaarheid** tab is now visible in the additional information tabs

---
Ticket: https://jira.uitdatabank.be/browse/III-7151
