### PR TITLE
III-7197 - Add children only section

### DIFF
--- a/src/constants/AudienceType.ts
+++ b/src/constants/AudienceType.ts
@@ -4,6 +4,7 @@ const AudienceTypes = {
   EVERYONE: 'everyone',
   MEMBERS: 'members',
   EDUCATION: 'education',
+  CHILDREN_ONLY: 'childrenOnly',
 } as const;
 
 type AudienceType = Values<typeof AudienceTypes>;

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -342,6 +342,12 @@
             "body": "Eine Aktivität 'nur für Kinder' kann nicht auf nur Mitglieder beschränkt werden. Möchten Sie fortfahren? Dann setzen wir den Zugang automatisch auf 'Für jeden'.",
             "confirm": "Fortfahren",
             "cancel": "Abbrechen"
+          },
+          "age_range_warning_modal": {
+            "title": "Achtung: Dieses Alter passt nicht mehr zu 'Nur für Kinder'",
+            "body": "Durch diese Änderung gilt diese Aktivität nicht mehr als 'Nur für Kinder'. Der Zugang wird automatisch auf 'Für alle' gesetzt und eventuelle Abfahrtsorte werden gelöscht.",
+            "confirm": "Fortfahren",
+            "cancel": "Abbrechen"
           }
         }
       }
@@ -376,7 +382,7 @@
       },
       "audience": {
         "childrenOnly": "Nur für Kinder",
-        "children_only_warning": "Diese Aktivität ist als 'Nur für Kinder' markiert.<br/><br/>Um den Zugang zu ändern, gehen Sie zu <strong>Basisangaben</strong> &rsaquo; <strong>Für wen ist diese Aktivität?</strong>.<br/><br/>Wählen Sie 'Für Kinder mit ihrer Familie oder einer anderen Begleitperson'.",
+        "children_only_warning": "Diese Aktivität ist als 'Nur für Kinder' markiert.<br/>Um den Zugang zu ändern, gehen Sie zu <strong>Basisangaben</strong> &rsaquo; <strong>Für wen ist diese Aktivität?</strong>.<br/>Wählen Sie 'Für Kinder mit ihrer Familie oder einer anderen Begleitperson'.",
         "education": "Nur für Schulen",
         "everyone": "Für alle",
         "members": "Nur für Mitglieder",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -317,7 +317,19 @@
         "input_range_title": "Geben Sie ein Mindest- und Höchstalter ein",
         "error_max_lower_than_min": "Das Höchstalter kann nicht unter dem Mindestalter liegen.",
         "error_max_age": "Das eingegebene Alter darf höchstens 120 Jahre betragen.",
-        "error_no_min_age": "Bitte geben Sie ein Mindestalter ein"
+        "error_no_min_age": "Bitte geben Sie ein Mindestalter ein",
+        "audience": {
+          "question": "Für wen ist diese Aktivität?",
+          "children_only": "Nur für Kinder",
+          "with_family": "Für Kinder mit ihrer Familie oder einer anderen Begleitperson",
+          "mutation_error": "Beim Speichern der Zielgruppe ist ein Fehler aufgetreten. Bitte erneut versuchen.",
+          "departure_places_warning_modal": {
+            "title": "Abfahrtsorte löschen",
+            "body": "Achtung: Mit dieser Aktion werden die von Ihnen angegebenen Abfahrtsorte gelöscht.",
+            "confirm": "Fortfahren",
+            "cancel": "Abbrechen"
+          }
+        }
       }
     },
     "type_and_theme": {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -298,6 +298,7 @@
       },
       "age": {
         "title": "Geeignet für",
+        "title_boa": "Geben Sie an, für welche Altersgruppen diese Aktivität geeignet ist",
         "input_mode": {
           "age": "Als Alter eingeben",
           "date_of_birth": "Als Geburtsdatum eingeben"

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -336,6 +336,12 @@
             "body": "Achtung: Mit dieser Aktion werden die von Ihnen angegebenen Abfahrtsorte gelöscht.",
             "confirm": "Fortfahren",
             "cancel": "Abbrechen"
+          },
+          "members_warning_modal": {
+            "title": "Achtung: Mit dieser Aktion ändern Sie die Zugänglichkeitsinformationen",
+            "body": "Eine Aktivität 'nur für Kinder' kann nicht auf nur Mitglieder beschränkt werden. Möchten Sie fortfahren? Dann setzen wir den Zugang automatisch auf 'Für jeden'.",
+            "confirm": "Fortfahren",
+            "cancel": "Abbrechen"
           }
         }
       }
@@ -369,6 +375,8 @@
         }
       },
       "audience": {
+        "childrenOnly": "Nur für Kinder",
+        "children_only_warning": "Diese Aktivität ist als 'Nur für Kinder' markiert.<br/><br/>Um den Zugang zu ändern, gehen Sie zu <strong>Basisangaben</strong> &rsaquo; <strong>Für wen ist diese Aktivität?</strong>.<br/><br/>Wählen Sie 'Für Kinder mit ihrer Familie oder einer anderen Begleitperson'.",
         "education": "Nur für Schulen",
         "everyone": "Für alle",
         "members": "Nur für Mitglieder",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -317,7 +317,19 @@
         "input_range_title": "Indiquez un âge minimum et maximum",
         "error_max_lower_than_min": "L'âge maximum ne peut être inférieur à l'âge minimum.",
         "error_max_age": "L'âge saisi peut être au maximum de 120 ans.",
-        "error_no_min_age": "Veuillez entrer un âge minimum"
+        "error_no_min_age": "Veuillez entrer un âge minimum",
+        "audience": {
+          "question": "Pour qui cette activité est-elle organisée ?",
+          "children_only": "Uniquement pour les enfants",
+          "with_family": "Pour les enfants accompagnés de leur famille ou d'un autre accompagnateur",
+          "mutation_error": "Une erreur est survenue lors de l'enregistrement du public cible. Veuillez réessayer.",
+          "departure_places_warning_modal": {
+            "title": "Supprimer les lieux de départ",
+            "body": "Attention : cette action supprime les lieux de départ que vous avez renseignés.",
+            "confirm": "Continuer",
+            "cancel": "Annuler"
+          }
+        }
       }
     },
     "type_and_theme": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -336,6 +336,12 @@
             "body": "Attention : cette action supprime les lieux de départ que vous avez renseignés.",
             "confirm": "Continuer",
             "cancel": "Annuler"
+          },
+          "members_warning_modal": {
+            "title": "Attention : cette action modifie les informations d'accessibilité",
+            "body": "Une activité 'uniquement pour les enfants' ne peut pas être limitée aux membres uniquement. Voulez-vous continuer ? L'accès sera alors défini automatiquement sur 'Pour tout le monde'.",
+            "confirm": "Continuer",
+            "cancel": "Annuler"
           }
         }
       }
@@ -371,6 +377,8 @@
         }
       },
       "audience": {
+        "childrenOnly": "Uniquement pour les enfants",
+        "children_only_warning": "Cette activité est définie comme 'Uniquement pour les enfants'.<br/>Pour modifier l'accès, allez à <strong>Données de base</strong> &rsaquo; <strong>Pour qui cette activité est-elle organisée ?</strong>.<br/>Choisissez 'Pour les enfants accompagnés de leur famille ou d'un autre accompagnateur'.",
         "education": "Spécifiquement pour des écoles",
         "everyone": "Pour tout le monde",
         "members": "Seulement pour des membres",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -298,6 +298,7 @@
       },
       "age": {
         "title": "Adapté à",
+        "title_boa": "Indiquez pour quels âges cette activité est adaptée",
         "input_mode": {
           "age": "Saisir comme âge",
           "date_of_birth": "Saisir comme date de naissance"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -342,6 +342,12 @@
             "body": "Une activité 'uniquement pour les enfants' ne peut pas être limitée aux membres uniquement. Voulez-vous continuer ? L'accès sera alors défini automatiquement sur 'Pour tout le monde'.",
             "confirm": "Continuer",
             "cancel": "Annuler"
+          },
+          "age_range_warning_modal": {
+            "title": "Attention : cet âge ne correspond plus à 'Uniquement pour les enfants'",
+            "body": "En modifiant l'âge, cette activité ne sera plus 'Uniquement pour les enfants'. L'accès sera automatiquement défini sur 'Pour tout le monde' et les lieux de départ éventuels seront supprimés.",
+            "confirm": "Continuer",
+            "cancel": "Annuler"
           }
         }
       }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -352,6 +352,12 @@
             "body": "Een activiteit 'voor kinderen alleen' kan niet beperkt worden tot enkel leden. Wil je doorgaan? Dan zetten we de toegang automatisch op 'Voor iedereen'.",
             "confirm": "Verdergaan",
             "cancel": "Annuleren"
+          },
+          "age_range_warning_modal": {
+            "title": "Let op: deze leeftijd valt buiten 'Voor kinderen alleen'",
+            "body": "Door deze wijziging valt de activiteit niet langer onder 'Voor kinderen alleen'. De toegang wordt automatisch ingesteld op 'Voor iedereen' en eventuele vertreklocaties worden verwijderd.",
+            "confirm": "Verdergaan",
+            "cancel": "Annuleren"
           }
         }
       },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -308,6 +308,7 @@
       },
       "age": {
         "title": "Geschikt voor",
+        "title_boa": "Geef aan op welke leeftijden deze activiteit geschikt is",
         "input_mode": {
           "age": "Ingeven als leeftijd",
           "date_of_birth": "Ingeven als geboortedatum"

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -327,7 +327,19 @@
         "input_range_title": "Geef een minimum en maximum leeftijd in",
         "error_max_lower_than_min": "De maximumleeftijd kan niet lager zijn dan de minimumleeftijd.",
         "error_max_age": "De ingevoerde leeftijd kan maximum 120 jaar zijn.",
-        "error_no_min_age": "Gelieve een minimum leeftijd in te vullen"
+        "error_no_min_age": "Gelieve een minimum leeftijd in te vullen",
+        "audience": {
+          "question": "Voor wie is deze activiteit?",
+          "children_only": "Voor kinderen alleen",
+          "with_family": "Voor kinderen samen met hun familie of een andere begeleider",
+          "mutation_error": "Er ging iets mis bij het opslaan van het doelpubliek. Probeer opnieuw.",
+          "departure_places_warning_modal": {
+            "title": "Vertreklocaties verwijderen",
+            "body": "Let op: deze actie verwijdert je ingevulde vertreklocaties.",
+            "confirm": "Doorgaan",
+            "cancel": "Annuleren"
+          }
+        }
       },
       "cultuurkuur": {
         "info": "Voeg de onderwijsniveaus toe waarvoor je activiteit geschikt is. Meer info over de nieuwe structuur van het onderwijs vind je <link1>hier</link1>.",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -346,6 +346,12 @@
             "body": "Let op: deze actie verwijdert je ingevulde vertreklocaties.",
             "confirm": "Doorgaan",
             "cancel": "Annuleren"
+          },
+          "members_warning_modal": {
+            "title": "Let op: met deze actie wijzig je de toegankelijkheidsinformatie",
+            "body": "Een activiteit 'voor kinderen alleen' kan niet beperkt worden tot enkel leden. Wil je doorgaan? Dan zetten we de toegang automatisch op 'Voor iedereen'.",
+            "confirm": "Verdergaan",
+            "cancel": "Annuleren"
           }
         }
       },
