### PR TITLE
III-7272 fix Tarief toevoegen button when shadcn flag is on

### DIFF
--- a/src/ui/Box.tsx
+++ b/src/ui/Box.tsx
@@ -464,6 +464,7 @@ const reactPropTypes = [
   'onInput',
   'onSubmit',
   'onChange',
+  'onMouseDown',
   'dangerouslySetInnerHTML',
 ];
 


### PR DESCRIPTION
### Changed
- The InlineShadcn path filters props via getBoxProps, which only allows reactPropTypes. onMouseDown was missing from that list, so the "Tarief toevoegen" button's handler was silently dropped when SHADCN_MIGRATION is on.

<img width="514" height="179" alt="Screenshot 2026-06-24 at 10 51 34" src="https://github.com/user-attachments/assets/3114c076-bfbb-439c-a307-d1be95c68246" />

Ticket: https://jira.uitdatabank.be/browse/III-7272
