### PR TITLE
III-7289-AdditionalInformationStep Tabs - reduce the gap

### DIFF
--- a/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
+++ b/src/pages/steps/AdditionalInformationStep/AdditionalInformationStep.tsx
@@ -186,7 +186,7 @@ const TabTitle = ({
   const title = titleKey ? t(titleKey) : t(defaultTitleKey);
 
   return (
-    <Inline spacing={3} alignItems="center" {...getInlineProps(props)}>
+    <Inline spacing={2} alignItems="center" {...getInlineProps(props)}>
       {validationStatus === ValidationStatus.SUCCESS && (
         <Icon name={Icons.CHECK_CIRCLE} className="tw:text-success" />
       )}


### PR DESCRIPTION
### Changed
- Reduce the gap between the icon and the text

<img width="2520" height="1058" alt="tabs" src="https://github.com/user-attachments/assets/def95a03-8180-4cdd-b033-2a1c9c7aa2d6" />

---

Ticket: https://jira.uitdatabank.be/browse/III-7289
