### PR TITLE
III-7335 Add aria-label to icon-only links for screen reader support

### DIFF
--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -569,6 +569,7 @@ const Sidebar = () => {
         justifyContent="center"
         href="/dashboard"
         title={t('menu.home')}
+        aria-label={t('menu.home')}
         customChildren
         paddingBottom={2}
       >

--- a/src/ui/Link.stories.tsx
+++ b/src/ui/Link.stories.tsx
@@ -83,7 +83,12 @@ export const CustomChildren: Story = {
     },
   },
   render: (args) => (
-    <Link customChildren={true} href={args.href} variant={args.variant}>
+    <Link
+      customChildren={true}
+      href={args.href}
+      variant={args.variant}
+      aria-label="View profile"
+    >
       <Icon name={args.iconName} />
     </Link>
   ),


### PR DESCRIPTION
### Fixed
- Icon-only links exposed no accessible name to screen readers (announced only as "link" with no context). Added aria-label to the "Custom Children" example in the Link component's Storybook story and to the sidebar logo link. A codebase-wide search confirmed the sidebar logo was the only production usage missing it.

---

Ticket: https://jira.uitdatabank.be/browse/III-7335
