### PR TITLE
III-7334 Give shadcn progress bar an accessible name

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1715,7 +1715,8 @@
   },
   "common": {
     "back_to_overview": "Zurück zur Liste",
-    "close": "Schließen"
+    "close": "Schließen",
+    "progress": "Fortschritt"
   },
   "users": {
     "search": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1715,7 +1715,8 @@
   },
   "common": {
     "back_to_overview": "Retour à la liste",
-    "close": "Fermer"
+    "close": "Fermer",
+    "progress": "Progression"
   },
   "users": {
     "search": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -1773,7 +1773,8 @@
   },
   "common": {
     "back_to_overview": "Terug naar de lijst",
-    "close": "Sluiten"
+    "close": "Sluiten",
+    "progress": "Voortgang"
   },
   "users": {
     "search": {

--- a/src/ui/ProgressBar.tsx
+++ b/src/ui/ProgressBar.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import { FeatureFlags, useFeatureFlag } from '@/hooks/useFeatureFlag';
 import type { Values } from '@/types/Values';
 import { Progress } from '@/ui/shadcn/progress';
@@ -34,6 +36,7 @@ const ProgressBar = ({
   showPercentage = false,
   className,
 }: Props) => {
+  const { t } = useTranslation();
   const [isShadcnMigrationEnabled] = useFeatureFlag(
     FeatureFlags.SHADCN_MIGRATION,
   );
@@ -48,6 +51,7 @@ const ProgressBar = ({
       )}
       <Progress
         value={progress}
+        aria-label={label ?? t('common.progress')}
         indicatorClassName={indicatorClasses[variant]}
       />
     </div>


### PR DESCRIPTION
### Fixed
- Progress bars now expose an accessible name to screen readers, using the visible label when provided or a default "Progress" description otherwise.

---

Ticket: https://jira.uitdatabank.be/browse/III-7334
