### PR TITLE
Revert "III-7166 disable Lost Pixel fail on difference"

### DIFF
--- a/lostpixel.config.ts
+++ b/lostpixel.config.ts
@@ -6,6 +6,6 @@ export const config: CustomProjectConfig = {
     elementLocator: '#storybook-root',
   },
   generateOnly: true,
-  failOnDifference: false,
+  failOnDifference: true,
   threshold: 20,
 };


### PR DESCRIPTION
Reverts cultuurnet/udb3-frontend#1240

- re-enables Lost Pixel failure on visual difference. The right fix when changing a component intentionally is to update the baseline, not suppress failures globally.