### PR TITLE
III-7193 - Add legacy component for easy boa ff toggle

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -314,7 +314,9 @@
         "from": "Von",
         "till": "Bis",
         "age": "Jahre",
+        "input_range_title": "Geben Sie ein Mindest- und Höchstalter ein",
         "error_max_lower_than_min": "Das Höchstalter kann nicht unter dem Mindestalter liegen.",
+        "error_max_age": "Das eingegebene Alter darf höchstens 120 Jahre betragen.",
         "error_no_min_age": "Bitte geben Sie ein Mindestalter ein"
       }
     },

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -323,6 +323,7 @@
         "input_range_title": "Geben Sie ein Mindest- und Höchstalter ein",
         "error_max_lower_than_min": "Das Höchstalter kann nicht unter dem Mindestalter liegen.",
         "error_max_age": "Das eingegebene Alter darf höchstens 120 Jahre betragen.",
+        "error_invalid": "Das angegebene Alter ist ungültig.",
         "error_no_min_age": "Bitte geben Sie ein Mindestalter ein"
       }
     },

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -323,6 +323,7 @@
         "input_range_title": "Indiquez un âge minimum et maximum",
         "error_max_lower_than_min": "L'âge maximum ne peut être inférieur à l'âge minimum.",
         "error_max_age": "L'âge saisi peut être au maximum de 120 ans.",
+        "error_invalid": "L'âge spécifié n'est pas valide.",
         "error_no_min_age": "Veuillez entrer un âge minimum"
       }
     },

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -314,7 +314,9 @@
         "from": "De",
         "till": "à",
         "age": "ans",
+        "input_range_title": "Indiquez un âge minimum et maximum",
         "error_max_lower_than_min": "L'âge maximum ne peut être inférieur à l'âge minimum.",
+        "error_max_age": "L'âge saisi peut être au maximum de 120 ans.",
         "error_no_min_age": "Veuillez entrer un âge minimum"
       }
     },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -324,7 +324,9 @@
         "from": "Van",
         "till": "Tot",
         "age": "jaar",
+        "input_range_title": "Geef een minimum en maximum leeftijd in",
         "error_max_lower_than_min": "De maximumleeftijd kan niet lager zijn dan de minimumleeftijd.",
+        "error_max_age": "De ingevoerde leeftijd kan maximum 120 jaar zijn.",
         "error_no_min_age": "Gelieve een minimum leeftijd in te vullen"
       },
       "cultuurkuur": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -333,6 +333,7 @@
         "input_range_title": "Geef een minimum en maximum leeftijd in",
         "error_max_lower_than_min": "De maximumleeftijd kan niet lager zijn dan de minimumleeftijd.",
         "error_max_age": "De ingevoerde leeftijd kan maximum 120 jaar zijn.",
