### PR TITLE
[fix] III-7185 wrap custom Tooltip trigger children in a span

### DIFF
--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -48,7 +48,11 @@ const Tooltip = ({ id, content, side, children }: Props) => {
     <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
       <ShadcnTooltip>
         <TooltipTrigger asChild>
-          {children ?? <DefaultTrigger content={content} />}
+          {children ? (
+            <span>{children}</span>
+          ) : (
+            <DefaultTrigger content={content} />
+          )}
         </TooltipTrigger>
         <TooltipContent side={side}>{content}</TooltipContent>
       </ShadcnTooltip>


### PR DESCRIPTION

<img width="240" height="123" alt="Screenshot 2026-07-14 at 10 45 01" src="https://github.com/user-attachments/assets/a1dc39bc-b473-4e2a-a0de-116d3748d9c1" />

### Fixed
- Tooltip: custom trigger children (e.g. Button) no longer respond to hover/focus. Removing the wrapping span when making the default trigger a real button also stripped it from custom children, so Radix's injected handlers were silently dropped by Button's prop filtering. Children are now wrapped in a span again.

---

Ticket: https://jira.uitdatabank.be/browse/III-7185
