### PR TITLE
III-7166 disable Lost Pixel fail on difference

### DIFF
--- a/lostpixel.config.ts
+++ b/lostpixel.config.ts
@@ -6,6 +6,6 @@ export const config: CustomProjectConfig = {
     elementLocator: '#storybook-root',
   },
   generateOnly: true,
-  failOnDifference: true,
+  failOnDifference: false,
   threshold: 20,
 };


### PR DESCRIPTION
### Changed
- failOnDifference set to false in lostpixel.config.ts — VRT runs as informational only, no longer blocks PRs

### Note
- This was overlooked in a previous PR where Lost Pixel was first introduced. Added as a follow-up on the same ticket.
---

Ticket: https://jira.uitdatabank.be/browse/III-7166