@@ -390,6 +396,8 @@
       },
       "audience": {
         "title": "Toegang",
+        "childrenOnly": "Voor kinderen alleen",
+        "children_only_warning": "Deze activiteit is ingesteld als 'Voor kinderen alleen'.<br/>Om de toegang te wijzigen, ga je naar <strong>Basisgegevens</strong> &rsaquo; <strong>Voor wie is deze activiteit?</strong>.<br/>Kies daar 'Voor kinderen samen met hun familie of een andere begeleider'.",
         "education": "Specifiek voor scholen",
         "everyone": "Voor iedereen",
         "members": "Enkel voor leden",

--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -288,9 +288,8 @@ const AdditionalInformationStep = ({
   const isCultuurkuurEvent =
     offer?.audience?.audienceType === AudienceTypes.EDUCATION;
 
-  // @ts-expect-error
-  // Remove ts error when the  childrenOnly audienceType has been added
-  const isChildrenOnly = offer?.audience?.audienceType === 'childrenOnly';
+  const isChildrenOnly =
+    offer?.audience?.audienceType === AudienceTypes.CHILDREN_ONLY;
 
   const [, hash] = asPath.split('#');
 

--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -299,6 +299,19 @@ const AdditionalInformationStep = ({
   }, [hash]);
 
   useEffect(() => {
+    if (!offer) return;
+    const isAccessibilityTabVisible = isChildrenOnly && isBoaEnabled;
+    if (isAccessibilityTabVisible) return;
+    setTab((current) => {
+      if (current !== Fields.ACCESSIBILITY) return current;
+      router.replace({ hash: Fields.DESCRIPTION }, undefined, {
+        shallow: true,
+      });
+      return Fields.DESCRIPTION;
+    });
+  }, [offer, isChildrenOnly, isBoaEnabled, router]);
+
+  useEffect(() => {
     if (!offerId) return;
     if (!containerRef.current?.parentElement) return;
 
@@ -310,8 +323,9 @@ const AdditionalInformationStep = ({
     });
   }, [offerId]);
 
-  const handleSelectTab = (tab: string) => {
-    router.push({ hash: tab }, undefined, { shallow: true });
+  const handleSelectTab = (newTab: string) => {
+    setTab(newTab);
+    router.push({ hash: newTab }, undefined, { shallow: true });
   };
 
   const [validatedFields, setValidatedFields] = useState(

--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -302,14 +302,10 @@ const AdditionalInformationStep = ({
     if (!offer) return;
     const isAccessibilityTabVisible = isChildrenOnly && isBoaEnabled;
     if (isAccessibilityTabVisible) return;
-    setTab((current) => {
-      if (current !== Fields.ACCESSIBILITY) return current;
-      router.replace({ hash: Fields.DESCRIPTION }, undefined, {
-        shallow: true,
-      });
-      return Fields.DESCRIPTION;
-    });
-  }, [offer, isChildrenOnly, isBoaEnabled, router]);
+    if (tab !== Fields.ACCESSIBILITY) return;
+    setTab(Fields.DESCRIPTION);
+    router.replace({ hash: Fields.DESCRIPTION }, undefined, { shallow: true });
+  }, [offer, isChildrenOnly, isBoaEnabled, router, tab]);
 
   useEffect(() => {
     if (!offerId) return;

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -23,7 +23,7 @@ import { Modal, ModalSizes, ModalVariants } from '@/ui/Modal';
 import { RadioButtonWithLabel } from '@/ui/RadioButtonWithLabel';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
 import { Text } from '@/ui/Text';
-import { getValueFromTheme } from '@/ui/theme';
+import { colors, getValueFromTheme } from '@/ui/theme';
 import { ToggleGroup } from '@/ui/ToggleGroup';
 
 import { AgeRangeStepLegacy } from './AgeRangeStepLegacy';
@@ -225,8 +225,8 @@ const AgeRangeStepBoa = ({
 
           return (
             <Stack spacing={2}>
-              <Text fontWeight="bold">
-                {t(`create.name_and_age.age.title`)}
+              <Text fontWeight="bold" paddingBottom={3}>
+                {t(`create.name_and_age.age.title_boa`)}
               </Text>
               <ToggleGroup
                 name="age-input-mode"
@@ -240,11 +240,11 @@ const AgeRangeStepBoa = ({
                 }))}
                 maxWidth="40rem"
                 css={`
-                  margin-bottom: 1rem;
+                  margin-bottom: 2rem;
                 `}
               />
               {inputMode === AgeInputModes.DATE_OF_BIRTH ? null : (
-                <Stack spacing={3} maxWidth="40rem">
+                <Stack spacing={3} maxWidth="40rem" paddingLeft={5}>
                   <Text fontWeight="bold">
                     {t('create.name_and_age.age.input_range_title')}
                   </Text>
@@ -326,7 +326,14 @@ const AgeRangeStepBoa = ({
                       })}
                   </Inline>
                   {showChildrenOnlySection && (
-                    <Stack spacing={2} marginTop={3}>
+                    <Stack
+                      spacing={2}
+                      marginTop={4}
+                      paddingTop={4}
+                      css={`
+                        border-top: 1px solid ${colors.grey3};
+                      `}
+                    >
                       <Text fontWeight="bold">
                         {t('create.name_and_age.age.audience.question')}
                       </Text>

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -138,10 +138,8 @@ const AgeRangeStepBoa = ({
 
   const useInitializeAgeRangeFields = (field: Field) => {
     useEffect(() => {
-      const typicalAgeRange = field.value?.typicalAgeRange;
-      if (!typicalAgeRange) return;
-
-      const [min, max] = typicalAgeRange.split('-');
+      if (!field.value?.typicalAgeRange) return;
+      const [min, max] = field.value.typicalAgeRange.split('-');
       setMinAge(min ?? '');
       setMaxAge(max ?? '');
     }, [field.value?.typicalAgeRange]);
@@ -159,7 +157,6 @@ const AgeRangeStepBoa = ({
     const [min, max] = apiLabel.split('-');
     setMinAge(min ?? '');
     setMaxAge(max ?? '');
-
     field.onChange({ ...field.value, typicalAgeRange: apiLabel });
     onChange({ ...field.value, typicalAgeRange: apiLabel });
   };
@@ -347,6 +344,37 @@ const AgeRangeStepBoa = ({
           );
         }}
       />
+
+      <Modal
+        variant={ModalVariants.QUESTION}
+        size={ModalSizes.MD}
+        visible={pendingAudienceChange !== null}
+        title={t(
+          'create.name_and_age.age.audience.departure_places_warning_modal.title',
+        )}
+        confirmTitle={t(
+          'create.name_and_age.age.audience.departure_places_warning_modal.confirm',
+        )}
+        cancelTitle={t(
+          'create.name_and_age.age.audience.departure_places_warning_modal.cancel',
+        )}
+        confirmButtonVariant={ButtonVariants.DANGER}
+        onClose={() => setPendingAudienceChange(null)}
+        onConfirm={() => {
+          if (pendingAudienceChange) {
+            applyAudienceChange(pendingAudienceChange);
+            setPendingAudienceChange(null);
+          }
+        }}
+      >
+        <Box padding={4}>
+          <Text>
+            {t(
+              'create.name_and_age.age.audience.departure_places_warning_modal.body',
+            )}
+          </Text>
+        </Box>
+      </Modal>
     </Stack>
   );
 };

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -187,7 +187,10 @@ const AgeRangeStepBoa = ({
     setAudienceMutationError(null);
     setValue('audience', { audienceType: newType });
     if (offerId) {
-      changeAudienceMutation.mutate({ eventId: offerId, audienceType: newType });
+      changeAudienceMutation.mutate({
+        eventId: offerId,
+        audienceType: newType,
+      });
     }
   };
 
@@ -309,9 +312,7 @@ const AgeRangeStepBoa = ({
                               }
                             `}
                           >
-                            {t(
-                              `create.name_and_age.age.${key.toLowerCase()}`,
-                            )}
+                            {t(`create.name_and_age.age.${key.toLowerCase()}`)}
                             <Text
                               css={css`
                                 color: ${getValue('rangeTextColor')};
@@ -332,9 +333,7 @@ const AgeRangeStepBoa = ({
                       <RadioButtonWithLabel
                         id="audience-children-only"
                         name="age-audience-type"
-                        checked={
-                          audienceType === AudienceTypes.CHILDREN_ONLY
-                        }
+                        checked={audienceType === AudienceTypes.CHILDREN_ONLY}
                         label={t(
                           'create.name_and_age.age.audience.children_only',
                         )}
@@ -345,9 +344,7 @@ const AgeRangeStepBoa = ({
                       <RadioButtonWithLabel
                         id="audience-with-family"
                         name="age-audience-type"
-                        checked={
-                          audienceType !== AudienceTypes.CHILDREN_ONLY
-                        }
+                        checked={audienceType !== AudienceTypes.CHILDREN_ONLY}
                         label={t(
                           'create.name_and_age.age.audience.with_family',
                         )}

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -73,7 +73,8 @@ const overlapsWithBoaAgeRange = (
   typicalAgeRange: string | undefined,
 ): boolean => {
   if (!typicalAgeRange) return false;
-  if (typicalAgeRange === '-' || typicalAgeRange === '0-') return true;
+  // "Alle leeftijden" is not children-specific
+  if (typicalAgeRange === '-' || typicalAgeRange === '0-') return false;
 
   const [minStr, maxStr] = typicalAgeRange.split('-');
   const min = minStr ? parseInt(minStr, 10) : undefined;

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -131,6 +131,8 @@ const AgeRangeStepBoa = ({
   const queryClient = useQueryClient();
   const deleteBirthdateRangeMutation = useDeleteOfferBirthdateRangeMutation();
 
+  const isEvent = scope === OfferTypes.EVENTS;
+
   const [inputMode, setInputMode] = useState<AgeInputMode>(AgeInputModes.AGE);
   const [minAge, setMinAge] = useState('');
   const [maxAge, setMaxAge] = useState('');
@@ -165,7 +167,7 @@ const AgeRangeStepBoa = ({
 
   const getEventByIdQuery = useGetEventByIdQuery(
     { id: offerId ?? '' },
-    { enabled: !!offerId },
+    { enabled: !!offerId && isEvent },
   );
   const event: Event | undefined = getEventByIdQuery.data;
 
@@ -286,6 +288,7 @@ const AgeRangeStepBoa = ({
   };
 
   const showChildrenOnlySection =
+    isEvent &&
     audienceType !== AudienceTypes.EDUCATION &&
     overlapsWithBoaAgeRange(watchedTypicalAgeRange);
 

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -148,13 +148,6 @@ const AgeRangeStepBoa = ({
     string | null
   >(null);
 
-  const invalidateOfferQuery = () => {
-    if (!offerId) return;
-    queryClient.invalidateQueries({
-      queryKey: [OfferTypes.EVENTS, { id: offerId }],
-    });
-  };
-
   const audienceType = useWatch({
     control,
     name: 'audience.audienceType',
@@ -176,7 +169,12 @@ const AgeRangeStepBoa = ({
   const event: Event | undefined = getEventByIdQuery.data;
 
   const changeAudienceMutation = useChangeAudienceMutation({
-    onSuccess: invalidateOfferQuery,
+    onSuccess: () => {
+      if (!offerId) return;
+      queryClient.invalidateQueries({
+        queryKey: [OfferTypes.EVENTS, { id: offerId }],
+      });
+    },
     onError: () => {
       setAudienceMutationError(
         t('create.name_and_age.age.audience.mutation_error'),
@@ -185,7 +183,12 @@ const AgeRangeStepBoa = ({
   });
 
   const changeDeparturePlacesMutation = useChangeDeparturePlacesMutation({
-    onSuccess: invalidateOfferQuery,
+    onSuccess: () => {
+      if (!offerId) return;
+      queryClient.invalidateQueries({
+        queryKey: [OfferTypes.EVENTS, { id: offerId }],
+      });
+    },
     onError: () => {
       setAudienceMutationError(
         t('create.name_and_age.age.audience.mutation_error'),

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -184,13 +184,21 @@ const AgeRangeStepBoa = ({
   };
 
   const applyAudienceChange = async (newType: AudienceType) => {
+    const previousType = audienceType;
     setAudienceMutationError(null);
     setValue('audience', { audienceType: newType });
     if (!offerId) return;
-    await changeAudienceMutation.mutateAsync({
-      eventId: offerId,
-      audienceType: newType,
-    });
+    try {
+      await changeAudienceMutation.mutateAsync({
+        eventId: offerId,
+        audienceType: newType,
+      });
+    } catch (error) {
+      // Revert the optimistic form update so the radio reflects the
+      // backend state again.
+      setValue('audience', { audienceType: previousType });
+      throw error;
+    }
   };
 
   const handleAudienceClick = (newType: AudienceType) => {

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -1,14 +1,23 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { Controller } from 'react-hook-form';
+import { Controller, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
 import { AgeRanges } from '@/constants/AgeRange';
+import { AudienceType, AudienceTypes } from '@/constants/AudienceType';
+import {
+  useChangeAudienceMutation,
+  useGetEventByIdQuery,
+} from '@/hooks/api/events';
 import { FeatureFlags, useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { Event } from '@/types/Event';
 import { Values } from '@/types/Values';
+import { Box } from '@/ui/Box';
 import { Button, ButtonVariants } from '@/ui/Button';
 import { Inline } from '@/ui/Inline';
 import { Input } from '@/ui/Input';
+import { Modal, ModalSizes, ModalVariants } from '@/ui/Modal';
+import { RadioButtonWithLabel } from '@/ui/RadioButtonWithLabel';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
 import { Text } from '@/ui/Text';
 import { getValueFromTheme } from '@/ui/theme';
@@ -25,6 +34,8 @@ const AgeInputModes = {
 type AgeInputMode = Values<typeof AgeInputModes>;
 
 const MAX_AGE = 120;
+const BOA_MIN_AGE = 2;
+const BOA_MAX_AGE = 12;
 
 const getValue = getValueFromTheme('ageRange');
 
@@ -58,6 +69,21 @@ const findPresetKey = (typicalAgeRange: string | undefined): string | null => {
   );
 };
 
+const overlapsWithBoaAgeRange = (
+  typicalAgeRange: string | undefined,
+): boolean => {
+  if (!typicalAgeRange) return false;
+  if (typicalAgeRange === '-' || typicalAgeRange === '0-') return true;
+
+  const [minStr, maxStr] = typicalAgeRange.split('-');
+  const min = minStr ? parseInt(minStr, 10) : undefined;
+  const max = maxStr ? parseInt(maxStr, 10) : undefined;
+
+  if (min !== undefined && min > BOA_MAX_AGE) return false;
+  if (max !== undefined && max < BOA_MIN_AGE) return false;
+  return true;
+};
+
 const AgeRangeStep = (props: AgeRangeStepProps) => {
   const [isBoaEnabled] = useFeatureFlag(FeatureFlags.BOA);
 
@@ -71,6 +97,8 @@ const AgeRangeStep = (props: AgeRangeStepProps) => {
 const AgeRangeStepBoa = ({
   control,
   onChange,
+  offerId,
+  setValue,
   ...props
 }: AgeRangeStepProps) => {
   const { t } = useTranslation();
@@ -78,6 +106,35 @@ const AgeRangeStepBoa = ({
   const [inputMode, setInputMode] = useState<AgeInputMode>(AgeInputModes.AGE);
   const [minAge, setMinAge] = useState('');
   const [maxAge, setMaxAge] = useState('');
+  const [pendingAudienceChange, setPendingAudienceChange] =
+    useState<AudienceType | null>(null);
+  const [audienceMutationError, setAudienceMutationError] = useState<
+    string | null
+  >(null);
+
+  const audienceType = useWatch({
+    control,
+    name: 'audience.audienceType',
+  }) as AudienceType | undefined;
+
+  const typicalAgeRange = useWatch({
+    control,
+    name: 'nameAndAgeRange.typicalAgeRange',
+  }) as string | undefined;
+
+  const getEventByIdQuery = useGetEventByIdQuery(
+    { id: offerId ?? '' },
+    { enabled: !!offerId },
+  );
+  const event: Event | undefined = getEventByIdQuery.data;
+
+  const changeAudienceMutation = useChangeAudienceMutation({
+    onError: () => {
+      setAudienceMutationError(
+        t('create.name_and_age.age.audience.mutation_error'),
+      );
+    },
+  });
 
   const useInitializeAgeRangeFields = (field: Field) => {
     useEffect(() => {
@@ -106,6 +163,31 @@ const AgeRangeStepBoa = ({
     field.onChange({ ...field.value, typicalAgeRange: apiLabel });
     onChange({ ...field.value, typicalAgeRange: apiLabel });
   };
+
+  const applyAudienceChange = (newType: AudienceType) => {
+    setAudienceMutationError(null);
+    setValue('audience', { audienceType: newType });
+    if (offerId) {
+      changeAudienceMutation.mutate({ eventId: offerId, audienceType: newType });
+    }
+  };
+
+  const handleAudienceClick = (newType: AudienceType) => {
+    if (newType === audienceType) return;
+    const isSwitchingAwayFromChildrenOnly =
+      audienceType === AudienceTypes.CHILDREN_ONLY &&
+      newType !== AudienceTypes.CHILDREN_ONLY;
+    const hasDeparturePlaces = !!event?.departurePlaces?.length;
+    if (isSwitchingAwayFromChildrenOnly && hasDeparturePlaces) {
+      setPendingAudienceChange(newType);
+      return;
+    }
+    applyAudienceChange(newType);
+  };
+
+  const showChildrenOnlySection =
+    audienceType !== AudienceTypes.EDUCATION &&
+    overlapsWithBoaAgeRange(typicalAgeRange);
 
   return (
     <Stack {...getStackProps(props)}>
@@ -208,7 +290,9 @@ const AgeRangeStepBoa = ({
                               }
                             `}
                           >
-                            {t(`create.name_and_age.age.${key.toLowerCase()}`)}
+                            {t(
+                              `create.name_and_age.age.${key.toLowerCase()}`,
+                            )}
                             <Text
                               css={css`
                                 color: ${getValue('rangeTextColor')};
@@ -221,6 +305,42 @@ const AgeRangeStepBoa = ({
                         );
                       })}
                   </Inline>
+                  {showChildrenOnlySection && (
+                    <Stack spacing={2} marginTop={3}>
+                      <Text fontWeight="bold">
+                        {t('create.name_and_age.age.audience.question')}
+                      </Text>
+                      <RadioButtonWithLabel
+                        id="audience-children-only"
+                        name="age-audience-type"
+                        checked={
+                          audienceType === AudienceTypes.CHILDREN_ONLY
+                        }
+                        label={t(
+                          'create.name_and_age.age.audience.children_only',
+                        )}
+                        onChange={() =>
+                          handleAudienceClick(AudienceTypes.CHILDREN_ONLY)
+                        }
+                      />
+                      <RadioButtonWithLabel
+                        id="audience-with-family"
+                        name="age-audience-type"
+                        checked={
+                          audienceType !== AudienceTypes.CHILDREN_ONLY
+                        }
+                        label={t(
+                          'create.name_and_age.age.audience.with_family',
+                        )}
+                        onChange={() =>
+                          handleAudienceClick(AudienceTypes.EVERYONE)
+                        }
+                      />
+                      {audienceMutationError && (
+                        <Text color="red">{audienceMutationError}</Text>
+                      )}
+                    </Stack>
+                  )}
                 </Stack>
               )}
             </Stack>

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { FormEvent, useEffect, useState } from 'react';
 import { Controller, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -5,8 +6,10 @@ import { css } from 'styled-components';
 
 import { AgeRanges } from '@/constants/AgeRange';
 import { AudienceType, AudienceTypes } from '@/constants/AudienceType';
+import { OfferTypes } from '@/constants/OfferType';
 import {
   useChangeAudienceMutation,
+  useChangeDeparturePlacesMutation,
   useGetEventByIdQuery,
 } from '@/hooks/api/events';
 import { FeatureFlags, useFeatureFlag } from '@/hooks/useFeatureFlag';
@@ -103,6 +106,7 @@ const AgeRangeStepBoa = ({
   ...props
 }: AgeRangeStepProps) => {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
 
   const [inputMode, setInputMode] = useState<AgeInputMode>(AgeInputModes.AGE);
   const [minAge, setMinAge] = useState('');
@@ -112,6 +116,13 @@ const AgeRangeStepBoa = ({
   const [audienceMutationError, setAudienceMutationError] = useState<
     string | null
   >(null);
+
+  const invalidateOfferQuery = () => {
+    if (!offerId) return;
+    queryClient.invalidateQueries({
+      queryKey: [OfferTypes.EVENTS, { id: offerId }],
+    });
+  };
 
   const audienceType = useWatch({
     control,
@@ -130,6 +141,16 @@ const AgeRangeStepBoa = ({
   const event: Event | undefined = getEventByIdQuery.data;
 
   const changeAudienceMutation = useChangeAudienceMutation({
+    onSuccess: invalidateOfferQuery,
+    onError: () => {
+      setAudienceMutationError(
+        t('create.name_and_age.age.audience.mutation_error'),
+      );
+    },
+  });
+
+  const changeDeparturePlacesMutation = useChangeDeparturePlacesMutation({
+    onSuccess: invalidateOfferQuery,
     onError: () => {
       setAudienceMutationError(
         t('create.name_and_age.age.audience.mutation_error'),
@@ -364,6 +385,12 @@ const AgeRangeStepBoa = ({
         onConfirm={() => {
           if (pendingAudienceChange) {
             applyAudienceChange(pendingAudienceChange);
+            if (offerId) {
+              changeDeparturePlacesMutation.mutate({
+                eventId: offerId,
+                departurePlaces: [],
+              });
+            }
             setPendingAudienceChange(null);
           }
         }}

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -349,22 +349,29 @@ const AgeRangeStepBoa = ({
                       ...field.value,
                       birthdateRange: undefined,
                     });
-                    onChange({ ...field.value, birthdateRange: undefined });
 
-                    if (offerId && previousBirthdateRange) {
-                      deleteBirthdateRangeMutation.mutate(
-                        { eventId: offerId, scope },
-                        {
-                          onError: () => {
-                            field.onChange({
-                              ...field.value,
-                              birthdateRange: previousBirthdateRange,
-                            });
-                            setInputMode(AgeInputModes.DATE_OF_BIRTH);
-                          },
-                        },
-                      );
+                    if (!offerId || !previousBirthdateRange) {
+                      return;
                     }
+
+                    deleteBirthdateRangeMutation.mutate(
+                      { eventId: offerId, scope },
+                      {
+                        onSuccess: () => {
+                          onChange({
+                            ...field.value,
+                            birthdateRange: undefined,
+                          });
+                        },
+                        onError: () => {
+                          field.onChange({
+                            ...field.value,
+                            birthdateRange: previousBirthdateRange,
+                          });
+                          setInputMode(AgeInputModes.DATE_OF_BIRTH);
+                        },
+                      },
+                    );
                   }}
                   options={Object.values(AgeInputModes).map((mode) => ({
                     value: mode,

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -142,6 +142,10 @@ const AgeRangeStepBoa = ({
     useState<AudienceType | null>(null);
   const [isMembersWarningModalVisible, setIsMembersWarningModalVisible] =
     useState(false);
+  const [pendingAgeRangeChange, setPendingAgeRangeChange] = useState<{
+    newValue: string;
+    previousValue: string;
+  } | null>(null);
   const [audienceMutationError, setAudienceMutationError] = useState<
     string | null
   >(null);
@@ -215,9 +219,19 @@ const AgeRangeStepBoa = ({
     min: string,
     max: string,
   ) => {
+    const previousValue = field.value?.typicalAgeRange ?? '';
+
     field.onChange({ ...field.value, typicalAgeRange: value });
 
     if (validateAgeRange(min, max)) return;
+
+    if (
+      audienceType === AudienceTypes.CHILDREN_ONLY &&
+      !overlapsWithBoaAgeRange(value)
+    ) {
+      setPendingAgeRangeChange({ newValue: value, previousValue });
+      return;
+    }
 
     onChange({ ...field.value, typicalAgeRange: value });
   };
@@ -604,6 +618,54 @@ const AgeRangeStepBoa = ({
         <Box padding={4}>
           <Text>
             {t('create.name_and_age.age.audience.members_warning_modal.body')}
+          </Text>
+        </Box>
+      </Modal>
+
+      <Modal
+        variant={ModalVariants.QUESTION}
+        size={ModalSizes.MD}
+        visible={pendingAgeRangeChange !== null}
+        title={t(
+          'create.name_and_age.age.audience.age_range_warning_modal.title',
+        )}
+        confirmTitle={t(
+          'create.name_and_age.age.audience.age_range_warning_modal.confirm',
+        )}
+        cancelTitle={t(
+          'create.name_and_age.age.audience.age_range_warning_modal.cancel',
+        )}
+        confirmButtonVariant={ButtonVariants.DANGER}
+        onClose={() => {
+          if (!pendingAgeRangeChange) return;
+          setValue(
+            'nameAndAgeRange.typicalAgeRange',
+            pendingAgeRangeChange.previousValue,
+          );
+          setPendingAgeRangeChange(null);
+        }}
+        onConfirm={async () => {
+          if (!pendingAgeRangeChange) return;
+          try {
+            await applyAudienceChange(AudienceTypes.EVERYONE);
+            if (offerId && event?.departurePlaces?.length) {
+              await changeDeparturePlacesMutation.mutateAsync({
+                eventId: offerId,
+                departurePlaces: [],
+              });
+            }
+            onChange({ typicalAgeRange: pendingAgeRangeChange.newValue });
+          } catch {
+            return;
+          }
+          setPendingAgeRangeChange(null);
+        }}
+      >
+        <Box padding={4}>
+          <Text>
+            {t(
+              'create.name_and_age.age.audience.age_range_warning_modal.body',
+            )}
           </Text>
         </Box>
       </Modal>

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -325,226 +325,288 @@ const AgeRangeStepBoa = ({
           const errorKey = validateAgeRange(minAge, maxAge);
 
           return (
-            <Stack spacing={2}>
-              <Text fontWeight="bold" paddingBottom={3}>
-                {t(`create.name_and_age.age.title_boa`)}
-              </Text>
-              <ToggleGroup
-                name="age-input-mode"
-                value={inputMode}
-                onChange={(newMode: string) => {
-                  const next = newMode as AgeInputMode;
-                  setInputMode(next);
+            <>
+              <Stack spacing={2}>
+                <Text fontWeight="bold" paddingBottom={3}>
+                  {t(`create.name_and_age.age.title_boa`)}
+                </Text>
+                <ToggleGroup
+                  name="age-input-mode"
+                  value={inputMode}
+                  onChange={(newMode: string) => {
+                    const next = newMode as AgeInputMode;
+                    setInputMode(next);
 
-                  if (next === AgeInputModes.DATE_OF_BIRTH) {
-                    setMinBirthDate((current) => current ?? new Date());
-                    setMaxBirthDate((current) => current ?? new Date());
-                    return;
-                  }
+                    if (next === AgeInputModes.DATE_OF_BIRTH) {
+                      setMinBirthDate((current) => current ?? new Date());
+                      setMaxBirthDate((current) => current ?? new Date());
+                      return;
+                    }
 
-                  const previousBirthdateRange = field.value?.birthdateRange;
+                    const previousBirthdateRange = field.value?.birthdateRange;
 
-                  field.onChange({ ...field.value, birthdateRange: undefined });
-                  onChange({ ...field.value, birthdateRange: undefined });
+                    field.onChange({
+                      ...field.value,
+                      birthdateRange: undefined,
+                    });
+                    onChange({ ...field.value, birthdateRange: undefined });
 
-                  if (offerId && previousBirthdateRange) {
-                    deleteBirthdateRangeMutation.mutate(
-                      { eventId: offerId, scope },
-                      {
-                        onError: () => {
-                          field.onChange({
-                            ...field.value,
-                            birthdateRange: previousBirthdateRange,
-                          });
-                          setInputMode(AgeInputModes.DATE_OF_BIRTH);
+                    if (offerId && previousBirthdateRange) {
+                      deleteBirthdateRangeMutation.mutate(
+                        { eventId: offerId, scope },
+                        {
+                          onError: () => {
+                            field.onChange({
+                              ...field.value,
+                              birthdateRange: previousBirthdateRange,
+                            });
+                            setInputMode(AgeInputModes.DATE_OF_BIRTH);
+                          },
                         },
-                      },
-                    );
-                  }
-                }}
-                options={Object.values(AgeInputModes).map((mode) => ({
-                  value: mode,
-                  label: t(`create.name_and_age.age.input_mode.${mode}`),
-                }))}
-                maxWidth="40rem"
-                css={`
-                  margin-bottom: 2rem;
-                `}
-              />
-              {inputMode === AgeInputModes.DATE_OF_BIRTH ? (
-                <Stack spacing={3} maxWidth="40rem" paddingLeft={5}>
-                  <Text fontWeight="bold">
-                    {t('create.name_and_age.age.birth_date.title')}
-                  </Text>
-                  <Inline spacing={3} alignItems="flex-end">
-                    <Stack spacing={2}>
-                      <Label
-                        variant={LabelVariants.BOLD}
-                        htmlFor="age-birth-date-min"
-                      >
-                        {t('create.name_and_age.age.birth_date.from')}
-                      </Label>
-                      <DatePicker
-                        id="age-birth-date-min"
-                        selected={minBirthDate}
-                        onChange={(date) =>
-                          commitBirthdateRange(field, date, maxBirthDate)
-                        }
+                      );
+                    }
+                  }}
+                  options={Object.values(AgeInputModes).map((mode) => ({
+                    value: mode,
+                    label: t(`create.name_and_age.age.input_mode.${mode}`),
+                  }))}
+                  maxWidth="40rem"
+                  css={`
+                    margin-bottom: 2rem;
+                  `}
+                />
+                {inputMode === AgeInputModes.DATE_OF_BIRTH ? (
+                  <Stack spacing={3} maxWidth="40rem" paddingLeft={5}>
+                    <Text fontWeight="bold">
+                      {t('create.name_and_age.age.birth_date.title')}
+                    </Text>
+                    <Inline spacing={3} alignItems="flex-end">
+                      <Stack spacing={2}>
+                        <Label
+                          variant={LabelVariants.BOLD}
+                          htmlFor="age-birth-date-min"
+                        >
+                          {t('create.name_and_age.age.birth_date.from')}
+                        </Label>
+                        <DatePicker
+                          id="age-birth-date-min"
+                          selected={minBirthDate}
+                          onChange={(date) =>
+                            commitBirthdateRange(field, date, maxBirthDate)
+                          }
+                        />
+                      </Stack>
+                      <Stack spacing={2}>
+                        <Label
+                          variant={LabelVariants.BOLD}
+                          htmlFor="age-birth-date-max"
+                        >
+                          {t('create.name_and_age.age.birth_date.to')}
+                        </Label>
+                        <DatePicker
+                          id="age-birth-date-max"
+                          selected={maxBirthDate}
+                          onChange={(date) =>
+                            commitBirthdateRange(field, minBirthDate, date)
+                          }
+                        />
+                      </Stack>
+                    </Inline>
+                    {minBirthDate &&
+                      maxBirthDate &&
+                      isBefore(
+                        startOfDay(maxBirthDate),
+                        startOfDay(minBirthDate),
+                      ) && (
+                        <Text color="red">
+                          {t(
+                            'create.name_and_age.age.birth_date.error_max_before_min',
+                          )}
+                        </Text>
+                      )}
+                  </Stack>
+                ) : (
+                  <Stack spacing={3} maxWidth="40rem" paddingLeft={5}>
+                    <Text fontWeight="bold">
+                      {t('create.name_and_age.age.input_range_title')}
+                    </Text>
+                    <Inline spacing={3}>
+                      <Input
+                        type="numeric"
+                        value={minAge}
+                        placeholder={t('create.name_and_age.age.from')}
+                        aria-label={t('create.name_and_age.age.from')}
+                        maxWidth="8rem"
+                        onChange={(event: FormEvent<HTMLInputElement>) => {
+                          setMinAge((event.target as HTMLInputElement).value);
+                        }}
+                        onBlur={(event: FormEvent<HTMLInputElement>) => {
+                          commitAgeRange(
+                            field,
+                            (event.target as HTMLInputElement).value,
+                            maxAge,
+                          );
+                        }}
                       />
-                    </Stack>
-                    <Stack spacing={2}>
-                      <Label
-                        variant={LabelVariants.BOLD}
-                        htmlFor="age-birth-date-max"
-                      >
-                        {t('create.name_and_age.age.birth_date.to')}
-                      </Label>
-                      <DatePicker
-                        id="age-birth-date-max"
-                        selected={maxBirthDate}
-                        onChange={(date) =>
-                          commitBirthdateRange(field, minBirthDate, date)
-                        }
+                      <Input
+                        type="numeric"
+                        value={maxAge}
+                        placeholder={t('create.name_and_age.age.till')}
+                        aria-label={t('create.name_and_age.age.till')}
+                        maxWidth="8rem"
+                        onChange={(event: FormEvent<HTMLInputElement>) => {
+                          setMaxAge((event.target as HTMLInputElement).value);
+                        }}
+                        onBlur={(event: FormEvent<HTMLInputElement>) => {
+                          commitAgeRange(
+                            field,
+                            minAge,
+                            (event.target as HTMLInputElement).value,
+                          );
+                        }}
                       />
-                    </Stack>
-                  </Inline>
-                  {minBirthDate &&
-                    maxBirthDate &&
-                    isBefore(
-                      startOfDay(maxBirthDate),
-                      startOfDay(minBirthDate),
-                    ) && (
-                      <Text color="red">
-                        {t(
-                          'create.name_and_age.age.birth_date.error_max_before_min',
-                        )}
-                      </Text>
-                    )}
-                </Stack>
-              ) : (
-                <Stack spacing={3} maxWidth="40rem" paddingLeft={5}>
-                  <Text fontWeight="bold">
-                    {t('create.name_and_age.age.input_range_title')}
-                  </Text>
-                  <Inline spacing={3}>
-                    <Input
-                      type="numeric"
-                      value={minAge}
-                      placeholder={t('create.name_and_age.age.from')}
-                      aria-label={t('create.name_and_age.age.from')}
-                      maxWidth="8rem"
-                      onChange={(event: FormEvent<HTMLInputElement>) => {
-                        setMinAge((event.target as HTMLInputElement).value);
-                      }}
-                      onBlur={(event: FormEvent<HTMLInputElement>) => {
-                        commitAgeRange(
-                          field,
-                          (event.target as HTMLInputElement).value,
-                          maxAge,
-                        );
-                      }}
-                    />
-                    <Input
-                      type="numeric"
-                      value={maxAge}
-                      placeholder={t('create.name_and_age.age.till')}
-                      aria-label={t('create.name_and_age.age.till')}
-                      maxWidth="8rem"
-                      onChange={(event: FormEvent<HTMLInputElement>) => {
-                        setMaxAge((event.target as HTMLInputElement).value);
-                      }}
-                      onBlur={(event: FormEvent<HTMLInputElement>) => {
-                        commitAgeRange(
-                          field,
-                          minAge,
-                          (event.target as HTMLInputElement).value,
-                        );
-                      }}
-                    />
-                  </Inline>
-                  {errorKey && <Text color="red">{t(errorKey)}</Text>}
-                  <Inline
-                    spacing={3}
-                    flexWrap="wrap"
-                    css={`
-                      row-gap: 0.5rem;
-                    `}
-                  >
-                    {Object.keys(AgeRanges)
-                      .filter((key) => AgeRanges[key].apiLabel)
-                      .map((key) => {
-                        const apiLabel = AgeRanges[key].apiLabel!;
-                        return (
-                          <Button
-                            key={key}
-                            width="auto"
-                            active={selectedPreset === key}
-                            display="inline-flex"
-                            variant={ButtonVariants.SECONDARY_TOGGLE}
-                            onClick={() => handlePresetClick(field, apiLabel)}
-                            css={`
-                              &.btn {
-                                padding: 0.3rem 0.7rem;
-                                box-shadow: ${({ theme }) =>
-                                  theme.components.global.boxShadow.heavy};
-                              }
-                            `}
-                          >
-                            {t(`create.name_and_age.age.${key.toLowerCase()}`)}
-                            <Text
-                              css={css`
-                                color: ${getValue('rangeTextColor')};
-                                font-size: 0.9rem;
-                              `}
-                            >
-                              &nbsp; {AgeRanges[key].label ?? ''}
-                            </Text>
-                          </Button>
-                        );
-                      })}
-                  </Inline>
-                  {showChildrenOnlySection && (
-                    <Stack
-                      spacing={2}
-                      marginTop={4}
-                      paddingTop={4}
+                    </Inline>
+                    {errorKey && <Text color="red">{t(errorKey)}</Text>}
+                    <Inline
+                      spacing={3}
+                      flexWrap="wrap"
                       css={`
-                        border-top: 1px solid ${colors.grey3};
+                        row-gap: 0.5rem;
                       `}
                     >
-                      <Text fontWeight="bold">
-                        {t('create.name_and_age.age.audience.question')}
-                      </Text>
-                      <RadioButtonWithLabel
-                        id="audience-children-only"
-                        name="age-audience-type"
-                        checked={audienceType === AudienceTypes.CHILDREN_ONLY}
-                        label={t(
-                          'create.name_and_age.age.audience.children_only',
+                      {Object.keys(AgeRanges)
+                        .filter((key) => AgeRanges[key].apiLabel)
+                        .map((key) => {
+                          const apiLabel = AgeRanges[key].apiLabel!;
+                          return (
+                            <Button
+                              key={key}
+                              width="auto"
+                              active={selectedPreset === key}
+                              display="inline-flex"
+                              variant={ButtonVariants.SECONDARY_TOGGLE}
+                              onClick={() => handlePresetClick(field, apiLabel)}
+                              css={`
+                                &.btn {
+                                  padding: 0.3rem 0.7rem;
+                                  box-shadow: ${({ theme }) =>
+                                    theme.components.global.boxShadow.heavy};
+                                }
+                              `}
+                            >
+                              {t(
+                                `create.name_and_age.age.${key.toLowerCase()}`,
+                              )}
+                              <Text
+                                css={css`
+                                  color: ${getValue('rangeTextColor')};
+                                  font-size: 0.9rem;
+                                `}
+                              >
+                                &nbsp; {AgeRanges[key].label ?? ''}
+                              </Text>
+                            </Button>
+                          );
+                        })}
+                    </Inline>
+                    {showChildrenOnlySection && (
+                      <Stack
+                        spacing={2}
+                        marginTop={4}
+                        paddingTop={4}
+                        css={`
+                          border-top: 1px solid ${colors.grey3};
+                        `}
+                      >
+                        <Text fontWeight="bold">
+                          {t('create.name_and_age.age.audience.question')}
+                        </Text>
+                        <RadioButtonWithLabel
+                          id="audience-children-only"
+                          name="age-audience-type"
+                          checked={audienceType === AudienceTypes.CHILDREN_ONLY}
+                          label={t(
+                            'create.name_and_age.age.audience.children_only',
+                          )}
+                          onChange={() =>
+                            handleAudienceClick(AudienceTypes.CHILDREN_ONLY)
+                          }
+                        />
+                        <RadioButtonWithLabel
+                          id="audience-with-family"
+                          name="age-audience-type"
+                          checked={audienceType !== AudienceTypes.CHILDREN_ONLY}
+                          label={t(
+                            'create.name_and_age.age.audience.with_family',
+                          )}
+                          onChange={() =>
+                            handleAudienceClick(AudienceTypes.EVERYONE)
+                          }
+                        />
+                        {audienceMutationError && (
+                          <Text color="red">{audienceMutationError}</Text>
                         )}
-                        onChange={() =>
-                          handleAudienceClick(AudienceTypes.CHILDREN_ONLY)
-                        }
-                      />
-                      <RadioButtonWithLabel
-                        id="audience-with-family"
-                        name="age-audience-type"
-                        checked={audienceType !== AudienceTypes.CHILDREN_ONLY}
-                        label={t(
-                          'create.name_and_age.age.audience.with_family',
-                        )}
-                        onChange={() =>
-                          handleAudienceClick(AudienceTypes.EVERYONE)
-                        }
-                      />
-                      {audienceMutationError && (
-                        <Text color="red">{audienceMutationError}</Text>
-                      )}
-                    </Stack>
-                  )}
-                </Stack>
-              )}
-            </Stack>
+                      </Stack>
+                    )}
+                  </Stack>
+                )}
+              </Stack>
+
+              <Modal
+                variant={ModalVariants.QUESTION}
+                size={ModalSizes.MD}
+                visible={pendingAgeRangeChange !== null}
+                title={t(
+                  'create.name_and_age.age.audience.age_range_warning_modal.title',
+                )}
+                confirmTitle={t(
+                  'create.name_and_age.age.audience.age_range_warning_modal.confirm',
+                )}
+                cancelTitle={t(
+                  'create.name_and_age.age.audience.age_range_warning_modal.cancel',
+                )}
+                confirmButtonVariant={ButtonVariants.DANGER}
+                onClose={() => {
+                  if (!pendingAgeRangeChange) return;
+                  const { previousValue } = pendingAgeRangeChange;
+                  field.onChange({
+                    ...field.value,
+                    typicalAgeRange: previousValue,
+                  });
+                  const [min, max] = previousValue.split('-');
+                  setMinAge(min ?? '');
+                  setMaxAge(max ?? '');
+                  setPendingAgeRangeChange(null);
+                }}
+                onConfirm={async () => {
+                  if (!pendingAgeRangeChange) return;
+                  try {
+                    await applyAudienceChange(AudienceTypes.EVERYONE);
+                    if (offerId && event?.departurePlaces?.length) {
+                      await changeDeparturePlacesMutation.mutateAsync({
+                        eventId: offerId,
+                        departurePlaces: [],
+                      });
+                    }
+                    onChange({
+                      ...field.value,
+                      typicalAgeRange: pendingAgeRangeChange.newValue,
+                    });
+                  } catch {
+                    return;
+                  }
+                  setPendingAgeRangeChange(null);
+                }}
+              >
+                <Box padding={4}>
+                  <Text>
+                    {t(
+                      'create.name_and_age.age.audience.age_range_warning_modal.body',
+                    )}
+                  </Text>
+                </Box>
+              </Modal>
+            </>
           );
         }}
       />
@@ -618,54 +680,6 @@ const AgeRangeStepBoa = ({
         <Box padding={4}>
           <Text>
             {t('create.name_and_age.age.audience.members_warning_modal.body')}
-          </Text>
-        </Box>
-      </Modal>
-
-      <Modal
-        variant={ModalVariants.QUESTION}
-        size={ModalSizes.MD}
-        visible={pendingAgeRangeChange !== null}
-        title={t(
-          'create.name_and_age.age.audience.age_range_warning_modal.title',
-        )}
-        confirmTitle={t(
-          'create.name_and_age.age.audience.age_range_warning_modal.confirm',
-        )}
-        cancelTitle={t(
-          'create.name_and_age.age.audience.age_range_warning_modal.cancel',
-        )}
-        confirmButtonVariant={ButtonVariants.DANGER}
-        onClose={() => {
-          if (!pendingAgeRangeChange) return;
-          setValue(
-            'nameAndAgeRange.typicalAgeRange',
-            pendingAgeRangeChange.previousValue,
-          );
-          setPendingAgeRangeChange(null);
-        }}
-        onConfirm={async () => {
-          if (!pendingAgeRangeChange) return;
-          try {
-            await applyAudienceChange(AudienceTypes.EVERYONE);
-            if (offerId && event?.departurePlaces?.length) {
-              await changeDeparturePlacesMutation.mutateAsync({
-                eventId: offerId,
-                departurePlaces: [],
-              });
-            }
-            onChange({ typicalAgeRange: pendingAgeRangeChange.newValue });
-          } catch {
-            return;
-          }
-          setPendingAgeRangeChange(null);
-        }}
-      >
-        <Box padding={4}>
-          <Text>
-            {t(
-              'create.name_and_age.age.audience.age_range_warning_modal.body',
-            )}
           </Text>
         </Box>
       </Modal>

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -138,14 +138,12 @@ const AgeRangeStepBoa = ({
   const [maxAge, setMaxAge] = useState('');
   const [minBirthDate, setMinBirthDate] = useState<Date | undefined>(undefined);
   const [maxBirthDate, setMaxBirthDate] = useState<Date | undefined>(undefined);
-  const [pendingAudienceChange, setPendingAudienceChange] =
-    useState<AudienceType | null>(null);
-  const [isMembersWarningModalVisible, setIsMembersWarningModalVisible] =
-    useState(false);
-  const [pendingAgeRangeChange, setPendingAgeRangeChange] = useState<{
-    newValue: string;
-    previousValue: string;
-  } | null>(null);
+  type ActiveModal =
+    | { kind: 'departurePlaces'; targetAudience: AudienceType }
+    | { kind: 'members' }
+    | { kind: 'ageRange'; newValue: string; previousValue: string };
+  const [activeModal, setActiveModal] = useState<ActiveModal | null>(null);
+  const closeModal = () => setActiveModal(null);
   const [audienceMutationError, setAudienceMutationError] = useState<
     string | null
   >(null);
@@ -232,7 +230,7 @@ const AgeRangeStepBoa = ({
       audienceType === AudienceTypes.CHILDREN_ONLY &&
       !overlapsWithBoaAgeRange(value)
     ) {
-      setPendingAgeRangeChange({ newValue: value, previousValue });
+      setActiveModal({ kind: 'ageRange', newValue: value, previousValue });
       return;
     }
 
@@ -300,7 +298,7 @@ const AgeRangeStepBoa = ({
       newType === AudienceTypes.CHILDREN_ONLY &&
       audienceType === AudienceTypes.MEMBERS
     ) {
-      setIsMembersWarningModalVisible(true);
+      setActiveModal({ kind: 'members' });
       return;
     }
     const isSwitchingAwayFromChildrenOnly =
@@ -308,7 +306,7 @@ const AgeRangeStepBoa = ({
       newType !== AudienceTypes.CHILDREN_ONLY;
     const hasDeparturePlaces = !!event?.departurePlaces?.length;
     if (isSwitchingAwayFromChildrenOnly && hasDeparturePlaces) {
-      setPendingAudienceChange(newType);
+      setActiveModal({ kind: 'departurePlaces', targetAudience: newType });
       return;
     }
     applyAudienceChange(newType).catch(() => undefined);
@@ -568,7 +566,7 @@ const AgeRangeStepBoa = ({
               <Modal
                 variant={ModalVariants.QUESTION}
                 size={ModalSizes.MD}
-                visible={pendingAgeRangeChange !== null}
+                visible={activeModal?.kind === 'ageRange'}
                 title={t(
                   'create.name_and_age.age.audience.age_range_warning_modal.title',
                 )}
@@ -580,8 +578,8 @@ const AgeRangeStepBoa = ({
                 )}
                 confirmButtonVariant={ButtonVariants.DANGER}
                 onClose={() => {
-                  if (!pendingAgeRangeChange) return;
-                  const { previousValue } = pendingAgeRangeChange;
+                  if (activeModal?.kind !== 'ageRange') return;
+                  const { previousValue } = activeModal;
                   field.onChange({
                     ...field.value,
                     typicalAgeRange: previousValue,
@@ -589,11 +587,12 @@ const AgeRangeStepBoa = ({
                   const [min, max] = previousValue.split('-');
                   setMinAge(min ?? '');
                   setMaxAge(max ?? '');
-                  setPendingAgeRangeChange(null);
+                  closeModal();
                 }}
                 onConfirm={async () => {
                   if (isAudiencePending) return;
-                  if (!pendingAgeRangeChange) return;
+                  if (activeModal?.kind !== 'ageRange') return;
+                  const { newValue } = activeModal;
                   try {
                     await applyAudienceChange(AudienceTypes.EVERYONE);
                     if (offerId && event?.departurePlaces?.length) {
@@ -604,12 +603,12 @@ const AgeRangeStepBoa = ({
                     }
                     onChange({
                       ...field.value,
-                      typicalAgeRange: pendingAgeRangeChange.newValue,
+                      typicalAgeRange: newValue,
                     });
                   } catch {
                     return;
                   }
-                  setPendingAgeRangeChange(null);
+                  closeModal();
                 }}
               >
                 <Box padding={4}>
@@ -628,7 +627,7 @@ const AgeRangeStepBoa = ({
       <Modal
         variant={ModalVariants.QUESTION}
         size={ModalSizes.MD}
-        visible={pendingAudienceChange !== null}
+        visible={activeModal?.kind === 'departurePlaces'}
         title={t(
           'create.name_and_age.age.audience.departure_places_warning_modal.title',
         )}
@@ -639,12 +638,12 @@ const AgeRangeStepBoa = ({
           'create.name_and_age.age.audience.departure_places_warning_modal.cancel',
         )}
         confirmButtonVariant={ButtonVariants.DANGER}
-        onClose={() => setPendingAudienceChange(null)}
+        onClose={closeModal}
         onConfirm={async () => {
           if (isAudiencePending) return;
-          if (!pendingAudienceChange) return;
+          if (activeModal?.kind !== 'departurePlaces') return;
           try {
-            await applyAudienceChange(pendingAudienceChange);
+            await applyAudienceChange(activeModal.targetAudience);
             if (offerId) {
               await changeDeparturePlacesMutation.mutateAsync({
                 eventId: offerId,
@@ -656,7 +655,7 @@ const AgeRangeStepBoa = ({
             // bail out and keep the modal open so the user can retry.
             return;
           }
-          setPendingAudienceChange(null);
+          closeModal();
         }}
       >
         <Box padding={4}>
@@ -671,7 +670,7 @@ const AgeRangeStepBoa = ({
       <Modal
         variant={ModalVariants.QUESTION}
         size={ModalSizes.MD}
-        visible={isMembersWarningModalVisible}
+        visible={activeModal?.kind === 'members'}
         title={t(
           'create.name_and_age.age.audience.members_warning_modal.title',
         )}
@@ -682,7 +681,7 @@ const AgeRangeStepBoa = ({
           'create.name_and_age.age.audience.members_warning_modal.cancel',
         )}
         confirmButtonVariant={ButtonVariants.DANGER}
-        onClose={() => setIsMembersWarningModalVisible(false)}
+        onClose={closeModal}
         onConfirm={async () => {
           if (isAudiencePending) return;
           try {
@@ -690,7 +689,7 @@ const AgeRangeStepBoa = ({
           } catch {
             return;
           }
-          setIsMembersWarningModalVisible(false);
+          closeModal();
         }}
       >
         <Box padding={4}>

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -140,6 +140,8 @@ const AgeRangeStepBoa = ({
   const [maxBirthDate, setMaxBirthDate] = useState<Date | undefined>(undefined);
   const [pendingAudienceChange, setPendingAudienceChange] =
     useState<AudienceType | null>(null);
+  const [isMembersWarningModalVisible, setIsMembersWarningModalVisible] =
+    useState(false);
   const [audienceMutationError, setAudienceMutationError] = useState<
     string | null
   >(null);
@@ -276,6 +278,13 @@ const AgeRangeStepBoa = ({
 
   const handleAudienceClick = (newType: AudienceType) => {
     if (newType === audienceType) return;
+    if (
+      newType === AudienceTypes.CHILDREN_ONLY &&
+      audienceType === AudienceTypes.MEMBERS
+    ) {
+      setIsMembersWarningModalVisible(true);
+      return;
+    }
     const isSwitchingAwayFromChildrenOnly =
       audienceType === AudienceTypes.CHILDREN_ONLY &&
       newType !== AudienceTypes.CHILDREN_ONLY;
@@ -564,6 +573,37 @@ const AgeRangeStepBoa = ({
             {t(
               'create.name_and_age.age.audience.departure_places_warning_modal.body',
             )}
+          </Text>
+        </Box>
+      </Modal>
+
+      <Modal
+        variant={ModalVariants.QUESTION}
+        size={ModalSizes.MD}
+        visible={isMembersWarningModalVisible}
+        title={t(
+          'create.name_and_age.age.audience.members_warning_modal.title',
+        )}
+        confirmTitle={t(
+          'create.name_and_age.age.audience.members_warning_modal.confirm',
+        )}
+        cancelTitle={t(
+          'create.name_and_age.age.audience.members_warning_modal.cancel',
+        )}
+        confirmButtonVariant={ButtonVariants.DANGER}
+        onClose={() => setIsMembersWarningModalVisible(false)}
+        onConfirm={async () => {
+          try {
+            await applyAudienceChange(AudienceTypes.CHILDREN_ONLY);
+          } catch {
+            return;
+          }
+          setIsMembersWarningModalVisible(false);
+        }}
+      >
+        <Box padding={4}>
+          <Text>
+            {t('create.name_and_age.age.audience.members_warning_modal.body')}
           </Text>
         </Box>
       </Modal>

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -183,15 +183,14 @@ const AgeRangeStepBoa = ({
     onChange({ ...field.value, typicalAgeRange: apiLabel });
   };
 
-  const applyAudienceChange = (newType: AudienceType) => {
+  const applyAudienceChange = async (newType: AudienceType) => {
     setAudienceMutationError(null);
     setValue('audience', { audienceType: newType });
-    if (offerId) {
-      changeAudienceMutation.mutate({
-        eventId: offerId,
-        audienceType: newType,
-      });
-    }
+    if (!offerId) return;
+    await changeAudienceMutation.mutateAsync({
+      eventId: offerId,
+      audienceType: newType,
+    });
   };
 
   const handleAudienceClick = (newType: AudienceType) => {
@@ -204,7 +203,7 @@ const AgeRangeStepBoa = ({
       setPendingAudienceChange(newType);
       return;
     }
-    applyAudienceChange(newType);
+    applyAudienceChange(newType).catch(() => undefined);
   };
 
   const showChildrenOnlySection =
@@ -386,17 +385,22 @@ const AgeRangeStepBoa = ({
         )}
         confirmButtonVariant={ButtonVariants.DANGER}
         onClose={() => setPendingAudienceChange(null)}
-        onConfirm={() => {
-          if (pendingAudienceChange) {
-            applyAudienceChange(pendingAudienceChange);
+        onConfirm={async () => {
+          if (!pendingAudienceChange) return;
+          try {
+            await applyAudienceChange(pendingAudienceChange);
             if (offerId) {
-              changeDeparturePlacesMutation.mutate({
+              await changeDeparturePlacesMutation.mutateAsync({
                 eventId: offerId,
                 departurePlaces: [],
               });
             }
-            setPendingAudienceChange(null);
+          } catch {
+            // Failure already surfaced inline via the mutation's onError —
+            // bail out and keep the modal open so the user can retry.
+            return;
           }
+          setPendingAudienceChange(null);
         }}
       >
         <Box padding={4}>

--- a/src/pages/steps/AgeRangeStep.tsx
+++ b/src/pages/steps/AgeRangeStep.tsx
@@ -195,6 +195,9 @@ const AgeRangeStepBoa = ({
     },
   });
 
+  const isAudiencePending =
+    changeAudienceMutation.isPending || changeDeparturePlacesMutation.isPending;
+
   useEffect(() => {
     if (!watchedTypicalAgeRange) return;
 
@@ -291,6 +294,7 @@ const AgeRangeStepBoa = ({
   };
 
   const handleAudienceClick = (newType: AudienceType) => {
+    if (isAudiencePending) return;
     if (newType === audienceType) return;
     if (
       newType === AudienceTypes.CHILDREN_ONLY &&
@@ -532,6 +536,7 @@ const AgeRangeStepBoa = ({
                           id="audience-children-only"
                           name="age-audience-type"
                           checked={audienceType === AudienceTypes.CHILDREN_ONLY}
+                          disabled={isAudiencePending}
                           label={t(
                             'create.name_and_age.age.audience.children_only',
                           )}
@@ -543,6 +548,7 @@ const AgeRangeStepBoa = ({
                           id="audience-with-family"
                           name="age-audience-type"
                           checked={audienceType !== AudienceTypes.CHILDREN_ONLY}
+                          disabled={isAudiencePending}
                           label={t(
                             'create.name_and_age.age.audience.with_family',
                           )}
@@ -586,6 +592,7 @@ const AgeRangeStepBoa = ({
                   setPendingAgeRangeChange(null);
                 }}
                 onConfirm={async () => {
+                  if (isAudiencePending) return;
                   if (!pendingAgeRangeChange) return;
                   try {
                     await applyAudienceChange(AudienceTypes.EVERYONE);
@@ -634,6 +641,7 @@ const AgeRangeStepBoa = ({
         confirmButtonVariant={ButtonVariants.DANGER}
         onClose={() => setPendingAudienceChange(null)}
         onConfirm={async () => {
+          if (isAudiencePending) return;
           if (!pendingAudienceChange) return;
           try {
             await applyAudienceChange(pendingAudienceChange);
@@ -676,6 +684,7 @@ const AgeRangeStepBoa = ({
         confirmButtonVariant={ButtonVariants.DANGER}
         onClose={() => setIsMembersWarningModalVisible(false)}
         onConfirm={async () => {
+          if (isAudiencePending) return;
           try {
             await applyAudienceChange(AudienceTypes.CHILDREN_ONLY);
           } catch {

--- a/src/pages/steps/AudienceStep.tsx
+++ b/src/pages/steps/AudienceStep.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/hooks/api/events';
 import { ValidationStatus } from '@/pages/steps/AdditionalInformationStep/AdditionalInformationStep';
 import { Event } from '@/types/Event';
+import { Alert, AlertVariants } from '@/ui/Alert';
 import { FormElement } from '@/ui/FormElement';
 import { RadioButtonWithLabel } from '@/ui/RadioButtonWithLabel';
 import { getStackProps, Stack, StackProps } from '@/ui/Stack';
@@ -46,6 +47,7 @@ const AudienceStep = ({
   });
 
   const watchedAudienceType = useWatch({ control, name: 'audienceType' });
+  const isChildrenOnly = watchedAudienceType === AudienceTypes.CHILDREN_ONLY;
 
   const getEventByIdQuery = useGetEventByIdQuery({ id: offerId });
 
@@ -78,8 +80,16 @@ const AudienceStep = ({
         <Text fontWeight="bold">
           {t('create.additionalInformation.audience.title')}
         </Text>
+        {isChildrenOnly && (
+          <Alert variant={AlertVariants.WARNING}>
+            {t('create.additionalInformation.audience.children_only_warning')}
+          </Alert>
+        )}
         {Object.values(AudienceTypes)
           .filter((type) => type !== AudienceTypes.EDUCATION)
+          .filter(
+            (type) => type !== AudienceTypes.CHILDREN_ONLY || isChildrenOnly,
+          )
           .map((type, index) => {
             return (
               <Fragment key={index}>
@@ -90,12 +100,14 @@ const AudienceStep = ({
                       {...register(`audienceType`)}
                       label={t(`create.additionalInformation.audience.${type}`)}
                       checked={watchedAudienceType === type}
+                      disabled={isChildrenOnly}
                       onChange={() => handleOnChangeAudience(type)}
                     />
                   }
                 />
                 {watchedAudienceType === type &&
-                  watchedAudienceType !== AudienceTypes.EVERYONE && (
+                  watchedAudienceType !== AudienceTypes.EVERYONE &&
+                  watchedAudienceType !== AudienceTypes.CHILDREN_ONLY && (
                     <Text variant="muted" maxWidth="30%">
                       {t(
                         `create.additionalInformation.audience.help.${watchedAudienceType}`,

--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { Controller } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
@@ -90,7 +89,6 @@ const NameAndAgeRangeStep = ({
   ...props
 }: StepProps) => {
   const { t } = useTranslation();
-  const router = useRouter();
 
   const errorBody = error?.body as DuplicatePlaceErrorBody;
   const errorMessage = error?.message;
@@ -154,6 +152,8 @@ const NameAndAgeRangeStep = ({
                 {...getStepProps(props)}
                 name={name}
                 control={control}
+                offerId={offerId}
+                setValue={setValue}
               />
             )}
             {isCultuurkuurEvent && !levels.isLoading && (

--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -140,7 +140,7 @@ const NameAndAgeRangeStep = ({
       name={name}
       render={() => {
         return (
-          <Stack spacing={4} maxWidth={parseSpacing(11)}>
+          <Stack spacing={5} maxWidth={parseSpacing(11)}>
             <NameStep
               {...getStepProps(props)}
               name={name}

--- a/src/test/e2e/events/event-age-range.spec.ts
+++ b/src/test/e2e/events/event-age-range.spec.ts
@@ -37,10 +37,22 @@ const minAgeInput = (page: Page) =>
 const maxAgeInput = (page: Page) =>
   page.getByPlaceholder(age.till, { exact: true });
 
+const childrenOnlyRadio = (page: Page) =>
+  page.locator('#audience-children-only');
+const withFamilyRadio = (page: Page) => page.locator('#audience-with-family');
+
 const waitForTypicalAgeRangePut = (page: Page) =>
   page.waitForResponse(
     (response) =>
       response.url().includes('/typicalAgeRange') &&
+      response.request().method() === 'PUT' &&
+      response.ok(),
+  );
+
+const waitForAudiencePut = (page: Page) =>
+  page.waitForResponse(
+    (response) =>
+      /\/events\/[a-f0-9-]+\/audience$/.test(response.url()) &&
       response.request().method() === 'PUT' &&
       response.ok(),
   );
@@ -160,5 +172,173 @@ test.describe('Age range', () => {
     await expect(page.getByText(age.error_invalid)).toBeHidden();
     await expect(minAgeInput(page)).toHaveValue('18');
     await expect(maxAgeInput(page)).toHaveValue('');
+  });
+
+  test('shows the children-only radios only when the age overlaps 2–12', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // Initial "Volwassenen 18+" range does not overlap BOA → section hidden.
+    await expect(minAgeInput(page)).toHaveValue('18');
+    await expect(childrenOnlyRadio(page)).toBeHidden();
+
+    // Switch to "Kinderen 6-11" → overlaps BOA → section appears.
+    const put = waitForTypicalAgeRangePut(page);
+    await page.getByRole('button', { name: new RegExp(age.kids) }).click();
+    await put;
+
+    await expect(childrenOnlyRadio(page)).toBeVisible();
+    await expect(withFamilyRadio(page)).toBeVisible();
+    await expect(withFamilyRadio(page)).toBeChecked();
+  });
+
+  test('persists the "for children only" audience across a reload', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    const ageRangePut = waitForTypicalAgeRangePut(page);
+    await page.getByRole('button', { name: new RegExp(age.kids) }).click();
+    await ageRangePut;
+
+    const audiencePut = waitForAudiencePut(page);
+    await childrenOnlyRadio(page).click();
+    await audiencePut;
+
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+
+    await page.goto(eventEditUrl);
+
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+  });
+
+  test('age outside 2–12 while "children only": confirm resets audience and saves the new age', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // Setup: 6-11 + children only.
+    const ageRangePut = waitForTypicalAgeRangePut(page);
+    await page.getByRole('button', { name: new RegExp(age.kids) }).click();
+    await ageRangePut;
+
+    const audiencePut = waitForAudiencePut(page);
+    await childrenOnlyRadio(page).click();
+    await audiencePut;
+    // Wait for the audience update to commit into the tree before clicking the
+    // next preset — otherwise commitTypicalAgeRange may still read a stale
+    // audienceType from useWatch and skip the warning modal.
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+
+    // Move out of BOA range — preset "Volwassenen 18+" triggers the warning.
+    await page.getByRole('button', { name: new RegExp(age.adults) }).click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(
+      age.audience.age_range_warning_modal.body,
+    );
+
+    // Confirm: audience reset PUT + typicalAgeRange PUT both fire.
+    const confirmAudiencePut = waitForAudiencePut(page);
+    const confirmAgePut = waitForTypicalAgeRangePut(page);
+    await modal
+      .getByRole('button', {
+        name: age.audience.age_range_warning_modal.confirm,
+      })
+      .click();
+    await confirmAudiencePut;
+    await confirmAgePut;
+
+    await page.goto(eventEditUrl);
+
+    // Age now "Volwassenen 18+" (no longer overlaps BOA) → section hidden.
+    await expect(minAgeInput(page)).toHaveValue('18');
+    await expect(maxAgeInput(page)).toHaveValue('');
+    await expect(childrenOnlyRadio(page)).toBeHidden();
+  });
+
+  test('age outside 2–12 while "children only": cancel keeps the previous age and audience', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    const ageRangePut = waitForTypicalAgeRangePut(page);
+    await page.getByRole('button', { name: new RegExp(age.kids) }).click();
+    await ageRangePut;
+
+    const audiencePut = waitForAudiencePut(page);
+    await childrenOnlyRadio(page).click();
+    await audiencePut;
+    // Wait for the audience update to commit into the tree before clicking the
+    // next preset — otherwise commitTypicalAgeRange may still read a stale
+    // audienceType from useWatch and skip the warning modal.
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+
+    await page.getByRole('button', { name: new RegExp(age.adults) }).click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    await modal
+      .getByRole('button', {
+        name: age.audience.age_range_warning_modal.cancel,
+      })
+      .click();
+    await expect(modal).toBeHidden();
+
+    // Previous "Kinderen 6-11" range survives + the preset stays active.
+    await expect(minAgeInput(page)).toHaveValue('6');
+    await expect(maxAgeInput(page)).toHaveValue('11');
+    await expect(
+      page.getByRole('button', { name: new RegExp(age.kids) }),
+    ).toHaveClass(/(?:^|\s)active(?:\s|$)/);
+
+    // Audience stayed CHILDREN_ONLY.
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+  });
+
+  test('members → children only: warning modal confirm makes audience CHILDREN_ONLY', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // Pre-condition: set audience to MEMBERS via the AudienceStep tab.
+    // Clicking the tab heading is more robust than relying on the #hash
+    // effect — the pane is otherwise mounted-but-hidden and not clickable.
+    await page.getByRole('tab', { name: /Toegang/ }).click();
+    const setMembers = waitForAudiencePut(page);
+    await page.locator('#audience-members').click();
+    await setMembers;
+
+    // Now select a BOA-overlapping age range.
+    const ageRangePut = waitForTypicalAgeRangePut(page);
+    await page.getByRole('button', { name: new RegExp(age.kids) }).click();
+    await ageRangePut;
+
+    // Click "for children only" — modal warns about the MEMBERS override.
+    await childrenOnlyRadio(page).click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(age.audience.members_warning_modal.body);
+
+    const confirmAudiencePut = waitForAudiencePut(page);
+    await modal
+      .getByRole('button', { name: age.audience.members_warning_modal.confirm })
+      .click();
+    await confirmAudiencePut;
+
+    await expect(modal).toBeHidden();
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+
+    await page.goto(eventEditUrl);
+    await expect(childrenOnlyRadio(page)).toBeChecked();
   });
 });

--- a/src/test/e2e/events/event-children-only.spec.ts
+++ b/src/test/e2e/events/event-children-only.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test as base } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 
 import nl from '../../../i18n/nl.json';
 import { createBasicEvent } from '../helpers/create-basic-event';
@@ -8,8 +8,10 @@ const age = nl.create.name_and_age.age;
 const audience = age.audience;
 
 const audienceQuestionLocator = audience.question;
-const childrenOnlyRadioLabel = audience.children_only;
-const withFamilyRadioLabel = audience.with_family;
+
+const childrenOnlyRadio = (page: Page) =>
+  page.locator('#audience-children-only');
+const withFamilyRadio = (page: Page) => page.locator('#audience-with-family');
 
 type TestFixtures = {
   eventId: string;
@@ -135,28 +137,20 @@ test.describe('Children-only audience section', () => {
     await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
 
     // Default is "with family"
-    await expect(
-      page.getByLabel(withFamilyRadioLabel, { exact: true }),
-    ).toBeChecked();
+    await expect(withFamilyRadio(page)).toBeChecked();
 
     // Select children-only and verify it sticks
-    await page.getByLabel(childrenOnlyRadioLabel, { exact: true }).click();
-    await expect(
-      page.getByLabel(childrenOnlyRadioLabel, { exact: true }),
-    ).toBeChecked();
+    await childrenOnlyRadio(page).click();
+    await expect(childrenOnlyRadio(page)).toBeChecked();
 
     // Reload — selection should persist because the audience mutation fired
     await page.waitForLoadState('networkidle');
     await page.goto(eventEditUrl);
-    await expect(
-      page.getByLabel(childrenOnlyRadioLabel, { exact: true }),
-    ).toBeChecked();
+    await expect(childrenOnlyRadio(page)).toBeChecked();
 
     // Switch back to "with family"
-    await page.getByLabel(withFamilyRadioLabel, { exact: true }).click();
-    await expect(
-      page.getByLabel(withFamilyRadioLabel, { exact: true }),
-    ).toBeChecked();
+    await withFamilyRadio(page).click();
+    await expect(withFamilyRadio(page)).toBeChecked();
   });
 
   test('hides the section again when the age range moves outside the BOA range', async ({
@@ -198,11 +192,9 @@ test.describe('Children-only audience section', () => {
         res.request().method() === 'PUT' &&
         res.ok(),
     );
-    await page.getByLabel(childrenOnlyRadioLabel, { exact: true }).click();
+    await childrenOnlyRadio(page).click();
     await audiencePut;
-    await expect(
-      page.getByLabel(childrenOnlyRadioLabel, { exact: true }),
-    ).toBeChecked();
+    await expect(childrenOnlyRadio(page)).toBeChecked();
 
     // Add a departure place via the Bereikbaarheid tab and explicitly wait
     // for the PUT and the cache-invalidated GET refetch to complete — the
@@ -239,7 +231,7 @@ test.describe('Children-only audience section', () => {
     ).toBeVisible();
 
     // Try to switch back to "with family" → warning modal must appear
-    await page.getByLabel(withFamilyRadioLabel, { exact: true }).click();
+    await withFamilyRadio(page).click();
 
     const modal = page.getByRole('dialog');
     await expect(modal).toBeVisible();
@@ -257,12 +249,10 @@ test.describe('Children-only audience section', () => {
       })
       .click();
     await expect(modal).toBeHidden();
-    await expect(
-      page.getByLabel(childrenOnlyRadioLabel, { exact: true }),
-    ).toBeChecked();
+    await expect(childrenOnlyRadio(page)).toBeChecked();
 
     // Click again, then confirm → audience flips and departure places are cleared
-    await page.getByLabel(withFamilyRadioLabel, { exact: true }).click();
+    await withFamilyRadio(page).click();
     await expect(modal).toBeVisible();
     await modal
       .getByRole('button', {
@@ -270,9 +260,7 @@ test.describe('Children-only audience section', () => {
       })
       .click();
     await expect(modal).toBeHidden();
-    await expect(
-      page.getByLabel(withFamilyRadioLabel, { exact: true }),
-    ).toBeChecked();
+    await expect(withFamilyRadio(page)).toBeChecked();
 
     await page.waitForLoadState('networkidle');
 

--- a/src/test/e2e/events/event-children-only.spec.ts
+++ b/src/test/e2e/events/event-children-only.spec.ts
@@ -1,0 +1,287 @@
+import { expect, test as base } from '@playwright/test';
+
+import nl from '../../../i18n/nl.json';
+import { createBasicEvent } from '../helpers/create-basic-event';
+import { suppressHydrationErrors } from '../helpers/suppress-hydration-errors';
+
+const age = nl.create.name_and_age.age;
+const audience = age.audience;
+
+const audienceQuestionLocator = audience.question;
+const childrenOnlyRadioLabel = audience.children_only;
+const withFamilyRadioLabel = audience.with_family;
+
+type TestFixtures = {
+  eventId: string;
+  eventEditUrl: string;
+};
+
+const test = base.extend<TestFixtures>({
+  eventId: async ({ page, baseURL }, applyFixture) => {
+    suppressHydrationErrors(page);
+    await createBasicEvent(
+      page,
+      baseURL,
+      `E2E ChildrenOnly Test ${Date.now()}`,
+    );
+    await page.getByRole('button', { name: 'Publiceren', exact: true }).click();
+    await page.waitForURL(/\/events\/[a-f0-9-]+/);
+    const eventId = page.url().match(/\/events\/([a-f0-9-]+)/)?.[1] ?? '';
+    await applyFixture(eventId);
+  },
+
+  eventEditUrl: async ({ eventId }, applyFixture) => {
+    await applyFixture(`/events/${eventId}/edit`);
+  },
+});
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(async ({ context }) => {
+  await context.addCookies([
+    {
+      name: 'ff_boa',
+      value: 'true',
+      domain: 'localhost',
+      path: '/',
+    },
+  ]);
+});
+
+test.describe('Children-only audience section', () => {
+  test('is hidden for non-BOA age ranges', async ({ page, eventEditUrl }) => {
+    await page.goto(eventEditUrl);
+
+    // createBasicEvent ends on "Volwassenen 18+" → no BOA-aged children → hidden
+    await expect(page.getByText(audienceQuestionLocator)).toBeHidden();
+
+    // "Alle leeftijden" is too broad to be children-specific → hidden
+    await page.getByRole('button', { name: new RegExp(`^${age.all}`) }).click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeHidden();
+
+    // "Senioren 65+" → hidden
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.seniors}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeHidden();
+
+    // "Jongeren 16-26" → min > 12 → hidden
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.youngsters}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeHidden();
+  });
+
+  test('appears when the age range overlaps with the BOA range (2-12)', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // "Peuters 0-2" → max ≥ 2 → visible
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.toddlers}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    // "Kleuters 3-5" → entirely inside BOA → visible
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.preschoolers}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    // "Kinderen 6-11" → entirely inside BOA → visible
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.kids}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    // "Tieners 12-15" → min = 12 → visible (overlaps at 12)
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.teenagers}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+  });
+
+  test('appears for a custom range that overlaps with the BOA range', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    const fromInput = page.getByLabel(age.from, { exact: true });
+    const tillInput = page.getByLabel(age.till, { exact: true });
+
+    // Custom range 8-15 → min ≤ 12, max ≥ 2 → visible
+    await fromInput.fill('8');
+    await tillInput.fill('15');
+    await tillInput.blur();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    // Custom range 13-20 → min > 12 → hidden
+    await fromInput.fill('13');
+    await tillInput.fill('20');
+    await tillInput.blur();
+    await expect(page.getByText(audienceQuestionLocator)).toBeHidden();
+  });
+
+  test('persists "Voor kinderen alleen" selection and switches back via the radio', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.kids}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    // Default is "with family"
+    await expect(
+      page.getByLabel(withFamilyRadioLabel, { exact: true }),
+    ).toBeChecked();
+
+    // Select children-only and verify it sticks
+    await page.getByLabel(childrenOnlyRadioLabel, { exact: true }).click();
+    await expect(
+      page.getByLabel(childrenOnlyRadioLabel, { exact: true }),
+    ).toBeChecked();
+
+    // Reload — selection should persist because the audience mutation fired
+    await page.waitForLoadState('networkidle');
+    await page.goto(eventEditUrl);
+    await expect(
+      page.getByLabel(childrenOnlyRadioLabel, { exact: true }),
+    ).toBeChecked();
+
+    // Switch back to "with family"
+    await page.getByLabel(withFamilyRadioLabel, { exact: true }).click();
+    await expect(
+      page.getByLabel(withFamilyRadioLabel, { exact: true }),
+    ).toBeChecked();
+  });
+
+  test('hides the section again when the age range moves outside the BOA range', async ({
+    page,
+    eventEditUrl,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // Switch into BOA range → section visible
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.kids}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    // Switch out → section hidden
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.adults}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeHidden();
+  });
+
+  test('warns before switching away from "kinderen alleen" when departurePlaces exist', async ({
+    page,
+    eventEditUrl,
+    eventId,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // Put the age range in the BOA window and pick "kinderen alleen"
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.kids}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    // Wait for both the audience PUT and the follow-up offer refetch
+    const audiencePut = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/events/${eventId}/audience`) &&
+        res.request().method() === 'PUT' &&
+        res.ok(),
+    );
+    await page.getByLabel(childrenOnlyRadioLabel, { exact: true }).click();
+    await audiencePut;
+    await expect(
+      page.getByLabel(childrenOnlyRadioLabel, { exact: true }),
+    ).toBeChecked();
+
+    // Add a departure place via the Bereikbaarheid tab and explicitly wait
+    // for the PUT and the cache-invalidated GET refetch to complete — the
+    // modal logic in AgeRangeStep reads departurePlaces from that offer
+    // query, so we can't open the modal until the refetch lands.
+    await page.getByRole('tab', { name: 'Bereikbaarheid' }).click();
+    await page.getByTestId('departure-city-0').fill('9000');
+    await page.getByRole('option', { name: '9000 Gent' }).click();
+    await page.getByTestId('departure-place-0').fill('S.M');
+
+    const departurePut = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/events/${eventId}/departurePlaces`) &&
+        res.request().method() === 'PUT' &&
+        res.ok(),
+    );
+    await page
+      .getByRole('option', { name: 'S.M.A.K.', exact: true })
+      .first()
+      .click();
+    await departurePut;
+
+    // Wait for the cache-invalidated GET so the AgeRangeStep observer sees
+    // the new departurePlaces on the offer.
+    await page.waitForResponse(
+      (res) =>
+        new RegExp(`/events/${eventId}(?:\\?|$)`).test(res.url()) &&
+        res.request().method() === 'GET' &&
+        res.ok(),
+    );
+
+    await expect(
+      page.getByRole('heading', { name: 'Vertreklocatie 1' }),
+    ).toBeVisible();
+
+    // Try to switch back to "with family" → warning modal must appear
+    await page.getByLabel(withFamilyRadioLabel, { exact: true }).click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+    await expect(
+      modal.getByText(audience.departure_places_warning_modal.title),
+    ).toBeVisible();
+    await expect(
+      modal.getByText(audience.departure_places_warning_modal.body),
+    ).toBeVisible();
+
+    // Cancel → modal closes, audience selection stays at "kinderen alleen"
+    await modal
+      .getByRole('button', {
+        name: audience.departure_places_warning_modal.cancel,
+      })
+      .click();
+    await expect(modal).toBeHidden();
+    await expect(
+      page.getByLabel(childrenOnlyRadioLabel, { exact: true }),
+    ).toBeChecked();
+
+    // Click again, then confirm → audience flips and departure places are cleared
+    await page.getByLabel(withFamilyRadioLabel, { exact: true }).click();
+    await expect(modal).toBeVisible();
+    await modal
+      .getByRole('button', {
+        name: audience.departure_places_warning_modal.confirm,
+      })
+      .click();
+    await expect(modal).toBeHidden();
+    await expect(
+      page.getByLabel(withFamilyRadioLabel, { exact: true }),
+    ).toBeChecked();
+
+    await page.waitForLoadState('networkidle');
+
+    // Optional sanity: the accessibility tab should be gone now that we're
+    // no longer in "kinderen alleen" mode.
+    await expect(
+      page.getByRole('tab', { name: 'Bereikbaarheid' }),
+    ).toBeHidden();
+  });
+});

--- a/src/test/e2e/events/event-children-only.spec.ts
+++ b/src/test/e2e/events/event-children-only.spec.ts
@@ -35,8 +35,6 @@ const test = base.extend<TestFixtures>({
   },
 });
 
-test.describe.configure({ mode: 'serial' });
-
 test.beforeEach(async ({ context }) => {
   await context.addCookies([
     {

--- a/src/test/e2e/events/event-children-only.spec.ts
+++ b/src/test/e2e/events/event-children-only.spec.ts
@@ -270,4 +270,115 @@ test.describe('Children-only audience section', () => {
       page.getByRole('tab', { name: 'Bereikbaarheid' }),
     ).toBeHidden();
   });
+
+  test('age outside 2–12 while "kinderen alleen": confirm resets audience and saves the new age', async ({
+    page,
+    eventEditUrl,
+    eventId,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    // Setup: 6–11 + children-only.
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.kids}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    const audiencePut = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/events/${eventId}/audience`) &&
+        res.request().method() === 'PUT' &&
+        res.ok(),
+    );
+    await childrenOnlyRadio(page).click();
+    await audiencePut;
+    // Wait for the audienceType update to commit before clicking the next
+    // preset — otherwise commitTypicalAgeRange may still read a stale value
+    // from useWatch and skip the warning modal.
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+
+    // Move out of BOA range — preset "Volwassenen 18+" triggers the warning.
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.adults}`) })
+      .click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+    await expect(
+      modal.getByText(audience.age_range_warning_modal.body),
+    ).toBeVisible();
+
+    // Confirm: audience reset PUT + typicalAgeRange PUT fire in sequence.
+    const confirmAudiencePut = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/events/${eventId}/audience`) &&
+        res.request().method() === 'PUT' &&
+        res.ok(),
+    );
+    const confirmAgePut = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/events/${eventId}/typicalAgeRange`) &&
+        res.request().method() === 'PUT' &&
+        res.ok(),
+    );
+    await modal
+      .getByRole('button', {
+        name: audience.age_range_warning_modal.confirm,
+      })
+      .click();
+    await confirmAudiencePut;
+    await confirmAgePut;
+
+    await page.goto(eventEditUrl);
+
+    // New age (18+) no longer overlaps BOA → children-only section is hidden.
+    await expect(page.getByText(audienceQuestionLocator)).toBeHidden();
+  });
+
+  test('age outside 2–12 while "kinderen alleen": cancel keeps the previous age and audience', async ({
+    page,
+    eventEditUrl,
+    eventId,
+  }) => {
+    await page.goto(eventEditUrl);
+
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.kids}`) })
+      .click();
+    await expect(page.getByText(audienceQuestionLocator)).toBeVisible();
+
+    const audiencePut = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/events/${eventId}/audience`) &&
+        res.request().method() === 'PUT' &&
+        res.ok(),
+    );
+    await childrenOnlyRadio(page).click();
+    await audiencePut;
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+
+    // Trigger the modal.
+    await page
+      .getByRole('button', { name: new RegExp(`^${age.adults}`) })
+      .click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    // Cancel → modal closes, previous range + audience preserved.
+    await modal
+      .getByRole('button', {
+        name: audience.age_range_warning_modal.cancel,
+      })
+      .click();
+    await expect(modal).toBeHidden();
+
+    // "Kinderen 6-11" preset stays active and the audience remains
+    // "kinderen alleen" — proves field.onChange revert actually updated the
+    // Controller's field.value (a setValue-based revert would not have).
+    await expect(
+      page.getByRole('button', { name: new RegExp(`^${age.kids}`) }),
+    ).toHaveClass(/(?:^|\s)active(?:\s|$)/);
+    await expect(childrenOnlyRadio(page)).toBeChecked();
+  });
 });

--- a/src/test/e2e/setup/auth-admin.setup.ts
+++ b/src/test/e2e/setup/auth-admin.setup.ts
@@ -18,16 +18,11 @@ setup('authenticate as admin', async ({ page, baseURL }) => {
 
   await page.getByRole('button', { name: 'Meld je aan', exact: true }).click();
 
-  // Now we're back to our own app
-  // Wait that the main page has loaded
-  // await page.waitForURL(new RegExp(`${baseURL}/dashboard*`), {
-  //   timeout: 60_000,
-  // });
-
-  // Wait for network to be idle, if we save storage too early, needed storage values might not yet be available
-  await page.waitForLoadState('networkidle');
-
-  await page.getByText('Welkom').waitFor();
+  // The welcome title only renders once useGetUserQuery resolves —
+  // by the time it's visible, the auth cookies/tokens are populated, so
+  // it's safe to save storage state. Avoid `networkidle`: dashboard polling
+  // queries keep the network alive and would never let it settle.
+  await page.getByText('Welkom').waitFor({ timeout: 60_000 });
 
   await page.context().storageState({ path: adminAuthFile });
 });

--- a/src/test/e2e/setup/auth.setup.ts
+++ b/src/test/e2e/setup/auth.setup.ts
@@ -14,16 +14,11 @@ setup('authenticate', async ({ baseURL, page }) => {
 
   await page.getByRole('button', { name: 'Meld je aan', exact: true }).click();
 
-  // Now we're back to our own app
-  // Wait that the main page has loaded
-  // await page.waitForURL(new RegExp(`${baseURL}/dashboard*`), {
-  //   timeout: 60_000,
-  // });
-
-  // Wait for network to be idle, if we save storage too early, needed storage values might not yet be available
-  await page.waitForLoadState('networkidle');
-
-  await page.getByText('Welkom').waitFor();
+  // The welcome title only renders once useGetUserQuery resolves —
+  // by the time it's visible, the auth cookies/tokens are populated, so
+  // it's safe to save storage state. Avoid `networkidle`: dashboard polling
+  // queries keep the network alive and would never let it settle.
+  await page.getByText('Welkom').waitFor({ timeout: 60_000 });
 
   await page.context().storageState({ path: authFile });
 });

--- a/src/ui/RadioButton.tsx
+++ b/src/ui/RadioButton.tsx
@@ -67,6 +67,12 @@ const RadioButton = forwardRef<HTMLInputElement, Props>(
       disabled={disabled}
       checked={checked}
       css={`
+        .form-check-input:disabled {
+          opacity: 1;
+          border-color: ${colors.grey5};
+          cursor: not-allowed;
+        }
+
         &.form-switch {
           font-size: 1rem;
           width: 2.5em;

--- a/src/ui/RadioButtonWithLabel.tsx
+++ b/src/ui/RadioButtonWithLabel.tsx
@@ -7,6 +7,7 @@ import type { RadioButtonProps } from './RadioButton';
 import { RadioButton } from './RadioButton';
 import { Stack } from './Stack';
 import { Text, TextVariants } from './Text';
+import { colors } from './theme';
 
 type Props = RadioButtonProps &
   Omit<BoxProps, 'onChange'> & {
@@ -52,7 +53,11 @@ const RadioButtonWithLabel = React.forwardRef(
           color={color}
         />
         <Stack>
-          <Label cursor="pointer" htmlFor={id}>
+          <Label
+            cursor={disabled ? 'not-allowed' : 'pointer'}
+            color={disabled ? colors.grey5 : undefined}
+            htmlFor={id}
+          >
             {label}
           </Label>
           {!!info && <Text variant={TextVariants.MUTED}>{info}</Text>}


### PR DESCRIPTION
### Added
- [new childrenOnly audienceType](https://github.com/cultuurnet/udb3-frontend/commit/ee70cd6818adf5bca3e457379507326cb11f544f)
- [childrenOnly section](https://github.com/cultuurnet/udb3-frontend/commit/f97a20df754a85bc591c6f0f639c0e93b9215259)
- [change destructive audience confirm modal](https://github.com/cultuurnet/udb3-frontend/commit/78ebea7462376fbb30051c0c0438f90029c8a6e2)
- [Improve layout](https://github.com/cultuurnet/udb3-frontend/commit/a220c2168d92e14e95edf3c7bfc8c90217db511f)
- [Add e2e test for children only flow](https://github.com/cultuurnet/udb3-frontend/commit/4713b7ade0aa8f8f2c153b936cc0a76d043a80fb)

Screenshots:
<img width="1249" height="682" alt="Screenshot 2026-05-21 at 14 06 39" src="https://github.com/user-attachments/assets/29ba62e9-beeb-425b-bc84-0ff3658416ed" />

<img width="1247" height="602" alt="Screenshot 2026-05-21 at 14 15 44" src="https://github.com/user-attachments/assets/16b11f60-2a5c-4b47-92ab-8655a12324ba" />

---
Ticket: https://jira.uitdatabank.be/browse/III-7197