+        "error_invalid": "De opgegeven leeftijd is niet geldig.",
         "error_no_min_age": "Gelieve een minimum leeftijd in te vullen"
       },
       "cultuurkuur": {

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -208,9 +208,7 @@ const AgeRangeStepBoa = ({
                               }
                             `}
                           >
-                            {t(
-                              `create.name_and_age.age.${key.toLowerCase()}`,
-                            )}
+                            {t(`create.name_and_age.age.${key.toLowerCase()}`)}
                             <Text
                               css={css`
                                 color: ${getValue('rangeTextColor')};

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -200,14 +200,24 @@ const AgeRangeStepBoa = ({
                     return;
                   }
 
+                  const previousBirthdateRange = field.value?.birthdateRange;
+
                   field.onChange({ ...field.value, birthdateRange: undefined });
                   onChange({ ...field.value, birthdateRange: undefined });
 
-                  if (offerId && field.value?.birthdateRange) {
-                    deleteBirthdateRangeMutation.mutate({
-                      eventId: offerId,
-                      scope,
-                    });
+                  if (offerId && previousBirthdateRange) {
+                    deleteBirthdateRangeMutation.mutate(
+                      { eventId: offerId, scope },
+                      {
+                        onError: () => {
+                          field.onChange({
+                            ...field.value,
+                            birthdateRange: previousBirthdateRange,
+                          });
+                          setInputMode(AgeInputModes.DATE_OF_BIRTH);
+                        },
+                      },
+                    );
                   }
                 }}
                 options={Object.values(AgeInputModes).map((mode) => ({

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -29,14 +29,25 @@ const AgeInputModes = {
 type AgeInputMode = Values<typeof AgeInputModes>;
 
 const MAX_AGE = 120;
+const AGE_PATTERN = /^\d+$/;
 
 const getValue = getValueFromTheme('ageRange');
 
 type AgeRangeStepProps = StackProps & StepProps;
 
+const parseAge = (value: string): number | undefined =>
+  value === '' ? undefined : Number(value);
+
 const validateAgeRange = (min: string, max: string): string | null => {
-  const minNum = min ? parseInt(min, 10) : undefined;
-  const maxNum = max ? parseInt(max, 10) : undefined;
+  if (
+    (min !== '' && !AGE_PATTERN.test(min)) ||
+    (max !== '' && !AGE_PATTERN.test(max))
+  ) {
+    return 'create.name_and_age.age.error_invalid';
+  }
+
+  const minNum = parseAge(min);
+  const maxNum = parseAge(max);
 
   if (
     (minNum !== undefined && minNum > MAX_AGE) ||

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -6,8 +6,6 @@ import { css } from 'styled-components';
 import { AgeRanges } from '@/constants/AgeRange';
 import { FeatureFlags, useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { Values } from '@/types/Values';
-import { Alert, AlertVariants } from '@/ui/Alert';
-import { parseSpacing } from '@/ui/Box';
 import { Button, ButtonVariants } from '@/ui/Button';
 import { Inline } from '@/ui/Inline';
 import { Input } from '@/ui/Input';
@@ -16,6 +14,7 @@ import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
 import { ToggleGroup } from '@/ui/ToggleGroup';
 
+import { AgeRangeStepLegacy } from './AgeRangeStepLegacy';
 import { Field, StepProps } from './Steps';
 
 const AgeInputModes = {
@@ -25,123 +24,87 @@ const AgeInputModes = {
 
 type AgeInputMode = Values<typeof AgeInputModes>;
 
+const MAX_AGE = 120;
+
 const getValue = getValueFromTheme('ageRange');
 
 type AgeRangeStepProps = StackProps & StepProps;
 
-const AgeRangeStep = ({
-  formState: { errors },
+const validateAgeRange = (min: string, max: string): string | null => {
+  const minNum = min ? parseInt(min, 10) : undefined;
+  const maxNum = max ? parseInt(max, 10) : undefined;
+
+  if (
+    (minNum !== undefined && minNum > MAX_AGE) ||
+    (maxNum !== undefined && maxNum > MAX_AGE)
+  ) {
+    return 'create.name_and_age.age.error_max_age';
+  }
+
+  if (minNum !== undefined && maxNum !== undefined && maxNum < minNum) {
+    return 'create.name_and_age.age.error_max_lower_than_min';
+  }
+
+  return null;
+};
+
+const findPresetKey = (typicalAgeRange: string | undefined): string | null => {
+  if (!typicalAgeRange) return null;
+  if (typicalAgeRange === '0-' || typicalAgeRange === '-') return 'ALL';
+  return (
+    Object.keys(AgeRanges).find(
+      (key) => AgeRanges[key].apiLabel === typicalAgeRange,
+    ) ?? null
+  );
+};
+
+const AgeRangeStep = (props: AgeRangeStepProps) => {
+  const [isBoaEnabled] = useFeatureFlag(FeatureFlags.BOA);
+
+  if (!isBoaEnabled) {
+    return <AgeRangeStepLegacy {...props} />;
+  }
+
+  return <AgeRangeStepBoa {...props} />;
+};
+
+const AgeRangeStepBoa = ({
   control,
   onChange,
   ...props
 }: AgeRangeStepProps) => {
   const { t } = useTranslation();
-  const [isBoaEnabled] = useFeatureFlag(FeatureFlags.BOA);
 
   const [inputMode, setInputMode] = useState<AgeInputMode>(AgeInputModes.AGE);
-  const [isCustomAgeRange, setIsCustomAgeRange] = useState(false);
-  const [customMinAgeRange, setCustomMinAgeRange] = useState('');
-  const [customMaxAgeRange, setCustomMaxAgeRange] = useState('');
-  const [customAgeRangeError, setCustomAgeRangeError] = useState('');
-
-  const isCustomAgeRangeSelected = (typicalAgeRange: string): boolean => {
-    return !Object.keys(AgeRanges).some(
-      (key) =>
-        AgeRanges[key].apiLabel && AgeRanges[key].apiLabel === typicalAgeRange,
-    );
-  };
-
-  const resetCustomAgeRange = (): void => {
-    setCustomMinAgeRange('');
-    setCustomMaxAgeRange('');
-    setIsCustomAgeRange(false);
-    setCustomAgeRangeError('');
-  };
+  const [minAge, setMinAge] = useState('');
+  const [maxAge, setMaxAge] = useState('');
 
   const useInitializeAgeRangeFields = (field: Field) => {
     useEffect(() => {
-      if (!field.value?.typicalAgeRange) return;
-      const typicalAgeRange = field.value.typicalAgeRange;
+      const typicalAgeRange = field.value?.typicalAgeRange;
+      if (!typicalAgeRange) return;
 
-      if (typicalAgeRange === '0-') {
-        setIsCustomAgeRange(false);
-        resetCustomAgeRange();
-        return;
-      }
-
-      if (isCustomAgeRangeSelected(typicalAgeRange)) {
-        const [min, max] = field.value.typicalAgeRange.split('-');
-
-        setCustomMinAgeRange(min ?? '');
-        setCustomMaxAgeRange(max ?? '');
-        setIsCustomAgeRange(true);
-        return;
-      }
-
-      resetCustomAgeRange();
+      const [min, max] = typicalAgeRange.split('-');
+      setMinAge(min ?? '');
+      setMaxAge(max ?? '');
     }, [field.value?.typicalAgeRange]);
   };
 
-  const getSelectedAgeRange = (typicalAgeRange: string): string => {
-    const foundAgeRange = Object.keys(AgeRanges).find((key: string) => {
-      return (
-        AgeRanges[key].apiLabel && AgeRanges[key].apiLabel === typicalAgeRange
-      );
-    });
+  const commitAgeRange = (field: Field, newMin: string, newMax: string) => {
+    if (validateAgeRange(newMin, newMax)) return;
 
-    if (typicalAgeRange === '0-') {
-      return 'ALL';
-    }
-
-    if (isCustomAgeRange) {
-      return 'CUSTOM';
-    }
-
-    if (!foundAgeRange) return 'NONE';
-
-    return foundAgeRange;
+    const value = !newMin && !newMax ? '' : `${newMin}-${newMax}`;
+    field.onChange({ ...field.value, typicalAgeRange: value });
+    onChange({ ...field.value, typicalAgeRange: value });
   };
 
-  const handleSubmitCustomAgeRange = (field: Field) => {
-    if (parseInt(customMinAgeRange) > parseInt(customMaxAgeRange)) {
-      setCustomAgeRangeError(
-        t('create.name_and_age.age.error_max_lower_than_min'),
-      );
-      return;
-    }
+  const handlePresetClick = (field: Field, apiLabel: string) => {
+    const [min, max] = apiLabel.split('-');
+    setMinAge(min ?? '');
+    setMaxAge(max ?? '');
 
-    setCustomAgeRangeError('');
-
-    const customAgeRange =
-      !customMinAgeRange && !customMaxAgeRange
-        ? ''
-        : `${customMinAgeRange}-${customMaxAgeRange}`;
-
-    field.onChange({
-      ...field.value,
-      typicalAgeRange: customAgeRange,
-    });
-
-    onChange({
-      ...field.value,
-      typicalAgeRange: customAgeRange,
-    });
-  };
-
-  const handleMinAgeRangeChange = (field: Field, value: string) => {
-    setCustomMinAgeRange(value);
-    handleSubmitCustomAgeRange(field);
-  };
-
-  const handleMaxAgeRangeChange = (field: Field, value: string) => {
-    setCustomMaxAgeRange(value);
-
-    if (!customMinAgeRange) {
-      setCustomAgeRangeError(t('create.name_and_age.age.error_no_min_age'));
-      return;
-    }
-
-    handleSubmitCustomAgeRange(field);
+    field.onChange({ ...field.value, typicalAgeRange: apiLabel });
+    onChange({ ...field.value, typicalAgeRange: apiLabel });
   };
 
   return (
@@ -153,148 +116,114 @@ const AgeRangeStep = ({
           // eslint-disable-next-line react-hooks/rules-of-hooks
           useInitializeAgeRangeFields(field);
 
-          const selectedAgeRange = getSelectedAgeRange(
-            field.value?.typicalAgeRange,
-          );
+          const selectedPreset = findPresetKey(field.value?.typicalAgeRange);
+          const errorKey = validateAgeRange(minAge, maxAge);
 
           return (
             <Stack spacing={2}>
               <Text fontWeight="bold">
                 {t(`create.name_and_age.age.title`)}
               </Text>
-              {isBoaEnabled && (
-                <ToggleGroup
-                  name="age-input-mode"
-                  value={inputMode}
-                  onChange={(newMode: string) =>
-                    setInputMode(newMode as AgeInputMode)
-                  }
-                  options={Object.values(AgeInputModes).map((mode) => ({
-                    value: mode,
-                    label: t(`create.name_and_age.age.input_mode.${mode}`),
-                  }))}
-                  maxWidth="40rem"
-                  css={`
-                    margin-bottom: 1rem;
-                  `}
-                />
-              )}
+              <ToggleGroup
+                name="age-input-mode"
+                value={inputMode}
+                onChange={(newMode: string) =>
+                  setInputMode(newMode as AgeInputMode)
+                }
+                options={Object.values(AgeInputModes).map((mode) => ({
+                  value: mode,
+                  label: t(`create.name_and_age.age.input_mode.${mode}`),
+                }))}
+                maxWidth="40rem"
+                css={`
+                  margin-bottom: 1rem;
+                `}
+              />
               {inputMode === AgeInputModes.DATE_OF_BIRTH ? null : (
-                <>
+                <Stack spacing={3} maxWidth="40rem">
+                  <Text fontWeight="bold">
+                    {t('create.name_and_age.age.input_range_title')}
+                  </Text>
+                  <Inline spacing={3}>
+                    <Input
+                      type="numeric"
+                      value={minAge}
+                      placeholder={t('create.name_and_age.age.from')}
+                      aria-label={t('create.name_and_age.age.from')}
+                      maxWidth="8rem"
+                      onChange={(event: FormEvent<HTMLInputElement>) => {
+                        setMinAge((event.target as HTMLInputElement).value);
+                      }}
+                      onBlur={(event: FormEvent<HTMLInputElement>) => {
+                        commitAgeRange(
+                          field,
+                          (event.target as HTMLInputElement).value,
+                          maxAge,
+                        );
+                      }}
+                    />
+                    <Input
+                      type="numeric"
+                      value={maxAge}
+                      placeholder={t('create.name_and_age.age.till')}
+                      aria-label={t('create.name_and_age.age.till')}
+                      maxWidth="8rem"
+                      onChange={(event: FormEvent<HTMLInputElement>) => {
+                        setMaxAge((event.target as HTMLInputElement).value);
+                      }}
+                      onBlur={(event: FormEvent<HTMLInputElement>) => {
+                        commitAgeRange(
+                          field,
+                          minAge,
+                          (event.target as HTMLInputElement).value,
+                        );
+                      }}
+                    />
+                  </Inline>
+                  {errorKey && <Text color="red">{t(errorKey)}</Text>}
                   <Inline
                     spacing={3}
                     flexWrap="wrap"
-                    maxWidth="40rem"
                     css={`
-                      row-gap: ${parseSpacing(3.5)()};
+                      row-gap: 0.5rem;
                     `}
                   >
-                    {Object.keys(AgeRanges).map((key: string) => {
-                      const apiLabel = AgeRanges[key].apiLabel;
-                      return (
-                        <Button
-                          key={key}
-                          width="auto"
-                          active={selectedAgeRange === key}
-                          display="inline-flex"
-                          variant={ButtonVariants.SECONDARY_TOGGLE}
-                          onClick={() => {
-                            setIsCustomAgeRange(key === 'CUSTOM');
-
-                            field.onChange({
-                              ...field.value,
-                              typicalAgeRange: apiLabel,
-                            });
-
-                            onChange({
-                              ...field.value,
-                              typicalAgeRange: apiLabel,
-                            });
-                          }}
-                          css={`
-                            &.btn {
-                              padding: 0.3rem 0.7rem;
-                              box-shadow: ${({ theme }) =>
-                                theme.components.global.boxShadow.heavy};
-                            }
-                          `}
-                        >
-                          {t(`create.name_and_age.age.${key.toLowerCase()}`)}
-                          <Text
-                            css={css`
-                              color: ${getValue('rangeTextColor')};
-                              font-size: 0.9rem;
+                    {Object.keys(AgeRanges)
+                      .filter((key) => AgeRanges[key].apiLabel)
+                      .map((key) => {
+                        const apiLabel = AgeRanges[key].apiLabel!;
+                        return (
+                          <Button
+                            key={key}
+                            width="auto"
+                            active={selectedPreset === key}
+                            display="inline-flex"
+                            variant={ButtonVariants.SECONDARY_TOGGLE}
+                            onClick={() => handlePresetClick(field, apiLabel)}
+                            css={`
+                              &.btn {
+                                padding: 0.3rem 0.7rem;
+                                box-shadow: ${({ theme }) =>
+                                  theme.components.global.boxShadow.heavy};
+                              }
                             `}
                           >
-                            &nbsp; {AgeRanges[key].label ?? ''}
-                          </Text>
-                        </Button>
-                      );
-                    })}
-                  </Inline>
-                  <Inline>
-                    {isCustomAgeRange && (
-                      <Stack spacing={3}>
-                        <Inline spacing={3}>
-                          <Stack>
-                            <Text fontWeight="bold">
-                              {t('create.name_and_age.age.from')}
+                            {t(
+                              `create.name_and_age.age.${key.toLowerCase()}`,
+                            )}
+                            <Text
+                              css={css`
+                                color: ${getValue('rangeTextColor')};
+                                font-size: 0.9rem;
+                              `}
+                            >
+                              &nbsp; {AgeRanges[key].label ?? ''}
                             </Text>
-                            <Input
-                              marginRight={3}
-                              type="numeric"
-                              value={customMinAgeRange}
-                              placeholder={t('create.name_and_age.age.from')}
-                              onChange={(event) => {
-                                const value = (event.target as HTMLInputElement)
-                                  .value;
-                                setCustomMinAgeRange(value);
-                              }}
-                              onBlur={(event: FormEvent<HTMLInputElement>) => {
-                                const value = (event.target as HTMLInputElement)
-                                  .value;
-                                handleMinAgeRangeChange(field, value);
-                              }}
-                            />
-                          </Stack>
-                          <Stack>
-                            <Text fontWeight="bold">
-                              {t('create.name_and_age.age.till')}
-                            </Text>
-                            <Input
-                              marginRight={3}
-                              type="numeric"
-                              value={customMaxAgeRange}
-                              placeholder={t('create.name_and_age.age.till')}
-                              onChange={(event) => {
-                                const value = (event.target as HTMLInputElement)
-                                  .value;
-                                setCustomMaxAgeRange(value);
-                              }}
-                              onBlur={(event: FormEvent<HTMLInputElement>) => {
-                                const value = (event.target as HTMLInputElement)
-                                  .value;
-                                handleMaxAgeRangeChange(field, value);
-                              }}
-                            />
-                          </Stack>
-                        </Inline>
-                        {customAgeRangeError && (
-                          <Alert variant={AlertVariants.DANGER}>
-                            {customAgeRangeError}
-                          </Alert>
-                        )}
-                      </Stack>
-                    )}
+                          </Button>
+                        );
+                      })}
                   </Inline>
-                  {errors.nameAndAgeRange?.typicalAgeRange && (
-                    <Text color="red">
-                      {t(
-                        `create.name_and_age.validation_messages.age_range.${errors.nameAndAgeRange?.typicalAgeRange.type}`,
-                      )}
-                    </Text>
-                  )}
-                </>
+                </Stack>
               )}
             </Stack>
           );

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -52,6 +52,12 @@ const validateAgeRange = (min: string, max: string): string | null => {
   return null;
 };
 
+const isValidAgeRange = (typicalAgeRange: string | undefined): boolean => {
+  if (!typicalAgeRange) return true;
+  const [min, max] = typicalAgeRange.split('-');
+  return validateAgeRange(min ?? '', max ?? '') === null;
+};
+
 const findPresetKey = (typicalAgeRange: string | undefined): string | null => {
   if (!typicalAgeRange) return null;
   if (typicalAgeRange === '0-' || typicalAgeRange === '-') return 'ALL';
@@ -121,10 +127,11 @@ const AgeRangeStepBoa = ({
   }, [watchedBirthdateRange]);
 
   const commitAgeRange = (field: Field, newMin: string, newMax: string) => {
-    if (validateAgeRange(newMin, newMax)) return;
-
     const value = !newMin && !newMax ? '' : `${newMin}-${newMax}`;
     field.onChange({ ...field.value, typicalAgeRange: value });
+
+    if (validateAgeRange(newMin, newMax)) return;
+
     onChange({ ...field.value, typicalAgeRange: value });
   };
 
@@ -344,4 +351,4 @@ const AgeRangeStepBoa = ({
   );
 };
 
-export { AgeRangeStep };
+export { AgeRangeStep, isValidAgeRange };

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -113,7 +113,9 @@ const AgeRangeStepBoa = ({
   useEffect(() => {
     if (!watchedBirthdateRange?.from || !watchedBirthdateRange?.to) return;
 
-    setMinBirthDate(parse(watchedBirthdateRange.from, 'yyyy-MM-dd', new Date()));
+    setMinBirthDate(
+      parse(watchedBirthdateRange.from, 'yyyy-MM-dd', new Date()),
+    );
     setMaxBirthDate(parse(watchedBirthdateRange.to, 'yyyy-MM-dd', new Date()));
     setInputMode(AgeInputModes.DATE_OF_BIRTH);
   }, [watchedBirthdateRange]);

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -132,13 +132,22 @@ const AgeRangeStepBoa = ({
     setInputMode(AgeInputModes.DATE_OF_BIRTH);
   }, [watchedBirthdateRange]);
 
-  const commitAgeRange = (field: Field, newMin: string, newMax: string) => {
-    const value = !newMin && !newMax ? '' : `${newMin}-${newMax}`;
+  const commitTypicalAgeRange = (
+    field: Field,
+    value: string,
+    min: string,
+    max: string,
+  ) => {
     field.onChange({ ...field.value, typicalAgeRange: value });
 
-    if (validateAgeRange(newMin, newMax)) return;
+    if (validateAgeRange(min, max)) return;
 
     onChange({ ...field.value, typicalAgeRange: value });
+  };
+
+  const commitAgeRange = (field: Field, newMin: string, newMax: string) => {
+    const value = !newMin && !newMax ? '' : `${newMin}-${newMax}`;
+    commitTypicalAgeRange(field, value, newMin, newMax);
   };
 
   const handlePresetClick = (field: Field, apiLabel: string) => {
@@ -146,8 +155,7 @@ const AgeRangeStepBoa = ({
     setMinAge(min ?? '');
     setMaxAge(max ?? '');
 
-    field.onChange({ ...field.value, typicalAgeRange: apiLabel });
-    onChange({ ...field.value, typicalAgeRange: apiLabel });
+    commitTypicalAgeRange(field, apiLabel, min ?? '', max ?? '');
   };
 
   const commitBirthdateRange = (

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -104,11 +104,6 @@ const AgeRangeStepBoa = ({
   });
 
   useEffect(() => {
-    setMinBirthDate((current) => current ?? new Date());
-    setMaxBirthDate((current) => current ?? new Date());
-  }, []);
-
-  useEffect(() => {
     if (!watchedTypicalAgeRange) return;
 
     const [min, max] = watchedTypicalAgeRange.split('-');
@@ -188,7 +183,11 @@ const AgeRangeStepBoa = ({
                   const next = newMode as AgeInputMode;
                   setInputMode(next);
 
-                  if (next === AgeInputModes.DATE_OF_BIRTH) return;
+                  if (next === AgeInputModes.DATE_OF_BIRTH) {
+                    setMinBirthDate((current) => current ?? new Date());
+                    setMaxBirthDate((current) => current ?? new Date());
+                    return;
+                  }
 
                   field.onChange({ ...field.value, birthdateRange: undefined });
                   onChange({ ...field.value, birthdateRange: undefined });

--- a/src/pages/steps/AgeRangeStepLegacy.tsx
+++ b/src/pages/steps/AgeRangeStepLegacy.tsx
@@ -1,0 +1,274 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { Controller } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { AgeRanges } from '@/constants/AgeRange';
+import { Alert, AlertVariants } from '@/ui/Alert';
+import { parseSpacing } from '@/ui/Box';
+import { Button, ButtonVariants } from '@/ui/Button';
+import { Inline } from '@/ui/Inline';
+import { Input } from '@/ui/Input';
+import { getStackProps, Stack, StackProps } from '@/ui/Stack';
+import { Text } from '@/ui/Text';
+import { getValueFromTheme } from '@/ui/theme';
+
+import { Field, StepProps } from './Steps';
+
+const getValue = getValueFromTheme('ageRange');
+
+type AgeRangeStepLegacyProps = StackProps & StepProps;
+
+const AgeRangeStepLegacy = ({
+  formState: { errors },
+  control,
+  onChange,
+  ...props
+}: AgeRangeStepLegacyProps) => {
+  const { t } = useTranslation();
+
+  const [isCustomAgeRange, setIsCustomAgeRange] = useState(false);
+  const [customMinAgeRange, setCustomMinAgeRange] = useState('');
+  const [customMaxAgeRange, setCustomMaxAgeRange] = useState('');
+  const [customAgeRangeError, setCustomAgeRangeError] = useState('');
+
+  const isCustomAgeRangeSelected = (typicalAgeRange: string): boolean => {
+    return !Object.keys(AgeRanges).some(
+      (key) =>
+        AgeRanges[key].apiLabel && AgeRanges[key].apiLabel === typicalAgeRange,
+    );
+  };
+
+  const resetCustomAgeRange = (): void => {
+    setCustomMinAgeRange('');
+    setCustomMaxAgeRange('');
+    setIsCustomAgeRange(false);
+    setCustomAgeRangeError('');
+  };
+
+  const useInitializeAgeRangeFields = (field: Field) => {
+    useEffect(() => {
+      if (!field.value?.typicalAgeRange) return;
+      const typicalAgeRange = field.value.typicalAgeRange;
+
+      if (typicalAgeRange === '0-') {
+        setIsCustomAgeRange(false);
+        resetCustomAgeRange();
+        return;
+      }
+
+      if (isCustomAgeRangeSelected(typicalAgeRange)) {
+        const [min, max] = field.value.typicalAgeRange.split('-');
+
+        setCustomMinAgeRange(min ?? '');
+        setCustomMaxAgeRange(max ?? '');
+        setIsCustomAgeRange(true);
+        return;
+      }
+
+      resetCustomAgeRange();
+    }, [field.value?.typicalAgeRange]);
+  };
+
+  const getSelectedAgeRange = (typicalAgeRange: string): string => {
+    const foundAgeRange = Object.keys(AgeRanges).find((key: string) => {
+      return (
+        AgeRanges[key].apiLabel && AgeRanges[key].apiLabel === typicalAgeRange
+      );
+    });
+
+    if (typicalAgeRange === '0-') {
+      return 'ALL';
+    }
+
+    if (isCustomAgeRange) {
+      return 'CUSTOM';
+    }
+
+    if (!foundAgeRange) return 'NONE';
+
+    return foundAgeRange;
+  };
+
+  const handleSubmitCustomAgeRange = (field: Field) => {
+    if (parseInt(customMinAgeRange) > parseInt(customMaxAgeRange)) {
+      setCustomAgeRangeError(
+        t('create.name_and_age.age.error_max_lower_than_min'),
+      );
+      return;
+    }
+
+    setCustomAgeRangeError('');
+
+    const customAgeRange =
+      !customMinAgeRange && !customMaxAgeRange
+        ? ''
+        : `${customMinAgeRange}-${customMaxAgeRange}`;
+
+    field.onChange({
+      ...field.value,
+      typicalAgeRange: customAgeRange,
+    });
+
+    onChange({
+      ...field.value,
+      typicalAgeRange: customAgeRange,
+    });
+  };
+
+  const handleMinAgeRangeChange = (field: Field, value: string) => {
+    setCustomMinAgeRange(value);
+    handleSubmitCustomAgeRange(field);
+  };
+
+  const handleMaxAgeRangeChange = (field: Field, value: string) => {
+    setCustomMaxAgeRange(value);
+
+    if (!customMinAgeRange) {
+      setCustomAgeRangeError(t('create.name_and_age.age.error_no_min_age'));
+      return;
+    }
+
+    handleSubmitCustomAgeRange(field);
+  };
+
+  return (
+    <Stack {...getStackProps(props)}>
+      <Controller
+        name={'nameAndAgeRange'}
+        control={control}
+        render={({ field }) => {
+          // eslint-disable-next-line react-hooks/rules-of-hooks
+          useInitializeAgeRangeFields(field);
+
+          const selectedAgeRange = getSelectedAgeRange(
+            field.value?.typicalAgeRange,
+          );
+
+          return (
+            <Stack spacing={2}>
+              <Text fontWeight="bold">
+                {t(`create.name_and_age.age.title`)}
+              </Text>
+              <Inline
+                spacing={3}
+                flexWrap="wrap"
+                maxWidth="40rem"
+                css={`
+                  row-gap: ${parseSpacing(3.5)()};
+                `}
+              >
+                {Object.keys(AgeRanges).map((key: string) => {
+                  const apiLabel = AgeRanges[key].apiLabel;
+                  return (
+                    <Button
+                      key={key}
+                      width="auto"
+                      active={selectedAgeRange === key}
+                      display="inline-flex"
+                      variant={ButtonVariants.SECONDARY_TOGGLE}
+                      onClick={() => {
+                        setIsCustomAgeRange(key === 'CUSTOM');
+
+                        field.onChange({
+                          ...field.value,
+                          typicalAgeRange: apiLabel,
+                        });
+
+                        onChange({
+                          ...field.value,
+                          typicalAgeRange: apiLabel,
+                        });
+                      }}
+                      css={`
+                        &.btn {
+                          padding: 0.3rem 0.7rem;
+                          box-shadow: ${({ theme }) =>
+                            theme.components.global.boxShadow.heavy};
+                        }
+                      `}
+                    >
+                      {t(`create.name_and_age.age.${key.toLowerCase()}`)}
+                      <Text
+                        css={css`
+                          color: ${getValue('rangeTextColor')};
+                          font-size: 0.9rem;
+                        `}
+                      >
+                        &nbsp; {AgeRanges[key].label ?? ''}
+                      </Text>
+                    </Button>
+                  );
+                })}
+              </Inline>
+              <Inline>
+                {isCustomAgeRange && (
+                  <Stack spacing={3}>
+                    <Inline spacing={3}>
+                      <Stack>
+                        <Text fontWeight="bold">
+                          {t('create.name_and_age.age.from')}
+                        </Text>
+                        <Input
+                          marginRight={3}
+                          type="numeric"
+                          value={customMinAgeRange}
+                          placeholder={t('create.name_and_age.age.from')}
+                          onChange={(event) => {
+                            const value = (event.target as HTMLInputElement)
+                              .value;
+                            setCustomMinAgeRange(value);
+                          }}
+                          onBlur={(event: FormEvent<HTMLInputElement>) => {
+                            const value = (event.target as HTMLInputElement)
+                              .value;
+                            handleMinAgeRangeChange(field, value);
+                          }}
+                        />
+                      </Stack>
+                      <Stack>
+                        <Text fontWeight="bold">
+                          {t('create.name_and_age.age.till')}
+                        </Text>
+                        <Input
+                          marginRight={3}
+                          type="numeric"
+                          value={customMaxAgeRange}
+                          placeholder={t('create.name_and_age.age.till')}
+                          onChange={(event) => {
+                            const value = (event.target as HTMLInputElement)
+                              .value;
+                            setCustomMaxAgeRange(value);
+                          }}
+                          onBlur={(event: FormEvent<HTMLInputElement>) => {
+                            const value = (event.target as HTMLInputElement)
+                              .value;
+                            handleMaxAgeRangeChange(field, value);
+                          }}
+                        />
+                      </Stack>
+                    </Inline>
+                    {customAgeRangeError && (
+                      <Alert variant={AlertVariants.DANGER}>
+                        {customAgeRangeError}
+                      </Alert>
+                    )}
+                  </Stack>
+                )}
+              </Inline>
+              {errors.nameAndAgeRange?.typicalAgeRange && (
+                <Text color="red">
+                  {t(
+                    `create.name_and_age.validation_messages.age_range.${errors.nameAndAgeRange?.typicalAgeRange.type}`,
+                  )}
+                </Text>
+              )}
+            </Stack>
+          );
+        }}
+      />
+    </Stack>
+  );
+};
+
+export { AgeRangeStepLegacy };

--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -29,7 +29,7 @@ import { DuplicatePlaceErrorBody } from '@/utils/fetchFromApi';
 import { parseOfferId } from '@/utils/parseOfferId';
 
 import { AlertDuplicatePlace } from '../AlertDuplicatePlace';
-import { AgeRangeStep } from './AgeRangeStep';
+import { AgeRangeStep, isValidAgeRange } from './AgeRangeStep';
 import { UseEditArguments } from './hooks/useEditField';
 import { NameStep } from './NameStep';
 import {
@@ -231,7 +231,10 @@ const nameAndAgeRangeStepConfiguration: StepsConfiguration<'nameAndAgeRange'> =
     title: ({ t }) => t('create.name_and_age.title'),
     validation: yup.object().shape({
       name: yup.object().shape({}).required(),
-      typicalAgeRange: yup.string().matches(numberHyphenNumberRegex),
+      typicalAgeRange: yup
+        .string()
+        .matches(numberHyphenNumberRegex)
+        .test('matches', '', (value) => isValidAgeRange(value)),
     }),
     shouldShowStep: ({ watch, formState }) => {
       const location = watch('location');

--- a/src/test/e2e/events/event-age-range.spec.ts
+++ b/src/test/e2e/events/event-age-range.spec.ts
@@ -1,0 +1,142 @@
+import { expect, Page, test as base } from '@playwright/test';
+
+import nl from '../../../i18n/nl.json';
+import { createBasicEvent } from '../helpers/create-basic-event';
+import { suppressHydrationErrors } from '../helpers/suppress-hydration-errors';
+
+const age = nl.create.name_and_age.age;
+
+type TestFixtures = {
+  eventId: string;
+  eventEditUrl: string;
+};
+
+const test = base.extend<TestFixtures>({
+  eventId: async ({ page, baseURL }, applyFixture) => {
+    suppressHydrationErrors(page);
+    await createBasicEvent(page, baseURL, `E2E Age Range Test ${Date.now()}`);
+    await page.getByRole('button', { name: 'Publiceren', exact: true }).click();
+    await page.waitForURL(/\/events\/[a-f0-9-]+/);
+    const eventId = page.url().match(/\/events\/([a-f0-9-]+)/)?.[1] ?? '';
+    await applyFixture(eventId);
+  },
+
+  eventEditUrl: async ({ eventId }, applyFixture) => {
+    await applyFixture(`/events/${eventId}/edit`);
+  },
+});
+
+test.beforeEach(async ({ context }) => {
+  await context.addCookies([
+    { name: 'ff_boa', value: 'true', domain: 'localhost', path: '/' },
+  ]);
+});
+
+const minAgeInput = (page: Page) =>
+  page.getByPlaceholder(age.from, { exact: true });
+const maxAgeInput = (page: Page) =>
+  page.getByPlaceholder(age.till, { exact: true });
+
+const waitForTypicalAgeRangePut = (page: Page) =>
+  page.waitForResponse(
+    (response) =>
+      response.url().includes('/typicalAgeRange') &&
+      response.request().method() === 'PUT' &&
+      response.ok(),
+  );
+
+test.describe('Age range', () => {
+  test('persists a custom age range after a page reload', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+    await expect(page.getByText(age.input_range_title)).toBeVisible();
+    // Wait for the initial "Volwassenen 18+" range to hydrate before editing.
+    await expect(minAgeInput(page)).toHaveValue('18');
+
+    const minPut = waitForTypicalAgeRangePut(page);
+    await minAgeInput(page).fill('6');
+    await minAgeInput(page).blur();
+    await minPut;
+
+    const maxPut = waitForTypicalAgeRangePut(page);
+    await maxAgeInput(page).fill('12');
+    await maxAgeInput(page).blur();
+    await maxPut;
+
+    await page.goto(eventEditUrl);
+
+    await expect(minAgeInput(page)).toHaveValue('6');
+    await expect(maxAgeInput(page)).toHaveValue('12');
+  });
+
+  test('fills the inputs when a preset is selected and persists it', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    const kidsButton = page.getByRole('button', { name: new RegExp(age.kids) });
+
+    const put = waitForTypicalAgeRangePut(page);
+    await kidsButton.click();
+    await put;
+
+    await expect(kidsButton).toHaveClass(/(?:^|\s)active(?:\s|$)/);
+    await expect(minAgeInput(page)).toHaveValue('6');
+    await expect(maxAgeInput(page)).toHaveValue('11');
+
+    await page.goto(eventEditUrl);
+
+    await expect(
+      page.getByRole('button', { name: new RegExp(age.kids) }),
+    ).toHaveClass(/(?:^|\s)active(?:\s|$)/);
+    await expect(minAgeInput(page)).toHaveValue('6');
+    await expect(maxAgeInput(page)).toHaveValue('11');
+  });
+
+  test('shows an error and does not persist when "from" is lower than "to"', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    const put = waitForTypicalAgeRangePut(page);
+    await page.getByRole('button', { name: new RegExp(age.kids) }).click();
+    await put;
+
+    await maxAgeInput(page).fill('5');
+    await maxAgeInput(page).blur();
+
+    await expect(page.getByText(age.error_max_lower_than_min)).toBeVisible();
+
+    await page.goto(eventEditUrl);
+
+    await expect(page.getByText(age.error_max_lower_than_min)).toBeHidden();
+    await expect(minAgeInput(page)).toHaveValue('6');
+    await expect(maxAgeInput(page)).toHaveValue('11');
+  });
+
+  test('shows an error and does not persist an age above the maximum', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // A freshly created event starts at the "Volwassenen 18+" preset (18-).
+    await expect(minAgeInput(page)).toHaveValue('18');
+
+    await minAgeInput(page).fill('200');
+    await minAgeInput(page).blur();
+
+    await expect(page.getByText(age.error_max_age)).toBeVisible();
+
+    await page.goto(eventEditUrl);
+
+    // The invalid value was never saved, so the previous range is untouched.
+    await expect(page.getByText(age.error_max_age)).toBeHidden();
+    await expect(minAgeInput(page)).toHaveValue('18');
+    await expect(maxAgeInput(page)).toHaveValue('');
+  });
+});

--- a/src/test/e2e/events/event-age-range.spec.ts
+++ b/src/test/e2e/events/event-age-range.spec.ts
@@ -139,4 +139,26 @@ test.describe('Age range', () => {
     await expect(minAgeInput(page)).toHaveValue('18');
     await expect(maxAgeInput(page)).toHaveValue('');
   });
+
+  test('shows an error and does not persist non-numeric input', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // A freshly created event starts at the "Volwassenen 18+" preset (18-).
+    await expect(minAgeInput(page)).toHaveValue('18');
+
+    await minAgeInput(page).fill('abc');
+    await minAgeInput(page).blur();
+
+    await expect(page.getByText(age.error_invalid)).toBeVisible();
+
+    await page.goto(eventEditUrl);
+
+    // The invalid value was never saved, so the previous range is untouched.
+    await expect(page.getByText(age.error_invalid)).toBeHidden();
+    await expect(minAgeInput(page)).toHaveValue('18');
+    await expect(maxAgeInput(page)).toHaveValue('');
+  });
 });


### PR DESCRIPTION
## Changed
- `AgeRangeStep` is now a thin switch on the BOA flag:
  - `ff_boa = false` → renders `AgeRangeStepLegacy` (existing behaviour, no visual or behavioural change).
  - `ff_boa = true` → renders the new BOA layout.
- BOA layout:
  - `van` / `tot` numeric inputs are always visible (no longer hidden behind the "Andere" toggle).
  - Preset buttons (Peuters, Kleuters, Kinderen, Tieners, Jongeren, Volwassenen, Senioren, Alle leeftijden) sit **below** the inputs.
  - Clicking a preset fills both inputs with that preset's values.
  - Inline red error text replaces the `Alert` box for validation messages.
  - Invalid values (range or > 120) are not pushed to form state, so neither auto-save nor the create-flow Save proceeds with bad data.

Screenshot:
<img width="736" height="286" alt="Screenshot 2026-05-20 at 15 08 00" src="https://github.com/user-attachments/assets/d7c630ae-5815-4b89-909f-4708ceead9ab" />

---
Ticket: https://jira.uitdatabank.be/browse/III-7193
