### PR TITLE
III-7274 Missing spacing between buttons on preview pages

### DIFF
--- a/src/ui/Stack.tsx
+++ b/src/ui/Stack.tsx
@@ -6,7 +6,7 @@ import { FeatureFlags, useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { Box, BoxProps, boxPropTypes, getBoxProps, UIProp } from './Box';
 import { cn } from './shadcn/utils';
 import { StackLegacy } from './StackLegacy';
-import { getGapClass } from './tailwindGap';
+import { GAP_CLASS_BY_SPACING, getGapClass } from './tailwindGap';
 import type { BreakpointValues } from './theme';
 
 type StackProps = {
@@ -45,7 +45,9 @@ const Stack = forwardRef<HTMLElement, Props>((props, ref) => {
   // caller-provided `display`. Those cases fall back to the legacy version.
   const canUseShadcn =
     isShadcnMigrationEnabled &&
-    (props.spacing === undefined || typeof props.spacing === 'number') &&
+    (props.spacing === undefined ||
+      (typeof props.spacing === 'number' &&
+        props.spacing in GAP_CLASS_BY_SPACING)) &&
     props.display === undefined;
 
   return canUseShadcn ? (


### PR DESCRIPTION
### Fixed
- StackShadcn silently produced no gap for non-integer spacings (e.g. 3.5,
4.5) because getGapClass returns '' for values outside GAP_CLASS_BY_SPACING.
Added the same guard that Inline already had, so those cases fall back to
StackLegacy which handles them correctly via margin injection.

- Before (shadecn flag on) 
<img width="308" height="247" alt="Screenshot 2026-06-26 at 13 00 14" src="https://github.com/user-attachments/assets/73d0ba4d-b467-479d-aa48-449db0fb354c" />

- After (shadecn flag on) 
<img width="314" height="282" alt="Screenshot 2026-06-26 at 13 17 23" src="https://github.com/user-attachments/assets/78991e50-685f-489d-9789-36a4f655ef78" />

---

### No ticket

Ticket: https://jira.uitdatabank.be/browse/III-7124
