### PR TITLE
III-7273 reduce spacing between education section elements

### DIFF
--- a/src/pages/steps/NameAndAgeRangeStep.tsx
+++ b/src/pages/steps/NameAndAgeRangeStep.tsx
@@ -171,19 +171,15 @@ const NameAndAgeRangeStep = ({
               />
             )}
             {isCultuurkuurEvent && !levels.isLoading && (
-              <>
-                <Text fontWeight="bold" marginBottom={3}>
+              <div className="tw:flex tw:flex-col tw:gap-3">
+                <Text fontWeight="bold">
                   {t(`create.name_and_age.age.title`)}
                 </Text>
                 <CultuurkuurLabelsPicker
                   labelsKey="education"
                   {...labelsPickerProps}
                 />
-                <Text
-                  variant={TextVariants.MUTED}
-                  maxWidth={parseSpacing(9)}
-                  marginTop={3}
-                >
+                <Text variant={TextVariants.MUTED} className="tw:max-w-lg">
                   <Trans
                     i18nKey={'create.name_and_age.cultuurkuur.info'}
                     components={{
@@ -201,7 +197,7 @@ const NameAndAgeRangeStep = ({
                     {t('cultuurkuur_modal.overview.error_education_levels')}
                   </Text>
                 )}
-              </>
+              </div>
             )}
             <AlertDuplicatePlace
               variant={AlertVariants.DANGER}


### PR DESCRIPTION
### Changed
- Replaced fragment with a Tailwind flex column div to control internal gap between education section elements
- Removed legacy `marginBottom`/`marginTop` props and `maxWidth={parseSpacing(9)}` in favour of Tailwind classes

### Fixed
- Fixed too much spacing between elements in the Cultuurkuur education section by replacing the fragment with a Tailwind flex column div and removing redundant legacy margin props

---

Ticket: https://jira.uitdatabank.be/browse/III-7273
