### PR TITLE
III-7363 fix Button spacing issues

### DIFF
--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -36,7 +36,6 @@ import { cn } from '@/ui/shadcn/utils';
 import { Stack } from '@/ui/Stack';
 import { Text } from '@/ui/Text';
 import { Breakpoints, colors, getValueFromTheme } from '@/ui/theme';
-import { Title } from '@/ui/Title';
 
 import { Announcements, AnnouncementStatus } from './Announcements';
 import { JobLogger, JobLoggerStates } from './joblogger/JobLogger';
@@ -125,6 +124,8 @@ const MenuItem = memo(
           onClick={onClick}
           customChildren
           title={label}
+          display="flex"
+          width="100%"
           className={cn(
             'tw:w-full tw:rounded-lg tw:pt-[0.5333rem] tw:pb-[0.5333rem] tw:pl-[1.0667rem] tw:pr-[0.5333rem] tw:hover:bg-accent tw:max-md:pt-[0.2667rem] tw:max-md:pb-[0.2667rem] tw:max-md:pl-[0.1333rem] tw:max-md:pr-[0.1333rem]',
             isActive && 'tw:bg-accent',
@@ -176,9 +177,9 @@ const Menu = memo(({ items = [], title, ...props }: MenuProps) => {
 
   return (
     <Stack spacing={3} {...props}>
-      <Title className="tw:text-xs tw:font-normal tw:uppercase tw:opacity-50 tw:max-md:text-center">
+      <h2 className="tw:text-xs tw:font-normal tw:uppercase tw:opacity-50 tw:max-md:text-center">
         {title}
-      </Title>
+      </h2>
       <Content />
     </Stack>
   );

--- a/src/ui/ButtonLegacy.tsx
+++ b/src/ui/ButtonLegacy.tsx
@@ -6,7 +6,7 @@ import type { ButtonProps } from './Button';
 import { ButtonVariants } from './Button';
 import { Icon } from './Icon';
 import type { InlineProps } from './Inline';
-import { Inline } from './Inline';
+import { getInlineProps, Inline } from './Inline';
 import { Link } from './Link';
 import { cn } from './shadcn/utils';
 import { Spinner, SpinnerSizes, SpinnerVariants } from './Spinner';
@@ -272,6 +272,7 @@ const ButtonLegacy = forwardRef<HTMLButtonElement, ButtonProps>(
       forwardedAs,
       type = 'button',
       active,
+      ...rest
     },
     ref,
   ) => {
@@ -306,6 +307,7 @@ const ButtonLegacy = forwardRef<HTMLButtonElement, ButtonProps>(
       type,
       active,
       ref,
+      ...getInlineProps(rest),
     };
 
     const clonedSuffix = suffix


### PR DESCRIPTION
### Fixed
- Button/link spacing (`marginBottom`/`marginRight`) inside `Stack`/`Inline` doing nothing with the `SHADCN_MIGRATION` flag off, because `ButtonLegacy` stopped reading cloned Box/Inline props after an earlier refactor ([61f1e58fc](https://github.com/cultuurnet/udb3-frontend/commit/61f1e58fc55434b8c9425defdb665831c91273d5))
- Sidebar nav-link hover/active highlight not spanning the full row width with the flag off
- Sidebar "Beheer" section label rendering oversized and bold instead of small/uppercase with the flag off


---

Ticket: https://jira.uitdatabank.be/browse/III-7363
