### PR TITLE
Fix local eslint issue

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default [
       'out/**',
       'build/**',
       'dist/**',
+      'storybook-static/**',
       'playwright-report/**',
       'scripts/**',
     ],


### PR DESCRIPTION
### Fixed
- [local eslint issue](https://github.com/cultuurnet/udb3-frontend/commit/12d8245e120939eae7d31e9b47fd1f516d13946f)

> ESLint linting build output: All 371 noise problems were inside storybook-static/ (minified Storybook runtime bundles like runtime.js, globals-runtime.js). That folder only exists locally because you've been running storybook build / yarn vrt for the VRT work. CI's lint job runs on a clean tree without it. eslint.config.mjs ignored .next, build, dist… but not storybook-static/, which was an oversight when the Storybook/Lost Pixel setup was recently added.

---
