### PR TITLE
add SHADCN_MIGRATION feature flag

### DIFF
--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -17,6 +17,7 @@ const FeatureFlags = {
   SHOW_CONSOLE_DEBUGGING: 'show_console_debugging',
   SHOW_IFRAME_BORDER: 'show_iframe_border',
   BOA: 'boa',
+  SHADCN_MIGRATION: 'shadcn_migration',
 } as const;
 
 const createCookieName = (identifier: string) => `ff_${identifier}`;


### PR DESCRIPTION
### Added
- SHADCN_MIGRATION feature flag to FeatureFlags for toggling shadcn migrated components — will be used across future component migrations
- 
### Note
- Opened as a separate PR so it can be reviewed and merged independently, avoiding blockers during the ongoing shadcn migration